### PR TITLE
fix: hide current network from network selection dropdown

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -48,36 +48,38 @@ export const NetworkSelectionContainer = ({
       <Transition>
         <Popover.Panel className="relative flex flex-col rounded-md lg:absolute lg:ml-1 lg:mt-1 lg:bg-white lg:shadow-[0px_4px_20px_rgba(0,0,0,0.2)]">
           {({ close }) =>
-            supportedNetworks?.map((chainId, i) => (
-              <div // TODO: replace with button
-                key={chainId}
-                className="flex h-12 cursor-pointer flex-nowrap items-center justify-start space-x-3 px-12 text-lg font-light text-white hover:bg-[rgba(0,0,0,0.2)] lg:px-4 lg:text-base lg:font-normal lg:text-dark"
-                onClick={() => {
-                  handleClick(chainId, close)
-                }}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.keyCode === 13) {
+            supportedNetworks
+              ?.filter(chainId => chainId !== chain?.id)
+              ?.map((chainId, i) => (
+                <div // TODO: replace with button
+                  key={chainId}
+                  className="flex h-12 cursor-pointer flex-nowrap items-center justify-start space-x-3 px-12 text-lg font-light text-white hover:bg-[rgba(0,0,0,0.2)] lg:px-4 lg:text-base lg:font-normal lg:text-dark"
+                  onClick={() => {
                     handleClick(chainId, close)
-                  }
-                }}
-                role="button"
-                tabIndex={i}
-                aria-label={`Switch to ${getNetworkName(Number(chainId))}`}
-              >
-                <div className="flex h-6 w-6 items-center justify-center lg:h-8 lg:w-8">
-                  <Image
-                    src={getNetworkLogo(Number(chainId))}
-                    alt={`${getNetworkName(Number(chainId))} logo`}
-                    className="h-full w-auto"
-                    width={24}
-                    height={24}
-                  />
+                  }}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' || e.keyCode === 13) {
+                      handleClick(chainId, close)
+                    }
+                  }}
+                  role="button"
+                  tabIndex={i}
+                  aria-label={`Switch to ${getNetworkName(Number(chainId))}`}
+                >
+                  <div className="flex h-6 w-6 items-center justify-center lg:h-8 lg:w-8">
+                    <Image
+                      src={getNetworkLogo(Number(chainId))}
+                      alt={`${getNetworkName(Number(chainId))} logo`}
+                      className="h-full w-auto"
+                      width={24}
+                      height={24}
+                    />
+                  </div>
+                  <span className="whitespace-nowrap">
+                    {getNetworkName(Number(chainId))}
+                  </span>
                 </div>
-                <span className="whitespace-nowrap">
-                  {getNetworkName(Number(chainId))}
-                </span>
-              </div>
-            ))
+              ))
           }
         </Popover.Panel>
       </Transition>


### PR DESCRIPTION
### Summary
The current network should not be displayed in the network selection dropdown.

This PR fixes the issue below: 
[https://github.com/OffchainLabs/arbitrum-token-bridge/issues/755](https://github.com/OffchainLabs/arbitrum-token-bridge/issues/755)

### Steps to test
check the dropdown on both dekstop: 
<img width="282" alt="Screenshot 2023-04-26 at 17 31 53" src="https://user-images.githubusercontent.com/15897482/234642214-0d62b724-8692-4853-a9c5-407e722bd714.png">
And mobile: 
<img width="282" alt="Screenshot 2023-04-26 at 17 32 18" src="https://user-images.githubusercontent.com/15897482/234642303-c323d560-e400-4c4a-b1c8-b84b91849dcf.png">
