### PR TITLE
chore: remove the New indicator from preferences

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
@@ -227,10 +227,6 @@ export function HeaderAccountPopover({
               >
                 <Cog6ToothIcon className="h-4 w-4 text-white" />
                 <span>Preferences</span>
-
-                <span className="rounded-md bg-red-600 px-2 text-xs text-white lg:!ml-auto">
-                  NEW
-                </span>
               </button>
             )}
 


### PR DESCRIPTION
It's been a while since we released the Preferences panel. We can remove the new badge.

<img width="386" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/26a7af96-a1e8-4277-b6e6-fa75b332ed4e">
