### PR TITLE
ci: fix build clean up

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,7 +54,7 @@ jobs:
     name: "Build"
     runs-on: ubuntu-latest
     outputs:
-      run_count: ${{ steps.build.outputs.run_count }}
+      build_count: ${{ steps.build_count.outputs.count }}
     needs: install
     steps:
       - name: Checkout
@@ -70,12 +70,16 @@ jobs:
         uses: ./.github/actions/build-artifacts/cache
 
       - name: Increment build count
+        id: build_count
         run: |
           echo "display jobs count"
-          echo ${{ jobs.build.outputs.run_count }}
-          echo "run_count=1" >> $GITHUB_OUTPUT
+          echo ${{ steps.build_count.outputs.count }}
+          if [[ ${{ github.run_attempt }} == 1 ]]; then
+          echo "count=1" >> $GITHUB_OUTPUT
+          else
+          echo "count=${{ steps.build_count.outputs.count }} + 1" >> $GITHUB_OUTPUT
           echo "display count again"
-          echo ${{ jobs.build.outputs.run_count }}
+          echo ${{ steps.build_count.outputs.count }}
         shell: bash
 
   test-sdk:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,12 +71,7 @@ jobs:
 
       - name: Increment build count
         run: |
-          if [[ "jobs.build.outputs.run_count" ]]; then
-          echo "run_count=jobs.build.outputs.run_count + 1" >> $GITHUB_OUTPUT
-          else
-          echo "run_count=1" >> $GITHUB_OUTPUT
-          fi
-          echo "Run count:"
+          echo "display jobs count"
           echo "jobs.build.outputs.run_count"
         shell: bash
 
@@ -243,4 +238,4 @@ jobs:
         run: gh extension install actions/gh-actions-cache
 
       - name: Delete build artifacts
-        run: gh actions-cache delete build-artifacts-${{ github.run_id }}-${{ jobs.build.outputs.run_count }} --confirm
+        run: gh actions-cache delete build-artifacts-${{ github.run_id }}-${{ github.run_attempt }} --confirm

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Increment build count
         run: |
           if [[ ${{ jobs.build.outputs.run_count }} ]]; then
-            echo "run_count=jobs.build.outputs.run_count + 1" >> $GITHUB_OUTPUT
+          echo "run_count=jobs.build.outputs.run_count + 1" >> $GITHUB_OUTPUT
           else
-            echo "run_count=1" >> $GITHUB_OUTPUT
+          echo "run_count=1" >> $GITHUB_OUTPUT
           fi
           echo "Run count:"
           echo ${{ jobs.build.outputs.run_count }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -78,6 +78,7 @@ jobs:
           echo "count=1" >> $GITHUB_OUTPUT
           else
           echo "count=${{ steps.build_count.outputs.count }} + 1" >> $GITHUB_OUTPUT
+          fi
           echo "display count again"
           echo "${{ steps.build_count.outputs.count }}"
         shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,13 +71,13 @@ jobs:
 
       - name: Increment build count
         run: |
-          if [[ ${{ jobs.build.outputs.run_count }} ]]; then
+          if [[ jobs.build.outputs.run_count ]]; then
           echo "run_count=jobs.build.outputs.run_count + 1" >> $GITHUB_OUTPUT
           else
           echo "run_count=1" >> $GITHUB_OUTPUT
           fi
           echo "Run count:"
-          echo ${{ jobs.build.outputs.run_count }}
+          echo jobs.build.outputs.run_count
 
   test-sdk:
     name: "Test SDK"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,6 +53,8 @@ jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
+    outputs:
+      run_count: ${{ steps.build.outputs.run_count }}
     needs: install
     steps:
       - name: Checkout
@@ -66,6 +68,16 @@ jobs:
 
       - name: Cache build artifacts
         uses: ./.github/actions/build-artifacts/cache
+
+      - name: Increment build count
+        run: |
+          if [[ ${{ jobs.build.outputs.run_count }} ]]; then
+            echo "run_count=jobs.build.outputs.run_count + 1" >> $GITHUB_OUTPUT
+          else
+            echo "run_count=1" >> $GITHUB_OUTPUT
+          fi
+          echo "Run count:"
+          echo ${{ jobs.build.outputs.run_count }}
 
   test-sdk:
     name: "Test SDK"
@@ -230,4 +242,4 @@ jobs:
         run: gh extension install actions/gh-actions-cache
 
       - name: Delete build artifacts
-        run: gh actions-cache delete build-artifacts-${{ github.run_id }}-${{ github.run_attempt }} --confirm
+        run: gh actions-cache delete build-artifacts-${{ github.run_id }}-${{ jobs.build.outputs.run_count }} --confirm

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -72,7 +72,10 @@ jobs:
       - name: Increment build count
         run: |
           echo "display jobs count"
-          echo "jobs.build.outputs.run_count"
+          echo jobs.build.outputs.run_count
+          echo "run_count=1" >> $GITHUB_OUTPUT
+          echo "display count again"
+          echo jobs.build.outputs.run_count
         shell: bash
 
   test-sdk:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,13 +71,13 @@ jobs:
 
       - name: Increment build count
         run: |
-          if [[ jobs.build.outputs.run_count ]]; then
+          if [[ "jobs.build.outputs.run_count" ]]; then
           echo "run_count=jobs.build.outputs.run_count + 1" >> $GITHUB_OUTPUT
           else
           echo "run_count=1" >> $GITHUB_OUTPUT
           fi
           echo "Run count:"
-          echo jobs.build.outputs.run_count
+          echo "jobs.build.outputs.run_count"
         shell: bash
 
   test-sdk:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -78,6 +78,7 @@ jobs:
           fi
           echo "Run count:"
           echo jobs.build.outputs.run_count
+        shell: bash
 
   test-sdk:
     name: "Test SDK"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -72,10 +72,10 @@ jobs:
       - name: Increment build count
         run: |
           echo "display jobs count"
-          echo jobs.build.outputs.run_count
+          echo ${{ jobs.build.outputs.run_count }}
           echo "run_count=1" >> $GITHUB_OUTPUT
           echo "display count again"
-          echo jobs.build.outputs.run_count
+          echo ${{ jobs.build.outputs.run_count }}
         shell: bash
 
   test-sdk:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -73,13 +73,13 @@ jobs:
         id: build_count
         run: |
           echo "display jobs count"
-          echo ${{ steps.build_count.outputs.count }}
+          echo "${{ steps.build_count.outputs.count }}"
           if [[ ${{ github.run_attempt }} == 1 ]]; then
           echo "count=1" >> $GITHUB_OUTPUT
           else
           echo "count=${{ steps.build_count.outputs.count }} + 1" >> $GITHUB_OUTPUT
           echo "display count again"
-          echo ${{ steps.build_count.outputs.count }}
+          echo "${{ steps.build_count.outputs.count }}"
         shell: bash
 
   test-sdk:


### PR DESCRIPTION
Clean up is checking for workflow run count and searching+deleting build cache based on that number. If we want to re-run a single job, `clean-up` job will fail due to workflow count being 2, but build still at 1.

Here we make `clean-up` search for the build job run count.

I didn't see GA having a built-in way to get job run count but if they do lmk