### PR TITLE
fix: broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ It is important for any code change to pass both unit and end-to-end tests. This
    $ yarn test:e2e
    ```
 
-Read more about the test setup [here](/packages/arb-token-bridge-ui/tests/e2e/readme.md).
+Read more about the test setup [here](/packages/arb-token-bridge-ui/tests/e2e/README.md).
 
 <br />
 


### PR DESCRIPTION
- A very small fix for the broken link in `README`

<img height="200" alt="image" src="https://user-images.githubusercontent.com/7558499/233333203-0f1016d7-1768-46dd-a210-f415723a3f33.png">
