### PR TITLE
chore: don't send release data to Sentry

### DIFF
--- a/packages/arb-token-bridge-ui/src/pages/_app.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/_app.tsx
@@ -13,7 +13,6 @@ import 'tippy.js/themes/light.css'
 
 import '@rainbow-me/rainbowkit/styles.css'
 
-import Package from '../../package.json'
 import { registerLocalNetwork } from '../util/networks'
 import { Layout } from '../components/common/Layout'
 
@@ -33,7 +32,6 @@ dayjs.extend(advancedFormat)
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: Package.version,
   integrations: [new BrowserTracing()],
   tracesSampleRate: 0.15,
   beforeSend: event => {


### PR DESCRIPTION
### Summary

We don't really maintain version numbers (which is fine, because it's an app and not a public package), and the current setup makes it look like we're always on the same version of the app on Sentry.

### Steps to test

N/A
