### PR TITLE
fix: token search popup height in mobile

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -88,7 +88,7 @@ export function TokenButton(): JSX.Element {
             <ChevronDownIcon className="h-4 w-4 text-gray-9" />
           </div>
         </Popover.Button>
-        <Popover.Panel className="absolute left-0 top-0 z-50 h-full w-full bg-white px-6 py-4 lg:left-auto lg:top-auto lg:h-auto lg:w-[466px] lg:rounded-lg lg:p-6 lg:shadow-[0px_4px_12px_#9e9e9e]">
+        <Popover.Panel className="absolute left-0 top-0 z-50 w-full rounded-lg bg-white px-6 py-4 shadow-[0px_4px_12px_#9e9e9e] lg:left-auto lg:top-auto lg:h-auto lg:w-[466px] lg:p-6">
           {({ close }) => (
             <TokenSearch close={close} onImportToken={importToken} />
           )}


### PR DESCRIPTION
### Summary

As a part of #742 we updated the Input panel component's positioning (to have an absolutely positioned background). That resulted in messing up the size of the token-search panel, which is set `absolute` inside the Input panel.

We fixed its impact on large screens, but it did not get resolved entirely on mobile. This PR fixes the mobile view of token search.

### Before > After
<p float="left">
<img height="300" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/77a788b7-a5b0-41f7-aa47-c090d7df357b">

<img height="300" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/e85d4cf8-3145-46f9-9023-bbb0a777eec3">
</p>