### PR TITLE
refactor: auto configure eth bridge for custom network

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.11",
-    "@arbitrum/sdk": "^3.1.2",
+    "@arbitrum/sdk": "^3.1.4-beta.0",
     "@ethersproject/providers": "^5.7.0",
     "@headlessui/react": "^1.7.8",
     "@headlessui/tailwindcss": "^0.1.2",

--- a/packages/arb-token-bridge-ui/src/pages/_app.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/_app.tsx
@@ -23,6 +23,7 @@ if (
   process.env.NODE_ENV !== 'production' ||
   process.env.NEXT_PUBLIC_IS_E2E_TEST
 ) {
+  // It's fine not to await the function below and just let it do its thing in the background
   registerLocalNetwork()
 }
 

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -133,50 +133,54 @@ export const chainIdToDefaultL2ChainId: { [chainId: number]: ChainId[] } = {
   [ChainId.ArbitrumGoerli]: [ChainId.ArbitrumGoerli]
 }
 
-const defaultL1Network: L1Network = {
-  blockTime: 10,
-  chainID: 1337,
-  explorerUrl: '',
-  isCustom: true,
-  name: 'EthLocal',
-  partnerChainIDs: [412346],
-  isArbitrum: false
+function getDefaultL1Network(): L1Network {
+  return {
+    blockTime: 10,
+    chainID: 1337,
+    explorerUrl: '',
+    isCustom: true,
+    name: 'EthLocal',
+    partnerChainIDs: [412346],
+    isArbitrum: false
+  }
 }
 
-const defaultL2Network: L2Network = {
-  chainID: 412346,
-  confirmPeriodBlocks: 20,
-  ethBridge: {
-    bridge: '0x2b360a9881f21c3d7aa0ea6ca0de2a3341d4ef3c',
-    inbox: '0xff4a24b22f94979e9ba5f3eb35838aa814bad6f1',
-    outbox: '0x49940929c7cA9b50Ff57a01d3a92817A414E6B9B',
-    rollup: '0x65a59d67da8e710ef9a01eca37f83f84aedec416',
-    sequencerInbox: '0xe7362d0787b51d8c72d504803e5b1d6dcda89540'
-  },
-  explorerUrl: '',
-  isArbitrum: true,
-  isCustom: true,
-  name: 'ArbLocal',
-  partnerChainID: 1337,
-  retryableLifetimeSeconds: 604800,
-  nitroGenesisBlock: 0,
-  nitroGenesisL1Block: 0,
-  depositTimeout: 900000,
-  tokenBridge: {
-    l1CustomGateway: '0x3DF948c956e14175f43670407d5796b95Bb219D8',
-    l1ERC20Gateway: '0x4A2bA922052bA54e29c5417bC979Daaf7D5Fe4f4',
-    l1GatewayRouter: '0x525c2aBA45F66987217323E8a05EA400C65D06DC',
-    l1MultiCall: '0xDB2D15a3EB70C347E0D2C2c7861cAFb946baAb48',
-    l1ProxyAdmin: '0xe1080224B632A93951A7CFA33EeEa9Fd81558b5e',
-    l1Weth: '0x408Da76E87511429485C32E4Ad647DD14823Fdc4',
-    l1WethGateway: '0xF5FfD11A55AFD39377411Ab9856474D2a7Cb697e',
-    l2CustomGateway: '0x525c2aBA45F66987217323E8a05EA400C65D06DC',
-    l2ERC20Gateway: '0xe1080224B632A93951A7CFA33EeEa9Fd81558b5e',
-    l2GatewayRouter: '0x1294b86822ff4976BfE136cB06CF43eC7FCF2574',
-    l2Multicall: '0xDB2D15a3EB70C347E0D2C2c7861cAFb946baAb48',
-    l2ProxyAdmin: '0xda52b25ddB0e3B9CC393b0690Ac62245Ac772527',
-    l2Weth: '0x408Da76E87511429485C32E4Ad647DD14823Fdc4',
-    l2WethGateway: '0x4A2bA922052bA54e29c5417bC979Daaf7D5Fe4f4'
+function getDefaultL2Network(): L2Network {
+  return {
+    chainID: 412346,
+    confirmPeriodBlocks: 20,
+    ethBridge: {
+      bridge: '0x2b360a9881f21c3d7aa0ea6ca0de2a3341d4ef3c',
+      inbox: '0xff4a24b22f94979e9ba5f3eb35838aa814bad6f1',
+      outbox: '0x49940929c7cA9b50Ff57a01d3a92817A414E6B9B',
+      rollup: '0x65a59d67da8e710ef9a01eca37f83f84aedec416',
+      sequencerInbox: '0xe7362d0787b51d8c72d504803e5b1d6dcda89540'
+    },
+    explorerUrl: '',
+    isArbitrum: true,
+    isCustom: true,
+    name: 'ArbLocal',
+    partnerChainID: 1337,
+    retryableLifetimeSeconds: 604800,
+    nitroGenesisBlock: 0,
+    nitroGenesisL1Block: 0,
+    depositTimeout: 900000,
+    tokenBridge: {
+      l1CustomGateway: '0x3DF948c956e14175f43670407d5796b95Bb219D8',
+      l1ERC20Gateway: '0x4A2bA922052bA54e29c5417bC979Daaf7D5Fe4f4',
+      l1GatewayRouter: '0x525c2aBA45F66987217323E8a05EA400C65D06DC',
+      l1MultiCall: '0xDB2D15a3EB70C347E0D2C2c7861cAFb946baAb48',
+      l1ProxyAdmin: '0xe1080224B632A93951A7CFA33EeEa9Fd81558b5e',
+      l1Weth: '0x408Da76E87511429485C32E4Ad647DD14823Fdc4',
+      l1WethGateway: '0xF5FfD11A55AFD39377411Ab9856474D2a7Cb697e',
+      l2CustomGateway: '0x525c2aBA45F66987217323E8a05EA400C65D06DC',
+      l2ERC20Gateway: '0xe1080224B632A93951A7CFA33EeEa9Fd81558b5e',
+      l2GatewayRouter: '0x1294b86822ff4976BfE136cB06CF43eC7FCF2574',
+      l2Multicall: '0xDB2D15a3EB70C347E0D2C2c7861cAFb946baAb48',
+      l2ProxyAdmin: '0xda52b25ddB0e3B9CC393b0690Ac62245Ac772527',
+      l2Weth: '0x408Da76E87511429485C32E4Ad647DD14823Fdc4',
+      l2WethGateway: '0x4A2bA922052bA54e29c5417bC979Daaf7D5Fe4f4'
+    }
   }
 }
 
@@ -186,8 +190,8 @@ export type RegisterLocalNetworkParams = {
 }
 
 const registerLocalNetworkDefaultParams: RegisterLocalNetworkParams = {
-  l1Network: defaultL1Network,
-  l2Network: defaultL2Network
+  l1Network: getDefaultL1Network(),
+  l2Network: getDefaultL2Network()
 }
 
 export const localL1NetworkRpcUrl = loadEnvironmentVariableWithFallback({

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -203,12 +203,19 @@ export const localL2NetworkRpcUrl = loadEnvironmentVariableWithFallback({
   fallback: 'http://localhost:8547'
 })
 
-export function registerLocalNetwork(
-  params: RegisterLocalNetworkParams = registerLocalNetworkDefaultParams
-) {
-  const { l1Network, l2Network } = params
-
+export function registerLocalNetwork(params?: RegisterLocalNetworkParams) {
   try {
+    let l1Network: L1Network
+    let l2Network: L2Network
+
+    if (typeof params === 'undefined') {
+      l1Network = getDefaultL1Network()
+      l2Network = getDefaultL2Network()
+    } else {
+      l1Network = params.l1Network
+      l2Network = params.l2Network
+    }
+
     rpcURLs[l1Network.chainID] = localL1NetworkRpcUrl
     rpcURLs[l2Network.chainID] = localL2NetworkRpcUrl
 

--- a/packages/arb-token-bridge-ui/synpress.config.ts
+++ b/packages/arb-token-bridge-ui/synpress.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   e2e: {
     // @ts-ignore
     async setupNodeEvents(on, config) {
-      registerLocalNetwork()
+      await registerLocalNetwork()
 
       if (!ethRpcUrl) {
         throw new Error('NEXT_PUBLIC_LOCAL_ETHEREUM_RPC_URL variable missing.')

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@arbitrum/sdk@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.1.2.tgz#c1ded298778c141b6d8d0342a507a4f94af02757"
-  integrity sha512-QcS5t6GDCLyY+u0WaYPIjBd2U9hmDbzGc8gLMyiUxpP7w4bOWs6ZGBGUw2N6oLOMLI5IEq9ZbRZEC/Ejsy/URg==
+"@arbitrum/sdk@^3.1.4-beta.0":
+  version "3.1.4-beta.0"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.1.4-beta.0.tgz#c9ea7bedebb7087bc6be6212cb9c7af72c66cc29"
+  integrity sha512-SrkpFf2zx+7IOOCj7BDkrYK4Opk5S4boX0NBr+VMqZeWyE3mC4E4tT97aJDnGEslkrtxJjbVXIru00XDToHB7Q==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"


### PR DESCRIPTION
### Summary

Makes it a tiny bit easier to configure custom networks without having to provide all the addresses for the Eth Bridge, and instead only requiring the address of the Rollup contract. We'll keep doing similar stuff in the future through some helpers in the SDK.

### Steps to test

Everything should still work the same.
