### PR TITLE
fix(wip): a bug fix for #601

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
@@ -212,7 +212,7 @@ export function WithdrawalConfirmationDialog(
             </div>
 
             <div className="mt-2 flex flex-row justify-end space-x-2">
-              <Button variant="secondary" onClick={() => props.onClose(false)}>
+              <Button variant="secondary" onClick={() => closeWithReset(false)}>
                 Cancel
               </Button>
               <Button

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
@@ -219,7 +219,7 @@ export function WithdrawalConfirmationDialog(
                 variant="primary"
                 disabled={!bothCheckboxesChecked}
                 onClick={() => {
-                  props.onClose(true)
+                  closeWithReset(true)
                   trackEvent('Slow Bridge Click')
                 }}
               >


### PR DESCRIPTION
### Summary

This PR resets the state of the dialog checkboxes for bug #601. This change is necessary so that every time the checkboxes pop up before withdrawing to L1, the user can consciously check them and ack them. Before the fix, it wouldn't reset the state, even when they pressed the **Cancel** button or **Continue** button. Now it resets correctly.

### Steps to test

https://user-images.githubusercontent.com/18104028/233706842-f895ed3b-7c52-4d6f-b819-bbc5b30dba0c.mov

### WIP

The reason I marked **WIP** is because the e2e tests are failing with `Error: cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (error={"reason":"cannot estimate gas; transaction may fail or may require manual gas limit"`. It seems it's failing on this line `const token = await contract.deploy()`. 

**_How do I fix this?_** I tried changing the gas limit for the `localWallet` with the overrides object when deploying the contract but then I got `Error: insufficient funds for intrinsic transaction cost`
