### PR TITLE
test: e2e independent of Metamask state

### DIFF
--- a/packages/arb-token-bridge-ui/synpress.config.ts
+++ b/packages/arb-token-bridge-ui/synpress.config.ts
@@ -7,7 +7,11 @@ import { TestWETH9__factory } from '@arbitrum/sdk/dist/lib/abi/factories/TestWET
 import { TestERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/TestERC20__factory'
 import { Erc20Bridger } from '@arbitrum/sdk'
 
-import { NetworkType, wethTokenAddressL1, wethTokenAddressL2 } from './tests/support/common'
+import {
+  NetworkType,
+  wethTokenAddressL1,
+  wethTokenAddressL2
+} from './tests/support/common'
 import { registerLocalNetwork } from './src/util/networks'
 
 export default defineConfig({

--- a/packages/arb-token-bridge-ui/synpress.config.ts
+++ b/packages/arb-token-bridge-ui/synpress.config.ts
@@ -8,7 +8,7 @@ import { TestERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/TestERC
 import { Erc20Bridger } from '@arbitrum/sdk'
 
 import {
-  NetworkType,
+  NetworkName,
   wethTokenAddressL1,
   wethTokenAddressL2
 } from './tests/support/common'
@@ -35,17 +35,17 @@ export default defineConfig({
   e2e: {
     // @ts-ignore
     async setupNodeEvents(on, config) {
-      let currentNetworkType: NetworkType | null = null
+      let currentNetworkName: NetworkName | null = null
       let networkSetupComplete = false
       let walletConnectedToDapp = false
 
       on('task', {
-        setCurrentNetworkType: (networkType: NetworkType) => {
-          currentNetworkType = networkType
+        setCurrentNetworkName: (networkName: NetworkName) => {
+          currentNetworkName = networkName
           return null
         },
-        getCurrentNetworkType: () => {
-          return currentNetworkType
+        getCurrentNetworkName: () => {
+          return currentNetworkName
         },
         setNetworkSetupComplete: () => {
           networkSetupComplete = true

--- a/packages/arb-token-bridge-ui/synpress.config.ts
+++ b/packages/arb-token-bridge-ui/synpress.config.ts
@@ -7,7 +7,7 @@ import { TestWETH9__factory } from '@arbitrum/sdk/dist/lib/abi/factories/TestWET
 import { TestERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/TestERC20__factory'
 import { Erc20Bridger } from '@arbitrum/sdk'
 
-import { wethTokenAddressL1, wethTokenAddressL2 } from './tests/support/common'
+import { NetworkType, wethTokenAddressL1, wethTokenAddressL2 } from './tests/support/common'
 import { registerLocalNetwork } from './src/util/networks'
 
 export default defineConfig({
@@ -31,6 +31,34 @@ export default defineConfig({
   e2e: {
     // @ts-ignore
     async setupNodeEvents(on, config) {
+      let currentNetworkType: NetworkType | null = null
+      let networkSetupComplete = false
+      let walletConnectedToDapp = false
+
+      on('task', {
+        setCurrentNetworkType: (networkType: NetworkType) => {
+          currentNetworkType = networkType
+          return null
+        },
+        getCurrentNetworkType: () => {
+          return currentNetworkType
+        },
+        setNetworkSetupComplete: () => {
+          networkSetupComplete = true
+          return null
+        },
+        getNetworkSetupComplete: () => {
+          return networkSetupComplete
+        },
+        setWalletConnectedToDapp: () => {
+          walletConnectedToDapp = true
+          return null
+        },
+        getWalletConnectedToDapp: () => {
+          return walletConnectedToDapp
+        }
+      })
+
       registerLocalNetwork()
 
       const ethRpcUrl = process.env.NEXT_PUBLIC_LOCAL_ETHEREUM_RPC_URL
@@ -149,7 +177,7 @@ export default defineConfig({
       'tests/e2e/specs/**/depositETH.cy.{js,jsx,ts,tsx}', // deposit ETH
       'tests/e2e/specs/**/withdrawETH.cy.{js,jsx,ts,tsx}', // withdraw ETH
       'tests/e2e/specs/**/depositERC20.cy.{js,jsx,ts,tsx}', // deposit ERC20
-      'tests/e2e/specs/**/withdrawERC20.cy.{js,jsx,ts,tsx}', // withdraw ERC20 (assumes L2 network is already added in a prev test)
+      'tests/e2e/specs/**/withdrawERC20.cy.{js,jsx,ts,tsx}', // withdraw ERC20
       'tests/e2e/specs/**/txHistory.cy.{js,jsx,ts,tsx}', // tx history
       'tests/e2e/specs/**/approveToken.cy.{js,jsx,ts,tsx}', // approve ERC20
       'tests/e2e/specs/**/importToken.cy.{js,jsx,ts,tsx}', // import test ERC20

--- a/packages/arb-token-bridge-ui/tests/e2e/cypress.d.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/cypress.d.ts
@@ -22,9 +22,6 @@ declare global {
       login(options: {
         networkType: NetworkType
         networkName?: string
-        addNewNetwork?: boolean
-        shouldChangeNetwork?: boolean
-        isWalletConnected?: boolean
         url?: string
         query?: { [s: string]: string }
       }): typeof login

--- a/packages/arb-token-bridge-ui/tests/e2e/cypress.d.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/cypress.d.ts
@@ -8,7 +8,7 @@ import {
   restoreAppState,
   saveAppState
 } from '../support/commands'
-import { NetworkType } from '../support/common'
+import { NetworkType, NetworkName } from '../support/common'
 
 declare global {
   namespace Cypress {
@@ -21,7 +21,7 @@ declare global {
       // eslint-disable-next-line no-unused-vars
       login(options: {
         networkType: NetworkType
-        networkName?: string
+        networkName?: NetworkName
         url?: string
         query?: { [s: string]: string }
       }): typeof login

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/approveToken.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/approveToken.cy.ts
@@ -13,7 +13,7 @@ describe('Approve token and deposit afterwards', () => {
 
   it('should approve and deposit ERC-20 token', () => {
     context('Approve token', () => {
-      cy.login({ networkType: 'L1', shouldChangeNetwork: true })
+      cy.login({ networkType: 'L1' })
       importTokenThroughUI(ERC20TokenAddressL1)
 
       // Select the ERC-20 token

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
@@ -35,7 +35,7 @@ describe('Deposit ERC20 Token', () => {
     })
 
     it('should show L1 and L2 chains, and ETH correctly', () => {
-      cy.login({ networkType: 'L1', shouldChangeNetwork: true })
+      cy.login({ networkType: 'L1' })
       cy.findByRole('button', { name: /From: Ethereum/i }).should('be.visible')
       cy.findByRole('button', { name: /To: Arbitrum/i }).should('be.visible')
       cy.findByRole('button', { name: 'Select Token' })

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/importToken.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/importToken.cy.ts
@@ -74,8 +74,7 @@ describe('Import token', () => {
         // we don't have the token list locally so we test on mainnet
         cy.login({
           networkType: 'L1',
-          networkName: 'mainnet',
-          shouldChangeNetwork: true
+          networkName: 'mainnet'
         })
 
         cy.findByRole('button', { name: 'Select Token' })
@@ -134,7 +133,7 @@ describe('Import token', () => {
           ERC20TokenAddressL1.length - 1
         )
 
-        cy.login({ networkType: 'L1', shouldChangeNetwork: true })
+        cy.login({ networkType: 'L1' })
         cy.findByRole('button', { name: 'Select Token' })
           .should('be.visible')
           .should('have.text', 'ETH')

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/login.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/login.cy.ts
@@ -3,10 +3,7 @@
  */
 
 import { formatAmount } from '../../../src/util/NumberUtils'
-import {
-  getInitialETHBalance,
-  metamaskLocalL1RpcUrl
-} from './../../support/common'
+import { getInitialETHBalance } from './../../support/common'
 
 describe('Login Account', () => {
   let l1ETHbal
@@ -29,15 +26,7 @@ describe('Login Account', () => {
   })
 
   it('should connect wallet using MetaMask and display L1 and L2 balances', () => {
-    cy.login({
-      networkType: 'L1',
-      // we add a new network if RPC is different to already set up MetaMask local network
-      // this is the case for CI where we use a different RPC url
-      addNewNetwork: Cypress.env('ETH_RPC_URL') !== metamaskLocalL1RpcUrl,
-      shouldChangeNetwork: true,
-      // first connection, need to confirm metamask popup
-      isWalletConnected: false
-    })
+    cy.login({ networkType: 'L1' })
     cy.findByText('Bridging summary will appear here.').should('be.visible')
     cy.findByText(`Balance: ${l1ETHbal}`).should('be.visible')
     cy.findByText(`Balance: ${l2ETHbal}`).should('be.visible')

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/readClassicDeposits.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/readClassicDeposits.cy.ts
@@ -48,8 +48,7 @@ describe('Read classic deposit messages', () => {
     before(() => {
       cy.login({
         networkType: 'L1',
-        networkName: 'mainnet',
-        shouldChangeNetwork: true
+        networkName: 'mainnet'
       })
     })
 

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/switchNetworks.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/switchNetworks.cy.ts
@@ -5,7 +5,7 @@
 describe('Switch Networks', () => {
   context('User is on test network L1', () => {
     it('should show L1 and L2 chains correctly', () => {
-      cy.login({ networkType: 'L1', shouldChangeNetwork: true })
+      cy.login({ networkType: 'L1' })
       cy.findByRole('button', { name: /From: Ethereum/i }).should('be.visible')
       cy.findByRole('button', { name: /To: Arbitrum/i }).should('be.visible')
     })
@@ -15,8 +15,7 @@ describe('Switch Networks', () => {
         // to view the correct list of networks (and not testnets), first navigate to mainnet
         cy.login({
           networkType: 'L1',
-          networkName: 'mainnet',
-          shouldChangeNetwork: true
+          networkName: 'mainnet'
         })
         cy.findByRole('button', { name: /Selected Network : /i })
           .should('be.visible')
@@ -51,7 +50,7 @@ describe('Switch Networks', () => {
       // })
 
       it('should change network to Arbitrum Nova successfully', () => {
-        cy.login({ networkType: 'L1', shouldChangeNetwork: true })
+        cy.login({ networkType: 'L1' })
         cy.findByRole('button', { name: /Selected Network : /i })
           .should('be.visible')
           .click({ scrollBehavior: false })
@@ -89,8 +88,7 @@ describe('Switch Networks', () => {
       it('should show wrong network UI', () => {
         cy.login({
           networkType: 'L1',
-          networkName: 'Sepolia test network',
-          shouldChangeNetwork: true
+          networkName: 'Sepolia test network'
         })
         cy.findByText(/Oops! You’re connected to the wrong network/i).should(
           'be.visible'

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/txHistory.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/txHistory.cy.ts
@@ -7,8 +7,7 @@ describe('Transaction History', () => {
   it('should successfuly open and use deposit history panel', () => {
     cy.login({
       networkType: 'L1',
-      networkName: 'goerli',
-      shouldChangeNetwork: true
+      networkName: 'goerli'
     })
     // Open tx history panel
     context('open transactions history panel', () => {

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
@@ -15,7 +15,7 @@ describe('Withdraw ERC20 Token', () => {
   // Happy Path
   context('User is on L2 and imports ERC-20', () => {
     it('should show form fields correctly', () => {
-      cy.login({ networkType: 'L2', shouldChangeNetwork: true })
+      cy.login({ networkType: 'L2' })
       cy.findByRole('button', { name: /From: Arbitrum/i }).should('be.visible')
       cy.findByRole('button', { name: /To: Ethereum/i }).should('be.visible')
 

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawETH.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawETH.cy.ts
@@ -6,10 +6,6 @@ import { zeroToLessThanOneETH } from '../../support/common'
 import { formatAmount } from '../../../src/util/NumberUtils'
 
 describe('Withdraw ETH', () => {
-  // when all of our tests need to run in a logged-in state
-  // we have to make sure we preserve a healthy LocalStorage state
-  // because it is cleared between each `it` cypress test
-
   const ETHToWithdraw = 0.0001
 
   const typeAmountIntoInput = () => {
@@ -21,10 +17,7 @@ describe('Withdraw ETH', () => {
   // Happy Path
   context('user has some ETH and is on L2', () => {
     it('should show form fields correctly', () => {
-      cy.login({
-        networkType: 'L2',
-        addNewNetwork: true
-      })
+      cy.login({ networkType: 'L2' })
       cy.findByRole('button', { name: /From: Arbitrum/i }).should('be.visible')
       cy.findByRole('button', { name: /To: Ethereum/i }).should('be.visible')
 

--- a/packages/arb-token-bridge-ui/tests/support/commands.ts
+++ b/packages/arb-token-bridge-ui/tests/support/commands.ts
@@ -31,7 +31,7 @@ function shouldChangeNetwork({
         const provider = new StaticJsonRpcProvider(Cypress.env('ETH_RPC_URL'))
         const currentNetworkName = (await provider.getNetwork()).name
         // change network if different network name or type
-        return currentNetworkName !== networkName || networkType === 'L2'
+        return currentNetworkName !== (networkName || 'unknown') || networkType === 'L2'
       } else if (currentNetworkType === 'L2') {
         // change network if different network type
         // name is irrelevant because there is only one local L2

--- a/packages/arb-token-bridge-ui/tests/support/commands.ts
+++ b/packages/arb-token-bridge-ui/tests/support/commands.ts
@@ -24,8 +24,9 @@ function shouldChangeNetwork({
   // TODO: remove this whenever fixed
 
   // currentNetworkType is stored after each network switch and used in the next login
-  return cy.task('getCurrentNetworkType').then(
-    async (currentNetworkType: NetworkType | null) => {
+  return cy
+    .task('getCurrentNetworkType')
+    .then(async (currentNetworkType: NetworkType | null) => {
       if (currentNetworkType === 'L1') {
         const provider = new StaticJsonRpcProvider(Cypress.env('ETH_RPC_URL'))
         const currentNetworkName = (await provider.getNetwork()).name
@@ -39,8 +40,7 @@ function shouldChangeNetwork({
         // change network if network type hasn't been set yet
         return true
       }
-    }
-  )
+    })
 }
 
 export function login({

--- a/packages/arb-token-bridge-ui/tests/support/commands.ts
+++ b/packages/arb-token-bridge-ui/tests/support/commands.ts
@@ -8,44 +8,23 @@
 // ***********************************************
 
 import '@testing-library/cypress/add-commands'
-import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { recurse } from 'cypress-recurse'
-import { NetworkType, setupMetamaskNetwork, startWebApp } from './common'
+import {
+  NetworkType,
+  NetworkName,
+  startWebApp,
+  getL1NetworkConfig,
+  getL2NetworkConfig
+} from './common'
 
-function shouldChangeNetwork({
-  networkType,
-  networkName
-}: {
-  networkType: NetworkType
-  networkName?: string
-}) {
+function shouldChangeNetwork(networkName: NetworkName) {
   // synpress throws if trying to connect to a network we are already connected to
   // issue has been raised with synpress and this is just a workaround
   // TODO: remove this whenever fixed
-
-  // currentNetworkType is stored after each network switch and used in the next login
   return cy
-    .task('getCurrentNetworkType')
-    .then(async (currentNetworkType: NetworkType | null) => {
-      if (currentNetworkType === 'L1') {
-        const provider = new StaticJsonRpcProvider(Cypress.env('ETH_RPC_URL'))
-        const currentNetworkName = (await provider.getNetwork()).name
-        // change network if different network name or type
-        // unknown is returned for local networks
-        // if it doesn't match it means it changed because there's only one L1 and one L2 local network
-        // it works for other networks because networkName is provided for them
-        return (
-          currentNetworkName !== (networkName || 'unknown') ||
-          networkType === 'L2'
-        )
-      } else if (currentNetworkType === 'L2') {
-        // change network if different network type
-        // name is irrelevant because there is only one local L2
-        return networkType === 'L1'
-      } else {
-        // change network if network type hasn't been set yet
-        return true
-      }
+    .task('getCurrentNetworkName')
+    .then((currentNetworkName: NetworkName) => {
+      return currentNetworkName !== networkName
     })
 }
 
@@ -56,7 +35,7 @@ export function login({
   query
 }: {
   networkType: NetworkType
-  networkName?: string
+  networkName?: NetworkName
   url?: string
   query?: { [s: string]: string }
 }) {
@@ -64,17 +43,22 @@ export function login({
     startWebApp(url, query)
   }
 
-  shouldChangeNetwork({ networkType, networkName }).then(changeNetwork => {
+  // if networkName is not specified we connect to default network from config
+  networkName =
+    networkName ||
+    (networkType === 'L1' ? getL1NetworkConfig() : getL2NetworkConfig())
+      .networkName
+
+  shouldChangeNetwork(networkName).then(changeNetwork => {
     if (changeNetwork) {
-      setupMetamaskNetwork(networkType, networkName).then(() => {
+      cy.changeMetamaskNetwork(networkName).then(() => {
         _startWebApp()
       })
     } else {
       _startWebApp()
     }
 
-    // set current network type
-    cy.task('setCurrentNetworkType', networkType)
+    cy.task('setCurrentNetworkName', networkName)
   })
 }
 

--- a/packages/arb-token-bridge-ui/tests/support/commands.ts
+++ b/packages/arb-token-bridge-ui/tests/support/commands.ts
@@ -34,7 +34,10 @@ function shouldChangeNetwork({
         // unknown is returned for local networks
         // if it doesn't match it means it changed because there's only one L1 and one L2 local network
         // it works for other networks because networkName is provided for them
-        return currentNetworkName !== (networkName || 'unknown') || networkType === 'L2'
+        return (
+          currentNetworkName !== (networkName || 'unknown') ||
+          networkType === 'L2'
+        )
       } else if (currentNetworkType === 'L2') {
         // change network if different network type
         // name is irrelevant because there is only one local L2

--- a/packages/arb-token-bridge-ui/tests/support/commands.ts
+++ b/packages/arb-token-bridge-ui/tests/support/commands.ts
@@ -17,7 +17,7 @@ function shouldChangeNetwork({
   networkName
 }: {
   networkType: NetworkType
-  networkName: string
+  networkName?: string
 }) {
   // synpress throws if trying to connect to a network we are already connected to
   // issue has been raised with synpress and this is just a workaround
@@ -31,6 +31,9 @@ function shouldChangeNetwork({
         const provider = new StaticJsonRpcProvider(Cypress.env('ETH_RPC_URL'))
         const currentNetworkName = (await provider.getNetwork()).name
         // change network if different network name or type
+        // unknown is returned for local networks
+        // if it doesn't match it means it changed because there's only one L1 and one L2 local network
+        // it works for other networks because networkName is provided for them
         return currentNetworkName !== (networkName || 'unknown') || networkType === 'L2'
       } else if (currentNetworkType === 'L2') {
         // change network if different network type

--- a/packages/arb-token-bridge-ui/tests/support/common.ts
+++ b/packages/arb-token-bridge-ui/tests/support/common.ts
@@ -88,19 +88,14 @@ export async function getInitialERC20Balance(
 
 export const setupMetamaskNetwork = (
   networkType: NetworkType,
-  networkName?: string,
-  addNewNetwork?: boolean
+  networkName?: string
 ) => {
   // we want control over the metamask flow before our web app starts (because we might want to start from an L2 network)
   // hence this additional network switch-check before actually starting the app
   const networkConfig =
     networkType === 'L1' ? getL1NetworkConfig() : getL2NetworkConfig()
 
-  if (addNewNetwork) {
-    return cy.addMetamaskNetwork(networkConfig)
-  } else {
-    return cy.changeMetamaskNetwork(networkName ?? networkConfig.networkName)
-  }
+  return cy.changeMetamaskNetwork(networkName ?? networkConfig.networkName)
 }
 
 export const acceptMetamaskAccess = () => {
@@ -115,8 +110,7 @@ export const acceptMetamaskAccess = () => {
 
 export const startWebApp = (
   url = '/',
-  qs: { [s: string]: string } = {},
-  isWalletConnected: boolean
+  qs: { [s: string]: string } = {}
 ) => {
   // once all the metamask setup is done, we can start the actual web-app for testing
   // clear local storage for terms to always have it pop up
@@ -125,7 +119,10 @@ export const startWebApp = (
     qs
   })
   cy.connectToApp()
-  if (!isWalletConnected) {
-    acceptMetamaskAccess()
-  }
+  cy.task('getWalletConnectedToDapp').then(connected => {
+    if (!connected) {
+      acceptMetamaskAccess()
+      cy.task('setWalletConnectedToDapp')
+    }
+  })
 }

--- a/packages/arb-token-bridge-ui/tests/support/common.ts
+++ b/packages/arb-token-bridge-ui/tests/support/common.ts
@@ -7,10 +7,26 @@ import { BigNumber } from 'ethers'
 import { MultiCaller } from '@arbitrum/sdk'
 
 export type NetworkType = 'L1' | 'L2'
+export type NetworkName =
+  | 'localhost'
+  | 'custom-localhost'
+  | 'arbitrum-localhost'
+  | 'mainnet'
+  | 'goerli'
+  | 'Sepolia test network'
 
 export const metamaskLocalL1RpcUrl = 'http://localhost:8545'
 
-export const getL1NetworkConfig = () => {
+type NetworkConfig = {
+  networkName: NetworkName
+  rpcUrl: string
+  chainId: string
+  symbol: string
+  isTestnet: boolean
+  multiCall: string
+}
+
+export const getL1NetworkConfig = (): NetworkConfig => {
   return {
     // reuse built-in Metamask network if possible
     // we add a new network in CI because of a different rpc url
@@ -26,7 +42,7 @@ export const getL1NetworkConfig = () => {
   }
 }
 
-export const getL2NetworkConfig = () => {
+export const getL2NetworkConfig = (): NetworkConfig => {
   return {
     networkName: 'arbitrum-localhost',
     rpcUrl: Cypress.env('ARB_RPC_URL'),
@@ -84,18 +100,6 @@ export async function getInitialERC20Balance(
     balanceOf: { account: Cypress.env('ADDRESS') }
   })
   return tokenData.balance
-}
-
-export const setupMetamaskNetwork = (
-  networkType: NetworkType,
-  networkName?: string
-) => {
-  // we want control over the metamask flow before our web app starts (because we might want to start from an L2 network)
-  // hence this additional network switch-check before actually starting the app
-  const networkConfig =
-    networkType === 'L1' ? getL1NetworkConfig() : getL2NetworkConfig()
-
-  return cy.changeMetamaskNetwork(networkName ?? networkConfig.networkName)
 }
 
 export const acceptMetamaskAccess = () => {

--- a/packages/arb-token-bridge-ui/tests/support/common.ts
+++ b/packages/arb-token-bridge-ui/tests/support/common.ts
@@ -108,10 +108,7 @@ export const acceptMetamaskAccess = () => {
   })
 }
 
-export const startWebApp = (
-  url = '/',
-  qs: { [s: string]: string } = {}
-) => {
+export const startWebApp = (url = '/', qs: { [s: string]: string } = {}) => {
   // once all the metamask setup is done, we can start the actual web-app for testing
   // clear local storage for terms to always have it pop up
   cy.clearLocalStorage('arbitrum:bridge:tos-v1')

--- a/packages/arb-token-bridge-ui/tests/support/index.ts
+++ b/packages/arb-token-bridge-ui/tests/support/index.ts
@@ -29,9 +29,6 @@ before(() => {
       // L2
       cy.addMetamaskNetwork(getL2NetworkConfig())
 
-      // to void the double connection issue
-      cy.changeMetamaskNetwork('goerli')
-
       cy.task('setNetworkSetupComplete')
     }
   })

--- a/packages/arb-token-bridge-ui/tests/support/index.ts
+++ b/packages/arb-token-bridge-ui/tests/support/index.ts
@@ -25,10 +25,10 @@ before(() => {
       if (Cypress.env('ETH_RPC_URL') !== metamaskLocalL1RpcUrl) {
         cy.addMetamaskNetwork(getL1NetworkConfig())
       }
-    
+
       // L2
       cy.addMetamaskNetwork(getL2NetworkConfig())
-    
+
       // to void the double connection issue
       cy.changeMetamaskNetwork('goerli')
 

--- a/packages/arb-token-bridge-ui/tests/support/index.ts
+++ b/packages/arb-token-bridge-ui/tests/support/index.ts
@@ -2,6 +2,12 @@ import './commands'
 import '@synthetixio/synpress/support'
 import 'cypress-localstorage-commands'
 
+import {
+  getL1NetworkConfig,
+  getL2NetworkConfig,
+  metamaskLocalL1RpcUrl
+} from './common'
+
 Cypress.Keyboard.defaults({
   // tests are flaky in CI with low keystroke delay
   keystrokeDelay: 150
@@ -10,4 +16,23 @@ Cypress.Keyboard.defaults({
 before(() => {
   // connect to goerli to avoid connecting to localhost twice and failing
   cy.setupMetamask(Cypress.env('PRIVATE_KEY'), 'goerli')
+
+  // setup local networks in Metamask if haven't done it yet
+  cy.task('getNetworkSetupComplete').then(complete => {
+    if (!complete) {
+      // L1
+      // only CI setup is required, Metamask already has localhost
+      if (Cypress.env('ETH_RPC_URL') !== metamaskLocalL1RpcUrl) {
+        cy.addMetamaskNetwork(getL1NetworkConfig())
+      }
+    
+      // L2
+      cy.addMetamaskNetwork(getL2NetworkConfig())
+    
+      // to void the double connection issue
+      cy.changeMetamaskNetwork('goerli')
+
+      cy.task('setNetworkSetupComplete')
+    }
+  })
 })


### PR DESCRIPTION
Until now a lot of tests were dependent on the Metamask state, such as network creation, previously connected network, wallet being connected to dapp. This also made some tests dependent on each other in some cases.

This PR introduces the following improvements/fixes:
- Metamask networks are now set up before all tests run. This means we don't have to e.g. run `withdrawETH` (which previously also did L2 setup) to test anything relying on L2 network
- Even though we are still waiting for https://github.com/Synthetixio/synpress/issues/702 fix from Synpress, `cy.login` will now handle itself and skip network connection if already connected to the desired network
- We don't rely on `login.cy.ts` to connect wallet to the bridge anymore. Any first use of `cy.login` will also connect to the bridge
- This also means we can run just one, or any number of tests, in any order, and they should all pass independently 🥳 