### PR TITLE
test: improve invalid tx search string in e2e

### DIFF
--- a/packages/arb-token-bridge-ui/tests/e2e/specs/txHistory.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/txHistory.cy.ts
@@ -68,7 +68,7 @@ describe('Transaction History', () => {
 
       // search for invalid address substring
       cy.findByPlaceholderText(DEPOSIT_SEARCH_IDENTIFIER)
-        .typeRecursively('invalidTransactionHash')
+        .typeRecursively('0xx') // 0xx is invalid tx hash
         .then(() => {
           cy.findByText(
             /Oops! Looks like nothing matched your search query/i
@@ -148,7 +148,7 @@ describe('Transaction History', () => {
 
       // search for invalid address substring
       cy.findByPlaceholderText(WITHDRAWAL_SEARCH_IDENTIFIER)
-        .typeRecursively('invalidTransactionHash')
+        .typeRecursively('0xx') // 0xx is invalid tx hash
         .then(() => {
           cy.findByText(
             /Oops! Looks like nothing matched your search query/i


### PR DESCRIPTION
In our transaction history test, we search for "invalidTransactionHash" to test for the `no results found` case.

It'd be better to use a much shorter invalid string here. Using "0xx" shaves 6s off our e2e test suite, given that each key-stroke takes 150ms, and longer typed strings increase the chances of flakiness. 😄 

---

<img width="726" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/cf7bf229-f9e7-43e4-931e-996207cfea58">
