### PR TITLE
fix: show correct balances for custom destination address

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -413,11 +413,7 @@ export function TransferPanelMain({
 
   useEffect(() => {
     // If a different destination address is specified, we want to update the ERC-20 balance accordingly
-    if (!selectedToken || !isAddress(destinationAddressOrWalletAddress)) return
-    if (isDepositMode) {
-      updateErc20L1Balance([selectedToken.address])
-      updateErc20L2Balance([String(selectedToken.l2Address)])
-    } else {
+    if (selectedToken && isAddress(destinationAddressOrWalletAddress)) {
       updateErc20L1Balance([selectedToken.address])
       updateErc20L2Balance([String(selectedToken.l2Address)])
     }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTokenBalances.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTokenBalances.ts
@@ -13,19 +13,31 @@ export type Balances = {
   [NetworkType.l1]: BigNumber | null
   [NetworkType.l2]: BigNumber | null
 }
-export function useTokenBalances(erc20L1Address?: string): Balances {
+export function useTokenBalances({
+  erc20L1Address,
+  walletAddress
+}: {
+  erc20L1Address?: string
+  walletAddress?: string
+}): Balances {
   const {
     app: {
-      arbTokenBridge: { walletAddress, bridgeTokens }
+      arbTokenBridge: { walletAddress: senderWalletAddress, bridgeTokens }
     }
   } = useAppState()
+
+  const _walletAddress = walletAddress || senderWalletAddress
+
   const { l1, l2 } = useNetworksAndSigners()
   const {
     erc20: [erc20L1Balances]
-  } = useBalance({ provider: l1.provider, walletAddress })
+  } = useBalance({
+    provider: l1.provider,
+    walletAddress: _walletAddress
+  })
   const {
     erc20: [erc20L2Balances]
-  } = useBalance({ provider: l2.provider, walletAddress })
+  } = useBalance({ provider: l2.provider, walletAddress: _walletAddress })
 
   return useMemo(() => {
     const defaultResult = { [NetworkType.l1]: null, [NetworkType.l2]: null }


### PR DESCRIPTION
Fix for https://github.com/OffchainLabs/arbitrum-token-bridge/pull/649

Balances will now correctly reflect what's in the destination address wallet (if provided, otherwise falls back to the wallet address).