### PR TITLE
test: keep list of node modules that need transformation

### DIFF
--- a/packages/arb-token-bridge-ui/jest.config.js
+++ b/packages/arb-token-bridge-ui/jest.config.js
@@ -13,5 +13,22 @@ const customJestConfig = {
   testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)']
 }
 
-// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-module.exports = createJestConfig(customJestConfig)
+// Lists out node modules that need to be transformed before running tests
+const transformNodeModules = [
+  'query-string',
+  'decode-uri-component',
+  'split-on-first',
+  'filter-obj'
+]
+
+module.exports = async function () {
+  const config = await createJestConfig(customJestConfig)()
+
+  return {
+    ...config,
+    transformIgnorePatterns: [
+      `node_modules/(?!(${transformNodeModules.join('|')})/)`,
+      '^.+\\.module\\.(css|sass|scss)$'
+    ]
+  }
+}

--- a/packages/arb-token-bridge-ui/jest.config.js
+++ b/packages/arb-token-bridge-ui/jest.config.js
@@ -16,6 +16,7 @@ const customJestConfig = {
 // Lists out node modules that need to be transformed before running tests
 const transformNodeModules = [
   'query-string',
+  // The following are dependencies for query-string (https://github.com/sindresorhus/query-string/blob/main/package.json)
   'decode-uri-component',
   'split-on-first',
   'filter-obj'


### PR DESCRIPTION
### Summary

Fixes test running with Jest when there's node modules that need to be transformed first. We now keep a list of those.

Source: https://github.com/vercel/next.js/issues/36077#issuecomment-1096635363