### PR TITLE
refactor: move account type check to `useAccountType`

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTable.tsx
@@ -85,7 +85,7 @@ export function TransactionsTable({
   loading,
   error
 }: TransactionsTableProps) {
-  const isSmartContractWallet = useAccountType() === 'Smart Contract'
+  const { isSmartContractWallet = false } = useAccountType()
 
   const {
     app: { mergedTransactions: locallyStoredTransactions }

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTable.tsx
@@ -14,7 +14,7 @@ import { TableBodyLoading } from './TableBodyLoading'
 import { TableBodyError } from './TableBodyError'
 import { TableActionHeader } from './TableActionHeader'
 import { useAppState } from '../../../state'
-import { useIsConnectedWithSmartContractWallet } from '../../../hooks/useIsConnectedWithSmartContractWallet'
+import { useAccountType } from '../../../hooks/useAccountType'
 
 export type PageParams = {
   searchString: string
@@ -85,7 +85,7 @@ export function TransactionsTable({
   loading,
   error
 }: TransactionsTableProps) {
-  const isSmartContractWallet = useIsConnectedWithSmartContractWallet() ?? false
+  const isSmartContractWallet = useAccountType() === 'Smart Contract'
 
   const {
     app: { mergedTransactions: locallyStoredTransactions }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -43,7 +43,7 @@ import {
 } from '../../util/TokenUtils'
 import { useBalance } from '../../hooks/useBalance'
 import { useSwitchNetworkWithConfig } from '../../hooks/useSwitchNetworkWithConfig'
-import { useIsConnectedWithSmartContractWallet } from '../../hooks/useIsConnectedWithSmartContractWallet'
+import { useAccountType } from '../../hooks/useAccountType'
 
 const onTxError = (error: any) => {
   if (error.code !== 'ACTION_REJECTED') {
@@ -138,7 +138,7 @@ export function TransferPanel() {
     l2: { network: l2Network, provider: l2Provider }
   } = networksAndSigners
 
-  const isSmartContractWallet = useIsConnectedWithSmartContractWallet() ?? false
+  const isSmartContractWallet = useAccountType() === 'Smart Contract'
 
   const { data: l1Signer } = useSigner({
     chainId: l1Network.id

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -350,7 +350,8 @@ export function TransferPanel() {
     }
 
     if (!isEOA && !isSmartContractWallet) {
-      throw 'Account type is undefined'
+      console.error('Account type is undefined')
+      return
     }
 
     if (!l1Signer || !l2Signer) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -138,7 +138,7 @@ export function TransferPanel() {
     l2: { network: l2Network, provider: l2Provider }
   } = networksAndSigners
 
-  const isSmartContractWallet = useAccountType() === 'Smart Contract'
+  const { isEOA = false, isSmartContractWallet = false } = useAccountType()
 
   const { data: l1Signer } = useSigner({
     chainId: l1Network.id
@@ -347,6 +347,10 @@ export function TransferPanel() {
   const transfer = async () => {
     if (!isConnected) {
       return
+    }
+
+    if (!isEOA && !isSmartContractWallet) {
+      throw 'Account type is undefined'
     }
 
     if (!l1Signer || !l2Signer) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -45,7 +45,7 @@ import { useBalance } from '../../hooks/useBalance'
 import { useGasPrice } from '../../hooks/useGasPrice'
 import { ERC20BridgeToken } from '../../hooks/arbTokenBridge.types'
 import { useSwitchNetworkWithConfig } from '../../hooks/useSwitchNetworkWithConfig'
-import { useIsConnectedWithSmartContractWallet } from '../../hooks/useIsConnectedWithSmartContractWallet'
+import { useAccountType } from '../../hooks/useAccountType'
 import { depositEthEstimateGas } from '../../util/EthDepositUtils'
 import { withdrawEthEstimateGas } from '../../util/EthWithdrawalUtils'
 
@@ -328,7 +328,7 @@ export function TransferPanelMain({
   const actions = useActions()
 
   const { l1, l2, isConnectedToArbitrum } = useNetworksAndSigners()
-  const isSmartContractWallet = useIsConnectedWithSmartContractWallet() ?? false
+  const isSmartContractWallet = useAccountType() === 'Smart Contract'
 
   const { switchNetworkAsync } = useSwitchNetworkWithConfig({
     isSwitchingNetworkBeforeTx: true

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -328,7 +328,7 @@ export function TransferPanelMain({
   const actions = useActions()
 
   const { l1, l2, isConnectedToArbitrum } = useNetworksAndSigners()
-  const isSmartContractWallet = useAccountType() === 'Smart Contract'
+  const { isSmartContractWallet = false } = useAccountType()
 
   const { switchNetworkAsync } = useSwitchNetworkWithConfig({
     isSwitchingNetworkBeforeTx: true

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -7,25 +7,38 @@ export function useAccountType() {
   const provider = useProvider()
   const { address } = useAccount()
 
-  const [result, setResult] = useState<'EOA' | 'Smart Contract' | undefined>(
-    undefined
-  )
+  const [result, setResult] = useState<{
+    isEOA: boolean | undefined
+    isSmartContractWallet: boolean | undefined
+  }>({
+    isEOA: undefined,
+    isSmartContractWallet: undefined
+  })
 
   useEffect(() => {
     async function update() {
       if (typeof address === 'undefined') {
-        setResult(undefined)
+        setResult({
+          isEOA: undefined,
+          isSmartContractWallet: undefined
+        })
         return
       }
 
       // TODO: Try to detect counterfactual/just-in-time deployed smart contract wallets
 
       if (await addressIsSmartContract(address, provider)) {
-        setResult('Smart Contract')
+        setResult({
+          isEOA: false,
+          isSmartContractWallet: true
+        })
         return
       }
 
-      setResult('EOA')
+      setResult({
+        isEOA: true,
+        isSmartContractWallet: false
+      })
     }
 
     update()

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -3,11 +3,13 @@ import { useAccount, useProvider } from 'wagmi'
 
 import { addressIsSmartContract } from '../util/AddressUtils'
 
-export function useIsConnectedWithSmartContractWallet() {
+export function useAccountType() {
   const provider = useProvider()
   const { address } = useAccount()
 
-  const [result, setResult] = useState<boolean | undefined>(undefined)
+  const [result, setResult] = useState<'EOA' | 'Smart Contract' | undefined>(
+    undefined
+  )
 
   useEffect(() => {
     async function update() {
@@ -18,7 +20,12 @@ export function useIsConnectedWithSmartContractWallet() {
 
       // TODO: Try to detect counterfactual/just-in-time deployed smart contract wallets
 
-      setResult(await addressIsSmartContract(address, provider))
+      if (await addressIsSmartContract(address, provider)) {
+        setResult('Smart Contract')
+        return
+      }
+
+      setResult('EOA')
     }
 
     update()

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -27,10 +27,15 @@ export function useAccountType() {
 
       // TODO: Try to detect counterfactual/just-in-time deployed smart contract wallets
 
-      if (await addressIsSmartContract(address, provider)) {
+      const isSmartContractWallet = await addressIsSmartContract(
+        address,
+        provider
+      )
+
+      if (isSmartContractWallet) {
         setResult({
-          isEOA: false,
-          isSmartContractWallet: true
+          isEOA: !isSmartContractWallet,
+          isSmartContractWallet
         })
         return
       }

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -3,25 +3,26 @@ import { useAccount, useProvider } from 'wagmi'
 
 import { addressIsSmartContract } from '../util/AddressUtils'
 
+type Result = {
+  isEOA: boolean | undefined
+  isSmartContractWallet: boolean | undefined
+}
+
+const defaultResult: Result = {
+  isEOA: undefined,
+  isSmartContractWallet: undefined
+}
+
 export function useAccountType() {
   const provider = useProvider()
   const { address } = useAccount()
 
-  const [result, setResult] = useState<{
-    isEOA: boolean | undefined
-    isSmartContractWallet: boolean | undefined
-  }>({
-    isEOA: undefined,
-    isSmartContractWallet: undefined
-  })
+  const [result, setResult] = useState<Result>(defaultResult)
 
   useEffect(() => {
     async function update() {
       if (typeof address === 'undefined') {
-        setResult({
-          isEOA: undefined,
-          isSmartContractWallet: undefined
-        })
+        setResult(defaultResult)
         return
       }
 

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -32,17 +32,9 @@ export function useAccountType() {
         provider
       )
 
-      if (isSmartContractWallet) {
-        setResult({
-          isEOA: !isSmartContractWallet,
-          isSmartContractWallet
-        })
-        return
-      }
-
       setResult({
-        isEOA: true,
-        isSmartContractWallet: false
+        isEOA: !isSmartContractWallet,
+        isSmartContractWallet
       })
     }
 

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/switchNetworks.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/switchNetworks.cy.ts
@@ -119,6 +119,8 @@ describe('Switch Networks', () => {
     context('Test Networks list in Wrong Network UI', () => {
       it('should show wrong network UI', () => {
         cy.login({ networkType: 'L1' })
+        // eslint-disable-next-line
+        cy.wait(5000)
         cy.changeMetamaskNetwork('Sepolia test network').then(() => {
           cy.waitUntil(
             () =>

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/switchNetworks.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/switchNetworks.cy.ts
@@ -119,6 +119,7 @@ describe('Switch Networks', () => {
     context('Test Networks list in Wrong Network UI', () => {
       it('should show wrong network UI', () => {
         cy.login({ networkType: 'L1' })
+        // wrong network UI flaky right after login, cy.wait fixes the flaky test
         // eslint-disable-next-line
         cy.wait(5000)
         cy.changeMetamaskNetwork('Sepolia test network').then(() => {


### PR DESCRIPTION
Currently our `useIsConnectedWithSmartContractWallet` hook can return either a `boolean` or `undefined`. There are some UI changes required for the custom address that are conditionally rendered based on `useIsConnectedWithSmartContractWallet` being `true`.

Therefore, we have to make checks like `useIsConnectedWithSmartContractWallet !== false` to cover the `undefined` case. This can be a bit confusing. This change will make it more clear:
`const { isEOA, isSmartContractWallet } = useAccountType()`