### PR TITLE
chore: remove `baseUrl` from `tsconfig.json`

### DIFF
--- a/packages/arb-token-bridge-ui/tsconfig.json
+++ b/packages/arb-token-bridge-ui/tsconfig.json
@@ -11,10 +11,9 @@
     "noEmit": true,
     "incremental": true,
     "jsx": "preserve",
-    "baseUrl": ".",
     "paths": {
-      "@/images/*": ["public/images/*"],
-      "@/icons/*": ["public/icons/*"]
+      "@/images/*": ["./public/images/*"],
+      "@/icons/*": ["./public/icons/*"]
     }
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
With baseUrl, import paths are automatically added by VSCode as `src/....`
This PR will allow VSCode to add `../../` relative path as import path