### PR TITLE
fix: menu text color not visible in mobile

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { twMerge } from 'tailwind-merge'
 import { Disclosure, Popover } from '@headlessui/react'
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/outline'
 
@@ -91,9 +92,10 @@ export function HeaderMenuMobile(
             }`}
           >
             <span
-              className={`flex flex-row flex-nowrap items-center space-x-4 text-2xl font-medium ${
+              className={twMerge(
+                `flex flex-row flex-nowrap items-center space-x-4 text-2xl font-medium`,
                 open ? `text-blue-arbitrum` : `text-white`
-              }`}
+              )}
             >
               {props.children}
             </span>

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
@@ -91,8 +91,8 @@ export function HeaderMenuMobile(
             }`}
           >
             <span
-              className={`flex flex-row flex-nowrap items-center space-x-4 text-2xl font-medium text-white ${
-                open && `text-blue-arbitrum`
+              className={`flex flex-row flex-nowrap items-center space-x-4 text-2xl font-medium ${
+                open ? `text-blue-arbitrum` : `text-white`
               }`}
             >
               {props.children}


### PR DESCRIPTION
Fixed logic for highlighting link color in the mobile header menu.

### Before - After
<p float="left">
<img height="300" alt="image" src="https://user-images.githubusercontent.com/7558499/236844932-f78c9a85-79b2-4997-bd07-94054cd89911.png">
<img height="300" alt="image" src="https://user-images.githubusercontent.com/7558499/236845040-ca0b6ae3-cbdb-4d58-8857-95c2365ef6db.png">
</p>