### PR TITLE
feat: change symbol from USDC to USDC.e for Arbitrum One

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -11,10 +11,12 @@ import {
   UseNetworksAndSignersStatus
 } from '../../hooks/useNetworksAndSigners'
 import { useDialog } from '../common/Dialog'
+import { CommonAddress } from '../../util/CommonAddressUtils'
 
 export function TokenButton(): JSX.Element {
   const {
     app: {
+      isDepositMode,
       selectedToken,
       arbTokenBridge: { bridgeTokens },
       arbTokenBridgeLoaded
@@ -45,6 +47,19 @@ export function TokenButton(): JSX.Element {
     }
     return undefined
   }, [bridgeTokens, selectedToken?.address, status, arbTokenBridgeLoaded])
+
+  const tokenSymbol = useMemo(() => {
+    if (!selectedToken) {
+      return 'ETH'
+    }
+
+    // Special case because token symbol for USDC is different on L1 and L2
+    if (selectedToken.address === CommonAddress.Mainnet.USDC) {
+      return isDepositMode ? 'USDC' : 'USDC.e'
+    }
+
+    return selectedToken.symbol
+  }, [selectedToken, isDepositMode])
 
   function closeWithReset() {
     setTokenToImport(undefined)
@@ -83,7 +98,7 @@ export function TokenButton(): JSX.Element {
               />
             )}
             <span className="text-xl font-light sm:text-3xl">
-              {selectedToken ? selectedToken.symbol : 'ETH'}
+              {tokenSymbol}
             </span>
             <ChevronDownIcon className="h-4 w-4 text-gray-6" />
           </div>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../hooks/useNetworksAndSigners'
 import { useDialog } from '../common/Dialog'
 import { CommonAddress } from '../../util/CommonAddressUtils'
+import { isNetwork } from '../../util/networks'
 
 export function TokenButton(): JSX.Element {
   const {
@@ -22,7 +23,7 @@ export function TokenButton(): JSX.Element {
       arbTokenBridgeLoaded
     }
   } = useAppState()
-  const { status } = useNetworksAndSigners()
+  const { status, l2 } = useNetworksAndSigners()
 
   const [tokenToImport, setTokenToImport] = useState<string>()
   const [tokenImportDialogProps, openTokenImportDialog] = useDialog()
@@ -53,13 +54,17 @@ export function TokenButton(): JSX.Element {
       return 'ETH'
     }
 
-    // Special case because token symbol for USDC is different on L1 and L2
-    if (selectedToken.address === CommonAddress.Mainnet.USDC) {
+    const addressLowercased = selectedToken.address.toLowerCase()
+    const isUSDC = addressLowercased === CommonAddress.Mainnet.USDC
+    const isL2ArbitrumOne = isNetwork(l2.network.id).isArbitrumOne
+
+    // Special case because token symbol for USDC is different on Mainnet and Arbitrum One
+    if (isUSDC && isL2ArbitrumOne) {
       return isDepositMode ? 'USDC' : 'USDC.e'
     }
 
     return selectedToken.symbol
-  }, [selectedToken, isDepositMode])
+  }, [selectedToken, isDepositMode, l2])
 
   function closeWithReset() {
     setTokenToImport(undefined)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -256,6 +256,7 @@ function TokenBalance({
   on: NetworkType
   prefix?: string
 }) {
+  const { l2 } = useNetworksAndSigners()
   const balance = useTokenBalances(forToken?.address)[on]
 
   const symbol = useMemo(() => {
@@ -263,16 +264,17 @@ function TokenBalance({
       return undefined
     }
 
-    // Special case because token symbol for USDC is different on L1 and L2
-    if (
-      on === NetworkType.l2 &&
-      forToken.address.toLowerCase() === CommonAddress.Mainnet.USDC
-    ) {
+    const addressLowercased = forToken.address.toLowerCase()
+    const isUSDC = addressLowercased === CommonAddress.Mainnet.USDC
+    const isL2ArbitrumOne = isNetwork(l2.network.id).isArbitrumOne
+
+    // Special case because token symbol for USDC is different on Mainnet and Arbitrum One
+    if (on === NetworkType.l2 && isUSDC && isL2ArbitrumOne) {
       return 'USDC.e'
     }
 
     return forToken.symbol
-  }, [forToken, on])
+  }, [forToken, on, l2])
 
   if (!forToken) {
     return null

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -45,6 +45,7 @@ import { useSwitchNetworkWithConfig } from '../../hooks/useSwitchNetworkWithConf
 import { useAccountType } from '../../hooks/useAccountType'
 import { depositEthEstimateGas } from '../../util/EthDepositUtils'
 import { withdrawEthEstimateGas } from '../../util/EthWithdrawalUtils'
+import { CommonAddress } from '../../util/CommonAddressUtils'
 
 export function SwitchNetworksButton(
   props: React.ButtonHTMLAttributes<HTMLButtonElement>
@@ -257,6 +258,22 @@ function TokenBalance({
 }) {
   const balance = useTokenBalances(forToken?.address)[on]
 
+  const symbol = useMemo(() => {
+    if (!forToken) {
+      return undefined
+    }
+
+    // Special case because token symbol for USDC is different on L1 and L2
+    if (
+      on === NetworkType.l2 &&
+      forToken.address.toLowerCase() === CommonAddress.Mainnet.USDC
+    ) {
+      return 'USDC.e'
+    }
+
+    return forToken.symbol
+  }, [forToken, on])
+
   if (!forToken) {
     return null
   }
@@ -270,7 +287,7 @@ function TokenBalance({
       {prefix}
       {formatAmount(balance, {
         decimals: forToken.decimals,
-        symbol: forToken.symbol
+        symbol
       })}
     </span>
   )
@@ -360,7 +377,7 @@ export function TransferPanelMain({
   const isMaxAmount = amount === AmountQueryParamEnum.MAX
 
   const showUSDCNotice =
-    selectedToken?.address === USDC_L1_ADDRESS &&
+    selectedToken?.address === CommonAddress.Mainnet.USDC &&
     isNetwork(l2.network.id).isArbitrumOne
 
   const [, setQueryParams] = useArbQueryParams()

--- a/packages/arb-token-bridge-ui/src/util/CommonAddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/CommonAddressUtils.ts
@@ -1,0 +1,5 @@
+export const CommonAddress = {
+  Mainnet: {
+    USDC: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+  }
+}


### PR DESCRIPTION
### Summary

Updates the token symbol for `USDC` to `USDC.e` whenever it's related to the token representation on Arbitrum One.

### Steps to test

When moving from or to Arbitrum One, the token symbol should be `USDC` for Mainnet, and `USDC.e` for Arbitrum One, both in the token selection button, and balance info.