### PR TITLE
fix: reverted the additional UI check which failed E2E

### DIFF
--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -135,14 +135,7 @@ export const defaultState: AppState = {
       s.arbTokenBridge?.pendingWithdrawalsMap || []
     ) as L2ToL1EventResultPlus[]
 
-    // make sure the withdrawals are filtered only for the current account
-    // prevents stale withdrawals from previous accounts to show up in tx-history
-    const filteredWithdrawals = withdrawals.filter(
-      tx =>
-        tx.caller.toLowerCase() === s.arbTokenBridge.walletAddress.toLowerCase()
-    )
-
-    return transformWithdrawals(filteredWithdrawals)
+    return transformWithdrawals(withdrawals)
   }),
   mergedTransactions: derived((s: AppState) => {
     return _reverse(


### PR DESCRIPTION
### Issue
E2E test for withdrawing the ERC20 token was failing in CI (and later, locally)

### Reasons
- As a part of https://github.com/OffchainLabs/arbitrum-token-bridge/pull/741 we added a UI check for this 
> We were not filtering withdrawal transactions by current account before loading in the UI - so all the transactions in the state would get considered for UI

- While running E2E, the withdrawals are initiated by the locally configured network, and due to this change, we filtered to only show those transactions whose `caller matches the current wallet address` - Which is not the case in E2E.

### Fix
Reverted this check as our previous issue was getting fixed by the state check revalidation only - so this check was redundant. The issue being fixed by https://github.com/OffchainLabs/arbitrum-token-bridge/pull/741 still remains fixed. 