### PR TITLE
fix: disable network switching for contract wallets

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -642,7 +642,7 @@ export function TransferPanelMain({
     if (isDepositMode) {
       return {
         from: {
-          // only EOA can switch origin networks
+          // only EOA can change the origin network
           disabled: !fromOptions.length || !isEOA,
           options: fromOptions,
           value: from,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -335,7 +335,7 @@ export function TransferPanelMain({
   const actions = useActions()
 
   const { l1, l2, isConnectedToArbitrum } = useNetworksAndSigners()
-  const { isEOA = false, isSmartContractWallet = false } = useAccountType()
+  const { isSmartContractWallet = false } = useAccountType()
 
   const { switchNetworkAsync } = useSwitchNetworkWithConfig({
     isSwitchingNetworkBeforeTx: true

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -49,12 +49,14 @@ import { withdrawEthEstimateGas } from '../../util/EthWithdrawalUtils'
 export function SwitchNetworksButton(
   props: React.ButtonHTMLAttributes<HTMLButtonElement>
 ) {
-  const { isEOA = false, isSmartContractWallet = false } = useAccountType()
+  const { isEOA, isSmartContractWallet } = useAccountType()
 
   return (
     <button
       type="button"
-      disabled={!isEOA}
+      disabled={
+        isSmartContractWallet || typeof isSmartContractWallet === 'undefined'
+      }
       className={twMerge(
         'min-h-14 lg:min-h-16 min-w-14 lg:min-w-16 flex h-14 w-14 items-center justify-center rounded-full bg-white p-3 shadow-[0_0_4px_0_rgba(0,0,0,0.25)] transition duration-200 lg:h-16 lg:w-16 lg:p-4',
         isEOA
@@ -630,9 +632,10 @@ export function TransferPanelMain({
     if (isDepositMode) {
       return {
         from: {
-          // only EOA can change the origin network
-          // we don't use isSmartContractWallet here because we also want to keep it disabled when undefined
-          disabled: !fromOptions.length || !isEOA,
+          disabled:
+            !fromOptions.length ||
+            isSmartContractWallet ||
+            typeof isSmartContractWallet === 'undefined',
           options: fromOptions,
           value: from,
           onChange: async network => {
@@ -759,7 +762,7 @@ export function TransferPanelMain({
     l1.network,
     from,
     to,
-    isEOA,
+    isSmartContractWallet,
     isDepositMode,
     setQueryParams,
     switchNetworkAsync,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -59,8 +59,10 @@ export function SwitchNetworksButton(
       type="button"
       disabled={!isEOA}
       className={twMerge(
-        'min-h-14 lg:min-h-16 min-w-14 lg:min-w-16 flex h-14 w-14 items-center justify-center rounded-full bg-white p-3 shadow-[0_0_4px_0_rgba(0,0,0,0.25)] transition duration-200 hover:bg-gray-1 focus-visible:ring-2 focus-visible:ring-gray-4 active:bg-gray-2 lg:h-16 lg:w-16 lg:p-4',
-        isEOA ? 'hover:animate-rotate-180 focus-visible:animate-rotate-180' : ''
+        'min-h-14 lg:min-h-16 min-w-14 lg:min-w-16 flex h-14 w-14 items-center justify-center rounded-full bg-white p-3 shadow-[0_0_4px_0_rgba(0,0,0,0.25)] transition duration-200 lg:h-16 lg:w-16 lg:p-4',
+        isEOA
+          ? 'hover:animate-rotate-180 focus-visible:animate-rotate-180 hover:bg-gray-1 focus-visible:ring-2 focus-visible:ring-gray-4 active:bg-gray-2'
+          : ''
       )}
       {...props}
     >
@@ -643,6 +645,7 @@ export function TransferPanelMain({
       return {
         from: {
           // only EOA can change the origin network
+          // we don't use isSmartContractWallet here because we also want to keep it disabled when undefined
           disabled: !fromOptions.length || !isEOA,
           options: fromOptions,
           value: from,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -603,6 +603,15 @@ export function TransferPanelMain({
       // Add L1 network to the list
       return [l1.network, ...options]
         .filter(option => {
+          // Remove the origin network from the destination list for contract wallets
+          // It's done so that the origin network is not changed
+          if (
+            isSmartContractWallet &&
+            direction === 'to' &&
+            option.id === from.id
+          ) {
+            return false
+          }
           // Remove selected network from the list
           return option.id !== selectedChainId
         })
@@ -702,7 +711,10 @@ export function TransferPanelMain({
 
     return {
       from: {
-        disabled: !fromOptions.length,
+        disabled:
+          !fromOptions.length ||
+          isSmartContractWallet ||
+          typeof isSmartContractWallet === 'undefined',
         options: fromOptions,
         value: from,
         onChange: async network => {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -52,13 +52,23 @@ import { withdrawEthEstimateGas } from '../../util/EthWithdrawalUtils'
 export function SwitchNetworksButton(
   props: React.ButtonHTMLAttributes<HTMLButtonElement>
 ) {
+  const { isEOA = false, isSmartContractWallet = false } = useAccountType()
+
   return (
     <button
       type="button"
-      className="min-h-14 lg:min-h-16 min-w-14 lg:min-w-16 hover:animate-rotate-180 focus-visible:animate-rotate-180 flex h-14 w-14 items-center justify-center rounded-full bg-white p-3 shadow-[0_0_4px_0_rgba(0,0,0,0.25)] transition duration-200 hover:bg-gray-1 focus-visible:ring-2 focus-visible:ring-gray-4 active:bg-gray-2 lg:h-16 lg:w-16 lg:p-4"
+      disabled={!isEOA}
+      className={twMerge(
+        'min-h-14 lg:min-h-16 min-w-14 lg:min-w-16 flex h-14 w-14 items-center justify-center rounded-full bg-white p-3 shadow-[0_0_4px_0_rgba(0,0,0,0.25)] transition duration-200 hover:bg-gray-1 focus-visible:ring-2 focus-visible:ring-gray-4 active:bg-gray-2 lg:h-16 lg:w-16 lg:p-4',
+        isEOA ? 'hover:animate-rotate-180 focus-visible:animate-rotate-180' : ''
+      )}
       {...props}
     >
-      <ArrowsUpDownIcon className="text-dark" />
+      {isSmartContractWallet ? (
+        <ChevronDownIcon className="text-dark" />
+      ) : (
+        <ArrowsUpDownIcon className="text-dark" />
+      )}
     </button>
   )
 }
@@ -328,7 +338,7 @@ export function TransferPanelMain({
   const actions = useActions()
 
   const { l1, l2, isConnectedToArbitrum } = useNetworksAndSigners()
-  const { isSmartContractWallet = false } = useAccountType()
+  const { isEOA = false, isSmartContractWallet = false } = useAccountType()
 
   const { switchNetworkAsync } = useSwitchNetworkWithConfig({
     isSwitchingNetworkBeforeTx: true
@@ -632,7 +642,8 @@ export function TransferPanelMain({
     if (isDepositMode) {
       return {
         from: {
-          disabled: !fromOptions.length,
+          // only EOA can switch origin networks
+          disabled: !fromOptions.length || !isEOA,
           options: fromOptions,
           value: from,
           onChange: async network => {
@@ -759,6 +770,7 @@ export function TransferPanelMain({
     l1.network,
     from,
     to,
+    isEOA,
     isDepositMode,
     setQueryParams,
     switchNetworkAsync,

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkInformation.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkInformation.tsx
@@ -4,9 +4,11 @@ import Image from 'next/image'
 import { useNetwork } from 'wagmi'
 
 import { getNetworkLogo, getNetworkName, isNetwork } from '../../util/networks'
+import { useAccountType } from '../../hooks/useAccountType'
 
 export function HeaderNetworkInformation() {
   const { chain } = useNetwork()
+  const { isSmartContractWallet } = useAccountType()
 
   if (!chain || chain.unsupported) {
     return null
@@ -34,11 +36,16 @@ export function HeaderNetworkInformation() {
         />
       </div>
 
-      <span className="text-2xl font-medium lg:text-base lg:font-normal">
+      <span
+        className={twMerge(
+          'text-2xl font-medium lg:text-base lg:font-normal',
+          isSmartContractWallet ? 'pr-2' : ''
+        )}
+      >
         {networkName}
       </span>
 
-      <ChevronDownIcon className="h-4 w-4" />
+      {!isSmartContractWallet && <ChevronDownIcon className="h-4 w-4" />}
     </div>
   )
 }

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkInformation.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkInformation.tsx
@@ -8,7 +8,7 @@ import { useAccountType } from '../../hooks/useAccountType'
 
 export function HeaderNetworkInformation() {
   const { chain } = useNetwork()
-  const { isSmartContractWallet } = useAccountType()
+  const { isSmartContractWallet = false } = useAccountType()
 
   if (!chain || chain.unsupported) {
     return null

--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -43,6 +43,7 @@ export const NetworkSelectionContainer = ({
   return (
     <Popover className="relative z-50 w-full lg:w-max">
       <Popover.Button
+        // we don't use isSmartContractWallet here because we also want to keep it disabled when undefined
         disabled={!isEOA}
         className="arb-hover flex w-full justify-start rounded-full px-6 py-3 lg:w-max lg:p-0"
       >

--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -10,6 +10,7 @@ import {
   getSupportedNetworks
 } from '../../util/networks'
 import { useSwitchNetworkWithConfig } from '../../hooks/useSwitchNetworkWithConfig'
+import { useAccountType } from '../../hooks/useAccountType'
 
 export const NetworkSelectionContainer = ({
   children
@@ -21,6 +22,7 @@ export const NetworkSelectionContainer = ({
   const supportedNetworks = getSupportedNetworks(chain?.id).filter(
     chainId => chainId !== chain?.id
   )
+  const { isEOA = false } = useAccountType()
 
   const handleClick = useCallback(
     (
@@ -40,7 +42,10 @@ export const NetworkSelectionContainer = ({
 
   return (
     <Popover className="relative z-50 w-full lg:w-max">
-      <Popover.Button className="arb-hover flex w-full justify-start rounded-full px-6 py-3 lg:w-max lg:p-0">
+      <Popover.Button
+        disabled={!isEOA}
+        className="arb-hover flex w-full justify-start rounded-full px-6 py-3 lg:w-max lg:p-0"
+      >
         {children}
       </Popover.Button>
 

--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -22,7 +22,7 @@ export const NetworkSelectionContainer = ({
   const supportedNetworks = getSupportedNetworks(chain?.id).filter(
     chainId => chainId !== chain?.id
   )
-  const { isEOA = false } = useAccountType()
+  const { isSmartContractWallet } = useAccountType()
 
   const handleClick = useCallback(
     (
@@ -43,8 +43,9 @@ export const NetworkSelectionContainer = ({
   return (
     <Popover className="relative z-50 w-full lg:w-max">
       <Popover.Button
-        // we don't use isSmartContractWallet here because we also want to keep it disabled when undefined
-        disabled={!isEOA}
+        disabled={
+          isSmartContractWallet || typeof isSmartContractWallet === 'undefined'
+        }
         className="arb-hover flex w-full justify-start rounded-full px-6 py-3 lg:w-max lg:p-0"
       >
         {children}


### PR DESCRIPTION
Closes https://github.com/OffchainLabs/arbitrum-token-bridge/issues/916

### Things to note
- Some elements might flicker for the smart contract wallet users. It's because we get the account type async and some UI will update accordingly. However, we make sure that EOA user experience hasn't changed (no side-effects for them)

<img width="1135" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/e15ce574-12d8-4b18-98cb-7d65e82dbb33">
