### PR TITLE
fix: reduce block-range for failing CI test

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsTestHelpers.ts
@@ -9,7 +9,7 @@ const baseQuery = {
 }
 
 export function getQueryCoveringClassicOnlyWithoutResults() {
-  return { ...baseQuery, fromBlock: 0, toBlock: 20785771 }
+  return { ...baseQuery, fromBlock: 20780771, toBlock: 20785771 }
 }
 
 export function getQueryCoveringClassicOnlyWithResults() {

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
@@ -16,7 +16,7 @@ const baseQuery = {
 }
 
 export function getQueryCoveringClassicOnlyWithoutResults() {
-  return { ...baseQuery, fromBlock: 0, toBlock: 19416899 }
+  return { ...baseQuery, fromBlock: 19411899, toBlock: 19416899 }
 }
 
 export function getQueryCoveringClassicOnlyWithResults() {


### PR DESCRIPTION
When the block-range is too much (>2M), the event logs' call intermittently fail with the error: `context deadline exceeded` which results in our integration tests failing in CI pipeline. This PR reduces the range of the error logs in the failing case, reducing the chances of a future failure.

<img width="1318" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/cdc5d46c-0195-4fcd-8634-362ad5f18b02">
