### PR TITLE
fix: expired txs should show one timestamp

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -108,12 +108,13 @@ function DepositRowTime({ tx }: { tx: MergedTransaction }) {
 
   return (
     <div className="flex flex-col space-y-3">
-      <Tooltip content={<span>L1 Transaction Time</span>}>
-        <TransactionDateTime standardizedDate={tx.createdAt} />
-      </Tooltip>
-      {tx.resolvedAt && (
+      {tx.resolvedAt ? (
         <Tooltip content={<span>L2 Transaction Time</span>}>
           <TransactionDateTime standardizedDate={tx.resolvedAt} />
+        </Tooltip>
+      ) : (
+        <Tooltip content={<span>L1 Transaction Time</span>}>
+          <TransactionDateTime standardizedDate={tx.createdAt} />
         </Tooltip>
       )}
     </div>


### PR DESCRIPTION
Fixes #859

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  The PR title should be in lowercase and must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - build: changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
  - ci: changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
  - docs: documentation only changes
  - feat: a new feature
  - fix: a bug fix
  - perf: a code change that improves performance
  - refactor: a code change that neither fixes a bug nor adds a feature
  - style: changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  - test: adding missing tests or correcting existing tests

  For a work-in-progress PR,
  - you can add (wip) to indicate the wip status and pass CI, i.e. fix(wip): a bug fix
  - please mark the PR as "Draft" if it is not ready for review
-->

### Summary

<!--
  Explain the **motivation** for making this change. Why was this change necessary?
  What existing problem does the pull request solve?
  Any implementation details to explain? What code paths or UI flow do the code changes hit?
-->

- In the transaction history list, any transaction with the value of `resolvedAt` would display two timestaps.
- This PR swaps the logic to only show one timestamp, with `resovledAt` taking prescedence.

### Steps to test

<!--
  How exactly did you verify that your PR solves the issue?
  If applicable, share the steps that a reviewer should follow to validate the new behavior.
  Example: The exact commands you ran and their output, screenshots / gifs / videos if the pull request changes the UI.
-->

I tested by editing the code to simulate the failed tx:

- Checkout `master`, then in `TransactionsTableDepositRow.tsx:108`, set `tx.resolvedAt` to any date, e.g. `tx.resolvedAt = '2021-10-13T18:00:00.000Z'` to see the issue.
- Checkout this PR, add those changes, and now it should be fixed.
