### PR TITLE
test: Reload on failed attempts

### DIFF
--- a/packages/arb-token-bridge-ui/tests/support/common.ts
+++ b/packages/arb-token-bridge-ui/tests/support/common.ts
@@ -119,6 +119,10 @@ export const startWebApp = (url = '/', qs: { [s: string]: string } = {}) => {
   cy.visit(url, {
     qs
   })
+  if (Cypress.currentRetry > 0) {
+    // ensures we don't test with the same state that could have caused the test to fail
+    cy.reload()
+  }
   cy.connectToApp()
   cy.task('getWalletConnectedToDapp').then(connected => {
     if (!connected) {

--- a/packages/arb-token-bridge-ui/tests/support/common.ts
+++ b/packages/arb-token-bridge-ui/tests/support/common.ts
@@ -121,7 +121,7 @@ export const startWebApp = (url = '/', qs: { [s: string]: string } = {}) => {
   })
   if (Cypress.currentRetry > 0) {
     // ensures we don't test with the same state that could have caused the test to fail
-    cy.reload()
+    cy.reload(true)
   }
   cy.connectToApp()
   cy.task('getWalletConnectedToDapp').then(connected => {


### PR DESCRIPTION
### **Issue**
There's a pattern where flaky tests (especially failing to type or initially load the page) would always fail their re-attempts.  The underlying issue is not clear but it could be that cypress is not starting the test over in a fresh state, but reusing the previous instance for next attempts.

### **Fix**
Not sure if that fixes our issue but if the mentioned problem is the cause, reloading the page after every failed attempt could make our tests much less flaky.