### PR TITLE
Hide moon more and change the footer text

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/Footer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Footer.tsx
@@ -40,7 +40,7 @@ export function Footer() {
     <footer className="z-[1] flex justify-center">
       <div className="flex w-full max-w-[1440px] flex-col space-y-8 py-20 text-white lg:px-8 lg:py-8">
         <div className="flex flex-col items-center space-y-2 px-8 text-center lg:items-start lg:px-0">
-          <span className="text-4xl">Now running Arbitrum Nitro.</span>
+          <span className="text-4xl">The most decentralized L2.</span>
           <ExternalLink
             href="https://developer.arbitrum.io"
             className="text-2xl underline"

--- a/packages/arb-token-bridge-ui/src/components/common/Layout.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Layout.tsx
@@ -20,7 +20,7 @@ function Moon() {
     <motion.img
       src="/images/moon.webp"
       alt="Moon"
-      className="absolute bottom-[-10%] z-0 lg:bottom-[-45%] lg:right-0 lg:max-w-[75vw]"
+      className="absolute bottom-[-10%] z-0 lg:bottom-[-65%] lg:right-0 lg:max-w-[75vw]"
       style={{ scale }}
     />
   )


### PR DESCRIPTION

### Summary
Fixed issue https://github.com/OffchainLabs/arbitrum-token-bridge/issues/681 : hide the moon a little bit more
Here are the changes i have made:
1. Fix the moon position so it will not overlap with any text.
2. Change the footer text to "The most decentralized L2."

### Steps to test

1. Run the application and go to the home page
2. Scroll up and down you will notice moon height is less now
3. The footer text is also changed

Here is the change:

[screen-recorder-thu-apr-13-2023-22-36-54.webm](https://user-images.githubusercontent.com/61174028/231840019-fdb66caf-84d6-4428-8e03-79e2c127c08c.webm)
