### PR TITLE
feat: improve UX for L2-native tokens

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -572,12 +572,12 @@ function TokensPanel({
 
   const storeNewToken = async () => {
     let error = 'Token not found on this network.'
-    let didSucceed = false
+    let isSuccessful = false
 
     try {
       // Try to add the token as an L2-native token
       token.addL2NativeToken(newToken)
-      didSucceed = true
+      isSuccessful = true
     } catch (error) {
       //
     }
@@ -585,7 +585,7 @@ function TokensPanel({
     try {
       // Try to add the token as a regular bridged token
       await token.add(newToken)
-      didSucceed = true
+      isSuccessful = true
     } catch (ex: any) {
       if (ex.name === 'TokenDisabledError') {
         error = 'This token is currently paused in the bridge.'
@@ -593,7 +593,7 @@ function TokensPanel({
     }
 
     // Only show error message if neither succeeded
-    if (!didSucceed) {
+    if (!isSuccessful) {
       setErrorMessage(error)
     }
   }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -247,9 +247,9 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
       disabled={!tokenIsBridgeable}
       className={twMerge(
         'flex w-full flex-row items-center justify-between bg-white px-4 py-3 hover:bg-gray-100',
-        !tokenIsBridgeable
-          ? 'cursor-not-allowed opacity-50'
-          : 'cursor-pointer opacity-100'
+        tokenIsBridgeable
+          ? 'cursor-pointer opacity-100'
+          : 'cursor-not-allowed opacity-50'
       )}
     >
       <div className="flex w-full flex-row items-center justify-start space-x-4">

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -12,6 +12,7 @@ import {
 import { useMedia } from 'react-use'
 import { constants } from 'ethers'
 import Image from 'next/image'
+import { Chain } from 'wagmi'
 
 import { Loader } from '../common/atoms/Loader'
 import { useActions, useAppState } from '../../state'
@@ -40,6 +41,7 @@ import { useBalance } from '../../hooks/useBalance'
 import { ERC20BridgeToken } from '../../hooks/arbTokenBridge.types'
 import { useTokenLists } from '../../hooks/useTokenLists'
 import { warningToast } from '../common/atoms/Toast'
+import { ExternalLink } from '../common/ExternalLink'
 
 enum Panel {
   TOKENS,
@@ -57,6 +59,27 @@ function TokenLogoFallback() {
     <div className="flex h-8 w-8 items-center justify-center rounded-full bg-ocl-blue text-sm font-medium text-white">
       ?
     </div>
+  )
+}
+
+function BlockExplorerTokenLink({
+  chain,
+  address
+}: {
+  chain: Chain
+  address: string | undefined
+}) {
+  const addressShortened =
+    typeof address !== 'undefined' ? shortenAddress(address).toLowerCase() : ''
+
+  return (
+    <ExternalLink
+      href={`${getExplorerUrl(chain.id)}/token/${address}`}
+      className="text-xs text-blue-link underline"
+      onClick={e => e.stopPropagation()}
+    >
+      {addressShortened}
+    </ExternalLink>
   )
 }
 
@@ -268,47 +291,24 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
               {isDepositMode ? (
                 <>
                   {isL2NativeToken ? (
-                    <a
-                      href={`${getExplorerUrl(l2Network.id)}/token/${
-                        token.address
-                      }`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs text-blue-link underline"
-                      onClick={e => e.stopPropagation()}
-                    >
-                      {shortenAddress(token.address).toLowerCase()}
-                    </a>
+                    <BlockExplorerTokenLink
+                      chain={l2Network}
+                      address={token.address}
+                    />
                   ) : (
-                    <a
-                      href={`${getExplorerUrl(l1Network.id)}/token/${
-                        token.address
-                      }`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs text-blue-link underline"
-                      onClick={e => e.stopPropagation()}
-                    >
-                      {shortenAddress(token.address).toLowerCase()}
-                    </a>
+                    <BlockExplorerTokenLink
+                      chain={l1Network}
+                      address={token.address}
+                    />
                   )}
                 </>
               ) : (
                 <>
                   {tokenHasL2Address ? (
-                    <a
-                      href={`${getExplorerUrl(l2Network.id)}/token/${
-                        token.l2Address
-                      }`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs text-blue-link underline"
-                      onClick={e => e.stopPropagation()}
-                    >
-                      {token.l2Address
-                        ? shortenAddress(token.l2Address).toLowerCase()
-                        : ''}
-                    </a>
+                    <BlockExplorerTokenLink
+                      chain={l2Network}
+                      address={token.l2Address}
+                    />
                   ) : (
                     <span className="text-xs text-gray-900">
                       This token hasn&apos;t been bridged to L2.

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -320,7 +320,7 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
                 <span className="flex gap-1 text-xs font-normal">
                   {`This token is native to ${getNetworkName(
                     l2Network.id
-                  )} and can’t be briged.`}
+                  )} and can’t be bridged.`}
                 </span>
               ) : (
                 <span className="flex gap-1 text-xs font-normal text-gray-500">

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -69,8 +69,9 @@ function BlockExplorerTokenLink({
   chain: Chain
   address: string | undefined
 }) {
-  const addressShortened =
-    typeof address !== 'undefined' ? shortenAddress(address).toLowerCase() : ''
+  if (typeof address === 'undefined') {
+    return null
+  }
 
   return (
     <ExternalLink
@@ -78,7 +79,7 @@ function BlockExplorerTokenLink({
       className="text-xs text-blue-link underline"
       onClick={e => e.stopPropagation()}
     >
-      {addressShortened}
+      {shortenAddress(address).toLowerCase()}
     </ExternalLink>
   )
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -266,17 +266,33 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
             <div className="flex flex-col items-start space-y-1">
               {/* TODO: anchor shouldn't be nested within a button */}
               {isDepositMode ? (
-                <a
-                  href={`${getExplorerUrl(l1Network.id)}/token/${
-                    token.address
-                  }`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs text-blue-link underline"
-                  onClick={e => e.stopPropagation()}
-                >
-                  {shortenAddress(token.address).toLowerCase()}
-                </a>
+                <>
+                  {isL2NativeToken ? (
+                    <a
+                      href={`${getExplorerUrl(l2Network.id)}/token/${
+                        token.address
+                      }`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-link underline"
+                      onClick={e => e.stopPropagation()}
+                    >
+                      {shortenAddress(token.address).toLowerCase()}
+                    </a>
+                  ) : (
+                    <a
+                      href={`${getExplorerUrl(l1Network.id)}/token/${
+                        token.address
+                      }`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-link underline"
+                      onClick={e => e.stopPropagation()}
+                    >
+                      {shortenAddress(token.address).toLowerCase()}
+                    </a>
+                  )}
+                </>
               ) : (
                 <>
                   {tokenHasL2Address ? (
@@ -295,7 +311,7 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
                     </a>
                   ) : (
                     <span className="text-xs text-gray-900">
-                      This token hasn&apos;t been bridged to L2
+                      This token hasn&apos;t been bridged to L2.
                     </span>
                   )}
                 </>

--- a/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
@@ -169,6 +169,7 @@ export interface ArbTokenBridgeEth {
 
 export interface ArbTokenBridgeToken {
   add: (erc20L1orL2Address: string) => Promise<void>
+  addL2NativeToken: (erc20L2Address: string) => void
   addTokensFromList: (tokenList: TokenList, listID: number) => void
   removeTokensFromList: (listID: number) => void
   updateTokenData: (l1Address: string) => Promise<void>

--- a/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
@@ -104,6 +104,7 @@ export interface BridgeToken {
   l2Address?: string
   logoURI?: string
   listIds: Set<number> // no listID indicates added by user
+  isL2Native: boolean
 }
 
 export interface ERC20BridgeToken extends BridgeToken {

--- a/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
@@ -104,7 +104,7 @@ export interface BridgeToken {
   l2Address?: string
   logoURI?: string
   listIds: Set<number> // no listID indicates added by user
-  isL2Native: boolean
+  isL2Native?: boolean
 }
 
 export interface ERC20BridgeToken extends BridgeToken {

--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -42,6 +42,7 @@ import {
   getL2ERC20Address,
   l1TokenIsDisabled
 } from '../util/TokenUtils'
+import { getL2NativeToken } from '../util/L2NativeUtils'
 
 export const wait = (ms = 0) => {
   return new Promise(res => setTimeout(res, ms))
@@ -887,6 +888,27 @@ export const useArbTokenBridge = (
     return rec
   }
 
+  function addL2NativeToken(erc20L2Address: string) {
+    const token = getL2NativeToken(erc20L2Address, l2.network.id)
+
+    setBridgeTokens(oldBridgeTokens => {
+      return {
+        ...oldBridgeTokens,
+        [`L2-NATIVE:${token.address}`]: {
+          name: token.name,
+          type: TokenType.ERC20,
+          symbol: token.symbol,
+          address: token.address,
+          l2Address: token.address,
+          decimals: token.decimals,
+          logoURI: token.logoURI,
+          listIds: new Set(),
+          isL2Native: true
+        }
+      }
+    })
+  }
+
   async function triggerOutboxEth({
     id,
     l1Signer
@@ -973,6 +995,7 @@ export const useArbTokenBridge = (
     },
     token: {
       add: addToken,
+      addL2NativeToken,
       addTokensFromList,
       removeTokensFromList,
       updateTokenData,

--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -666,7 +666,8 @@ export const useArbTokenBridge = (
           l2Address: address.toLowerCase(),
           decimals,
           logoURI,
-          listIds: new Set([listId])
+          listIds: new Set([listId]),
+          isL2Native: false
         }
       }
       // save potentially unbridged L1 tokens:
@@ -679,7 +680,8 @@ export const useArbTokenBridge = (
           address: address.toLowerCase(),
           decimals,
           logoURI,
-          listIds: new Set([listId])
+          listIds: new Set([listId]),
+          isL2Native: false
         })
       }
     }
@@ -783,7 +785,8 @@ export const useArbTokenBridge = (
       address: l1AddressLowerCased,
       l2Address: l2Address?.toLowerCase(),
       decimals,
-      listIds: new Set()
+      listIds: new Set(),
+      isL2Native: false
     }
 
     setBridgeTokens(oldBridgeTokens => {

--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -667,8 +667,7 @@ export const useArbTokenBridge = (
           l2Address: address.toLowerCase(),
           decimals,
           logoURI,
-          listIds: new Set([listId]),
-          isL2Native: false
+          listIds: new Set([listId])
         }
       }
       // save potentially unbridged L1 tokens:
@@ -681,8 +680,7 @@ export const useArbTokenBridge = (
           address: address.toLowerCase(),
           decimals,
           logoURI,
-          listIds: new Set([listId]),
-          isL2Native: false
+          listIds: new Set([listId])
         })
       }
     }
@@ -786,8 +784,7 @@ export const useArbTokenBridge = (
       address: l1AddressLowerCased,
       l2Address: l2Address?.toLowerCase(),
       decimals,
-      listIds: new Set(),
-      isL2Native: false
+      listIds: new Set()
     }
 
     setBridgeTokens(oldBridgeTokens => {

--- a/packages/arb-token-bridge-ui/src/util/L2NativeUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/L2NativeUtils.ts
@@ -1,0 +1,59 @@
+import { ChainId } from '../util/networks'
+
+export type L2NativeToken = {
+  name: string
+  symbol: string
+  address: string
+  decimals: number
+  logoURI: string
+}
+
+const L2NativeTokens: { [chainId: number]: L2NativeToken[] } = {
+  [ChainId.ArbitrumOne]: [
+    {
+      name: 'GMX',
+      symbol: 'GMX',
+      address: '0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a',
+      decimals: 18,
+      logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/11857.png'
+    },
+    {
+      name: 'STASIS EURO',
+      symbol: 'EURS',
+      address: '0xD22a58f79e9481D1a88e00c343885A588b34b68B',
+      decimals: 2,
+      logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/2989.png'
+    }
+  ],
+  [ChainId.ArbitrumNova]: [],
+  [ChainId.ArbitrumGoerli]: []
+}
+
+function find(erc20L2Address: string, l2ChainId: number) {
+  return (
+    (L2NativeTokens[l2ChainId] ?? [])
+      //
+      .find(
+        token => token.address.toLowerCase() === erc20L2Address.toLowerCase()
+      )
+  )
+}
+
+export function tokenIsL2Native(erc20L2Address: string, l2ChainId: number) {
+  return typeof find(erc20L2Address, l2ChainId) !== 'undefined'
+}
+
+export function getL2NativeToken(
+  erc20L2Address: string,
+  l2ChainId: number
+): L2NativeToken {
+  const token = find(erc20L2Address, l2ChainId)
+
+  if (typeof token === 'undefined') {
+    throw new Error(
+      `Can't find L2-native token with address ${erc20L2Address} on chain ${l2ChainId}`
+    )
+  }
+
+  return token
+}

--- a/packages/arb-token-bridge-ui/src/util/L2NativeUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/L2NativeUtils.ts
@@ -23,6 +23,13 @@ const L2NativeTokens: { [chainId: number]: L2NativeToken[] } = {
       address: '0xD22a58f79e9481D1a88e00c343885A588b34b68B',
       decimals: 2,
       logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/2989.png'
+    },
+    {
+      name: 'USD Coin',
+      symbol: 'USDC',
+      address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+      decimals: 6,
+      logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/3408.png'
     }
   ],
   [ChainId.ArbitrumNova]: [],


### PR DESCRIPTION
Closes https://github.com/OffchainLabs/arbitrum-token-bridge/issues/659. Closes https://github.com/OffchainLabs/arbitrum-token-bridge/issues/829.

This PR is a simpler version of https://github.com/OffchainLabs/arbitrum-token-bridge/pull/806. It removes the logic around L2-native tokens, and instead keeps a list of them.

### Summary

Currently, we can only add bridgeable tokens in the token search panel, i.e. tokens which are bridged using the token bridge.

Adding L2-native tokens currently results in a `Token not found on this network.` error which is confusing. In addition, a rare case where a token is present on the same address on both the L1 and the L2 chain (L2-native) resulted in the L2-native token not being displayed, which is also confusing.

### Steps to test

To test out the fix for https://github.com/OffchainLabs/arbitrum-token-bridge/issues/829, you can try adding an L2-native token to the Bridge, like [GMX](https://arbiscan.io/token/0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a) or [USDC](0xaf88d065e77c8cC2239327C5EDb3A432268e5831).

To test out the fix for https://github.com/OffchainLabs/arbitrum-token-bridge/issues/659, you can try adding `0xD22a58f79e9481D1a88e00c343885A588b34b68B`, which corresponds to [IVN on L1](https://etherscan.io/token/0xD22a58f79e9481D1a88e00c343885A588b34b68B) and [EURS on L2](https://arbiscan.io/token/0xD22a58f79e9481D1a88e00c343885A588b34b68B). The issue with balance loading indefinitely for the L2 side is not affected by this PR.