### PR TITLE
fix: patch token name and symbol for USDC and USDCe

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -204,6 +204,15 @@ export function TransactionsTableDepositRow({
     return ''
   }, [tx, isError, showRedeemRetryableButton, showRetryableExpiredText])
 
+  const tokenSymbol = useMemo(
+    () =>
+      sanitizeTokenSymbol(tx.asset, {
+        erc20L1Address: tx.tokenAddress,
+        chain: l1.network
+      }),
+    [l1.network, tx.asset, tx.tokenAddress]
+  )
+
   return (
     <tr
       className={`text-sm text-dark ${
@@ -221,10 +230,7 @@ export function TransactionsTableDepositRow({
 
       <td className="w-1/5 whitespace-nowrap px-3 py-3">
         {formatAmount(Number(tx.value), {
-          symbol: sanitizeTokenSymbol(tx.asset, {
-            erc20L1Address: tx.tokenAddress,
-            chain: l1.network
-          })
+          symbol: tokenSymbol
         })}
       </td>
 

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import { mainnet } from 'wagmi'
 
 import { DepositStatus, MergedTransaction } from '../../../state/app/state'
 import { StatusBadge } from '../../common/StatusBadge'

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { mainnet } from 'wagmi'
 
 import { DepositStatus, MergedTransaction } from '../../../state/app/state'
 import { StatusBadge } from '../../common/StatusBadge'
@@ -15,7 +16,6 @@ import { isDepositReadyToRedeem, isPending } from '../../../state/app/utils'
 import { TransactionDateTime } from './TransactionsTable'
 import { formatAmount } from '../../../util/NumberUtils'
 import { sanitizeTokenSymbol } from '../../../util/TokenUtils'
-import { mainnet } from 'wagmi'
 
 function DepositRowStatus({ tx }: { tx: MergedTransaction }) {
   switch (tx.depositStatus) {

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -9,16 +9,13 @@ import { DepositCountdown } from '../../common/DepositCountdown'
 import { ExternalLink } from '../../common/ExternalLink'
 import { Button } from '../../common/Button'
 import { Tooltip } from '../../common/Tooltip'
-import {
-  getExplorerUrl,
-  getNetworkName,
-  isNetwork
-} from '../../../util/networks'
+import { getExplorerUrl, getNetworkName } from '../../../util/networks'
 import { InformationCircleIcon } from '@heroicons/react/24/outline'
 import { isDepositReadyToRedeem, isPending } from '../../../state/app/utils'
 import { TransactionDateTime } from './TransactionsTable'
 import { formatAmount } from '../../../util/NumberUtils'
-import { patchTokenSymbol } from '../../../util/TokenUtils'
+import { sanitizeTokenSymbol } from '../../../util/TokenUtils'
+import { mainnet } from 'wagmi'
 
 function DepositRowStatus({ tx }: { tx: MergedTransaction }) {
   switch (tx.depositStatus) {
@@ -173,7 +170,6 @@ export function TransactionsTableDepositRow({
 }) {
   const { isConnectedToArbitrum } = useNetworksAndSigners()
   const { redeem, isRedeeming } = useRedeemRetryable()
-  const { l2 } = useNetworksAndSigners()
 
   const isError = useMemo(() => {
     if (
@@ -225,11 +221,9 @@ export function TransactionsTableDepositRow({
 
       <td className="w-1/5 whitespace-nowrap px-3 py-3">
         {formatAmount(Number(tx.value), {
-          symbol: patchTokenSymbol({
-            symbol: tx.asset.toUpperCase(),
-            tokenAddress: tx.tokenAddress ?? '',
-            isDeposit: true,
-            isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+          symbol: sanitizeTokenSymbol(tx.asset.toUpperCase(), {
+            erc20L1Address: tx.tokenAddress ?? '',
+            chain: mainnet
           })
         })}
       </td>

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -221,8 +221,8 @@ export function TransactionsTableDepositRow({
 
       <td className="w-1/5 whitespace-nowrap px-3 py-3">
         {formatAmount(Number(tx.value), {
-          symbol: sanitizeTokenSymbol(tx.asset.toUpperCase(), {
-            erc20L1Address: tx.tokenAddress ?? '',
+          symbol: sanitizeTokenSymbol(tx.asset, {
+            erc20L1Address: tx.tokenAddress,
             chain: mainnet
           })
         })}

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -9,11 +9,16 @@ import { DepositCountdown } from '../../common/DepositCountdown'
 import { ExternalLink } from '../../common/ExternalLink'
 import { Button } from '../../common/Button'
 import { Tooltip } from '../../common/Tooltip'
-import { getExplorerUrl, getNetworkName } from '../../../util/networks'
+import {
+  getExplorerUrl,
+  getNetworkName,
+  isNetwork
+} from '../../../util/networks'
 import { InformationCircleIcon } from '@heroicons/react/24/outline'
 import { isDepositReadyToRedeem, isPending } from '../../../state/app/utils'
 import { TransactionDateTime } from './TransactionsTable'
 import { formatAmount } from '../../../util/NumberUtils'
+import { patchTokenSymbol } from '../../../util/TokenUtils'
 
 function DepositRowStatus({ tx }: { tx: MergedTransaction }) {
   switch (tx.depositStatus) {
@@ -168,6 +173,7 @@ export function TransactionsTableDepositRow({
 }) {
   const { isConnectedToArbitrum } = useNetworksAndSigners()
   const { redeem, isRedeeming } = useRedeemRetryable()
+  const { l2 } = useNetworksAndSigners()
 
   const isError = useMemo(() => {
     if (
@@ -218,7 +224,14 @@ export function TransactionsTableDepositRow({
       </td>
 
       <td className="w-1/5 whitespace-nowrap px-3 py-3">
-        {formatAmount(Number(tx.value), { symbol: tx.asset.toUpperCase() })}
+        {formatAmount(Number(tx.value), {
+          symbol: patchTokenSymbol({
+            symbol: tx.asset.toUpperCase(),
+            tokenAddress: tx.tokenAddress ?? '',
+            isDeposit: true,
+            isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+          })
+        })}
       </td>
 
       <td className="w-1/5 px-3 py-3">

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -168,6 +168,7 @@ export function TransactionsTableDepositRow({
   tx: MergedTransaction
   className?: string
 }) {
+  const { l1 } = useNetworksAndSigners()
   const { isConnectedToArbitrum } = useNetworksAndSigners()
   const { redeem, isRedeeming } = useRedeemRetryable()
 
@@ -223,7 +224,7 @@ export function TransactionsTableDepositRow({
         {formatAmount(Number(tx.value), {
           symbol: sanitizeTokenSymbol(tx.asset, {
             erc20L1Address: tx.tokenAddress,
-            chain: mainnet
+            chain: l1.network
           })
         })}
       </td>

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
@@ -12,7 +12,11 @@ import { ExternalLink } from '../../common/ExternalLink'
 import { shortenTxHash } from '../../../util/CommonUtils'
 import { Button } from '../../common/Button'
 import { Tooltip } from '../../common/Tooltip'
-import { getExplorerUrl, getNetworkName } from '../../../util/networks'
+import {
+  getExplorerUrl,
+  getNetworkName,
+  isNetwork
+} from '../../../util/networks'
 import {
   EllipsisVerticalIcon,
   InformationCircleIcon
@@ -25,6 +29,7 @@ import {
 } from '../../../state/app/utils'
 import { TransactionDateTime } from './TransactionsTable'
 import { formatAmount } from '../../../util/NumberUtils'
+import { patchTokenSymbol } from '../../../util/TokenUtils'
 
 function WithdrawalRowStatus({ tx }: { tx: MergedTransaction }) {
   const matchingL1Tx = findMatchingL1TxForWithdrawal(tx)
@@ -341,6 +346,7 @@ export function TransactionsTableWithdrawalRow({
   className?: string
 }) {
   const isError = tx.status === 'Failure'
+  const { l2 } = useNetworksAndSigners()
 
   const bgClassName = useMemo(() => {
     if (isError) return 'bg-brick'
@@ -364,7 +370,14 @@ export function TransactionsTableWithdrawalRow({
       </td>
 
       <td className="w-1/5 whitespace-nowrap px-3 py-3">
-        {formatAmount(Number(tx.value), { symbol: tx.asset.toUpperCase() })}
+        {formatAmount(Number(tx.value), {
+          symbol: patchTokenSymbol({
+            symbol: tx.asset.toUpperCase(),
+            tokenAddress: tx.tokenAddress ?? '',
+            isDeposit: false,
+            isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+          })
+        })}
       </td>
 
       <td className="w-1/5 px-3 py-3">

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
@@ -367,8 +367,8 @@ export function TransactionsTableWithdrawalRow({
 
       <td className="w-1/5 whitespace-nowrap px-3 py-3">
         {formatAmount(Number(tx.value), {
-          symbol: sanitizeTokenSymbol(tx.asset.toUpperCase(), {
-            erc20L1Address: tx.tokenAddress ?? '',
+          symbol: sanitizeTokenSymbol(tx.asset, {
+            erc20L1Address: tx.tokenAddress,
             chain: l2.network
           })
         })}

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
@@ -350,6 +350,15 @@ export function TransactionsTableWithdrawalRow({
     return ''
   }, [tx, isError])
 
+  const tokenSymbol = useMemo(
+    () =>
+      sanitizeTokenSymbol(tx.asset, {
+        erc20L1Address: tx.tokenAddress,
+        chain: l2.network
+      }),
+    [l2.network, tx.tokenAddress, tx.asset]
+  )
+
   return (
     <tr
       className={`text-sm text-dark ${
@@ -367,10 +376,7 @@ export function TransactionsTableWithdrawalRow({
 
       <td className="w-1/5 whitespace-nowrap px-3 py-3">
         {formatAmount(Number(tx.value), {
-          symbol: sanitizeTokenSymbol(tx.asset, {
-            erc20L1Address: tx.tokenAddress,
-            chain: l2.network
-          })
+          symbol: tokenSymbol
         })}
       </td>
 

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
@@ -12,11 +12,7 @@ import { ExternalLink } from '../../common/ExternalLink'
 import { shortenTxHash } from '../../../util/CommonUtils'
 import { Button } from '../../common/Button'
 import { Tooltip } from '../../common/Tooltip'
-import {
-  getExplorerUrl,
-  getNetworkName,
-  isNetwork
-} from '../../../util/networks'
+import { getExplorerUrl, getNetworkName } from '../../../util/networks'
 import {
   EllipsisVerticalIcon,
   InformationCircleIcon

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableWithdrawalRow.tsx
@@ -29,7 +29,7 @@ import {
 } from '../../../state/app/utils'
 import { TransactionDateTime } from './TransactionsTable'
 import { formatAmount } from '../../../util/NumberUtils'
-import { patchTokenSymbol } from '../../../util/TokenUtils'
+import { sanitizeTokenSymbol } from '../../../util/TokenUtils'
 
 function WithdrawalRowStatus({ tx }: { tx: MergedTransaction }) {
   const matchingL1Tx = findMatchingL1TxForWithdrawal(tx)
@@ -371,11 +371,9 @@ export function TransactionsTableWithdrawalRow({
 
       <td className="w-1/5 whitespace-nowrap px-3 py-3">
         {formatAmount(Number(tx.value), {
-          symbol: patchTokenSymbol({
-            symbol: tx.asset.toUpperCase(),
-            tokenAddress: tx.tokenAddress ?? '',
-            isDeposit: false,
-            isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+          symbol: sanitizeTokenSymbol(tx.asset.toUpperCase(), {
+            erc20L1Address: tx.tokenAddress ?? '',
+            chain: l2.network
           })
         })}
       </td>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
@@ -1,4 +1,5 @@
-import { getNetworkName, isNetwork } from '../../util/networks'
+import { mainnet } from 'wagmi'
+import { getNetworkName } from '../../util/networks'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { MergedTransaction } from '../../state/app/state'
 import { DepositCountdown } from '../common/DepositCountdown'
@@ -8,7 +9,7 @@ import {
   DepositL2TxStatus
 } from './DepositCard'
 import { formatAmount } from '../../util/NumberUtils'
-import { patchTokenSymbol } from '../../util/TokenUtils'
+import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 
 export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
   const { l2 } = useNetworksAndSigners()
@@ -22,11 +23,9 @@ export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
           <span className="ml-8 animate-pulse text-lg text-ocl-blue lg:ml-0 lg:text-2xl">
             Moving{' '}
             {formatAmount(Number(tx.value), {
-              symbol: patchTokenSymbol({
-                symbol: tx.asset.toUpperCase(),
-                tokenAddress: tx.tokenAddress || '',
-                isDeposit: true,
-                isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+              symbol: sanitizeTokenSymbol(tx.asset.toUpperCase(), {
+                erc20L1Address: tx.tokenAddress ?? '',
+                chain: mainnet
               })
             })}{' '}
             to {networkName}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
@@ -12,7 +12,7 @@ import { formatAmount } from '../../util/NumberUtils'
 import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 
 export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
-  const { l2 } = useNetworksAndSigners()
+  const { l1, l2 } = useNetworksAndSigners()
   const networkName = getNetworkName(l2.network.id)
 
   return (
@@ -25,7 +25,7 @@ export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
             {formatAmount(Number(tx.value), {
               symbol: sanitizeTokenSymbol(tx.asset, {
                 erc20L1Address: tx.tokenAddress,
-                chain: mainnet
+                chain: l1.network
               })
             })}{' '}
             to {networkName}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
@@ -1,4 +1,4 @@
-import { getNetworkName } from '../../util/networks'
+import { getNetworkName, isNetwork } from '../../util/networks'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { MergedTransaction } from '../../state/app/state'
 import { DepositCountdown } from '../common/DepositCountdown'
@@ -8,6 +8,7 @@ import {
   DepositL2TxStatus
 } from './DepositCard'
 import { formatAmount } from '../../util/NumberUtils'
+import { patchTokenSymbol } from '../../util/TokenUtils'
 
 export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
   const { l2 } = useNetworksAndSigners()
@@ -20,7 +21,14 @@ export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
           {/* Heading */}
           <span className="ml-8 animate-pulse text-lg text-ocl-blue lg:ml-0 lg:text-2xl">
             Moving{' '}
-            {formatAmount(Number(tx.value), { symbol: tx.asset.toUpperCase() })}{' '}
+            {formatAmount(Number(tx.value), {
+              symbol: patchTokenSymbol({
+                symbol: tx.asset.toUpperCase(),
+                tokenAddress: tx.tokenAddress || '',
+                isDeposit: true,
+                isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+              })
+            })}{' '}
             to {networkName}
           </span>
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
@@ -23,8 +23,8 @@ export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
           <span className="ml-8 animate-pulse text-lg text-ocl-blue lg:ml-0 lg:text-2xl">
             Moving{' '}
             {formatAmount(Number(tx.value), {
-              symbol: sanitizeTokenSymbol(tx.asset.toUpperCase(), {
-                erc20L1Address: tx.tokenAddress ?? '',
+              symbol: sanitizeTokenSymbol(tx.asset, {
+                erc20L1Address: tx.tokenAddress,
                 chain: mainnet
               })
             })}{' '}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { getNetworkName } from '../../util/networks'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { MergedTransaction } from '../../state/app/state'
@@ -14,6 +15,15 @@ export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
   const { l1, l2 } = useNetworksAndSigners()
   const networkName = getNetworkName(l2.network.id)
 
+  const tokenSymbol = useMemo(
+    () =>
+      sanitizeTokenSymbol(tx.asset, {
+        erc20L1Address: tx.tokenAddress,
+        chain: l1.network
+      }),
+    [l1.network, tx.tokenAddress, tx.asset]
+  )
+
   return (
     <DepositCardContainer tx={tx}>
       <div className="flex flex-row flex-wrap items-center justify-between">
@@ -22,10 +32,7 @@ export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
           <span className="ml-8 animate-pulse text-lg text-ocl-blue lg:ml-0 lg:text-2xl">
             Moving{' '}
             {formatAmount(Number(tx.value), {
-              symbol: sanitizeTokenSymbol(tx.asset, {
-                erc20L1Address: tx.tokenAddress,
-                chain: l1.network
-              })
+              symbol: tokenSymbol
             })}{' '}
             to {networkName}
           </span>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
@@ -1,4 +1,3 @@
-import { mainnet } from 'wagmi'
 import { getNetworkName } from '../../util/networks'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { MergedTransaction } from '../../state/app/state'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { Popover } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/24/outline'
+import { mainnet } from 'wagmi'
 
 import { useAppState } from '../../state'
 import { sanitizeImageSrc } from '../../util'
@@ -11,8 +12,7 @@ import {
   UseNetworksAndSignersStatus
 } from '../../hooks/useNetworksAndSigners'
 import { useDialog } from '../common/Dialog'
-import { patchTokenSymbol } from '../../util/TokenUtils'
-import { isNetwork } from '../../util/networks'
+import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 
 export function TokenButton(): JSX.Element {
   const {
@@ -54,11 +54,9 @@ export function TokenButton(): JSX.Element {
       return 'ETH'
     }
 
-    return patchTokenSymbol({
-      symbol: selectedToken.symbol,
-      tokenAddress: selectedToken.address,
-      isDeposit: isDepositMode,
-      isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+    return sanitizeTokenSymbol(selectedToken.symbol, {
+      erc20L1Address: selectedToken.address,
+      chain: isDepositMode ? mainnet : l2.network
     })
   }, [selectedToken, isDepositMode, l2])
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react'
 import { Popover } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/24/outline'
-import { mainnet } from 'wagmi'
 
 import { useAppState } from '../../state'
 import { sanitizeImageSrc } from '../../util'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -11,7 +11,7 @@ import {
   UseNetworksAndSignersStatus
 } from '../../hooks/useNetworksAndSigners'
 import { useDialog } from '../common/Dialog'
-import { CommonAddress } from '../../util/CommonAddressUtils'
+import { patchTokenSymbol } from '../../util/TokenUtils'
 import { isNetwork } from '../../util/networks'
 
 export function TokenButton(): JSX.Element {
@@ -54,16 +54,12 @@ export function TokenButton(): JSX.Element {
       return 'ETH'
     }
 
-    const addressLowercased = selectedToken.address.toLowerCase()
-    const isUSDC = addressLowercased === CommonAddress.Mainnet.USDC
-    const isL2ArbitrumOne = isNetwork(l2.network.id).isArbitrumOne
-
-    // Special case because token symbol for USDC is different on Mainnet and Arbitrum One
-    if (isUSDC && isL2ArbitrumOne) {
-      return isDepositMode ? 'USDC' : 'USDC.e'
-    }
-
-    return selectedToken.symbol
+    return patchTokenSymbol({
+      symbol: selectedToken.symbol,
+      tokenAddress: selectedToken.address,
+      isDeposit: isDepositMode,
+      isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+    })
   }, [selectedToken, isDepositMode, l2])
 
   function closeWithReset() {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -23,7 +23,7 @@ export function TokenButton(): JSX.Element {
       arbTokenBridgeLoaded
     }
   } = useAppState()
-  const { status, l2 } = useNetworksAndSigners()
+  const { status, l1, l2 } = useNetworksAndSigners()
 
   const [tokenToImport, setTokenToImport] = useState<string>()
   const [tokenImportDialogProps, openTokenImportDialog] = useDialog()
@@ -56,9 +56,9 @@ export function TokenButton(): JSX.Element {
 
     return sanitizeTokenSymbol(selectedToken.symbol, {
       erc20L1Address: selectedToken.address,
-      chain: isDepositMode ? mainnet : l2.network
+      chain: isDepositMode ? l1.network : l2.network
     })
-  }, [selectedToken, isDepositMode, l2])
+  }, [selectedToken, isDepositMode, l2.network, l1.network])
 
   function closeWithReset() {
     setTokenToImport(undefined)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -111,20 +111,20 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
       token
         ? sanitizeTokenName(token.name, {
             erc20L1Address: token.address,
-            chain: isDepositMode ? mainnet : l2Network
+            chain: isDepositMode ? l1Network : l2Network
           })
         : 'Ether',
-    [token, isDepositMode, l2Network]
+    [token, isDepositMode, l2Network, l1Network]
   )
   const tokenSymbol = useMemo(
     () =>
       token
         ? sanitizeTokenSymbol(token.symbol, {
             erc20L1Address: token.address,
-            chain: isDepositMode ? mainnet : l2Network
+            chain: isDepositMode ? l1Network : l2Network
           })
         : 'ETH',
-    [token, isDepositMode, l2Network]
+    [token, isDepositMode, l2Network, l1Network]
   )
   const isL2NativeToken = useMemo(() => token?.isL2Native ?? false, [token])
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -12,7 +12,7 @@ import {
 import { useMedia } from 'react-use'
 import { constants } from 'ethers'
 import Image from 'next/image'
-import { Chain } from 'wagmi'
+import { Chain, mainnet } from 'wagmi'
 
 import { Loader } from '../common/atoms/Loader'
 import { useActions, useAppState } from '../../state'
@@ -25,7 +25,7 @@ import {
 } from '../../util/TokenListUtils'
 import { formatAmount } from '../../util/NumberUtils'
 import { shortenAddress } from '../../util/CommonUtils'
-import { getL1TokenData, patchTokenSymbol } from '../../util/TokenUtils'
+import { getL1TokenData, sanitizeTokenSymbol } from '../../util/TokenUtils'
 import { Button } from '../common/Button'
 import { SafeImage } from '../common/SafeImage'
 import {
@@ -106,14 +106,12 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
   const tokenSymbol = useMemo(
     () =>
       token
-        ? patchTokenSymbol({
-            symbol: token.symbol,
-            tokenAddress: token.address,
-            isDeposit: isDepositMode,
-            isL2ArbitrumOne: isNetwork(l2Network.id).isArbitrumOne
+        ? sanitizeTokenSymbol(token.symbol, {
+            erc20L1Address: token.address,
+            chain: isDepositMode ? mainnet : l2Network
           })
         : 'ETH',
-    [token, isDepositMode, l2Network.id]
+    [token, isDepositMode, l2Network]
   )
   const isL2NativeToken = useMemo(() => token?.isL2Native ?? false, [token])
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -25,7 +25,11 @@ import {
 } from '../../util/TokenListUtils'
 import { formatAmount } from '../../util/NumberUtils'
 import { shortenAddress } from '../../util/CommonUtils'
-import { getL1TokenData, sanitizeTokenSymbol } from '../../util/TokenUtils'
+import {
+  getL1TokenData,
+  sanitizeTokenName,
+  sanitizeTokenSymbol
+} from '../../util/TokenUtils'
 import { Button } from '../common/Button'
 import { SafeImage } from '../common/SafeImage'
 import {
@@ -102,7 +106,16 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
     l2: { network: l2Network, provider: l2Provider }
   } = useNetworksAndSigners()
 
-  const tokenName = useMemo(() => (token ? token.name : 'Ether'), [token])
+  const tokenName = useMemo(
+    () =>
+      token
+        ? sanitizeTokenName(token.name, {
+            erc20L1Address: token.address,
+            chain: isDepositMode ? mainnet : l2Network
+          })
+        : 'Ether',
+    [token, isDepositMode, l2Network]
+  )
   const tokenSymbol = useMemo(
     () =>
       token

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -12,7 +12,7 @@ import {
 import { useMedia } from 'react-use'
 import { constants } from 'ethers'
 import Image from 'next/image'
-import { Chain, mainnet } from 'wagmi'
+import { Chain } from 'wagmi'
 
 import { Loader } from '../common/atoms/Loader'
 import { useActions, useAppState } from '../../state'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../util/TokenListUtils'
 import { formatAmount } from '../../util/NumberUtils'
 import { shortenAddress } from '../../util/CommonUtils'
-import { getL1TokenData } from '../../util/TokenUtils'
+import { getL1TokenData, patchTokenSymbol } from '../../util/TokenUtils'
 import { Button } from '../common/Button'
 import { SafeImage } from '../common/SafeImage'
 import {
@@ -34,7 +34,7 @@ import {
   toERC20BridgeToken
 } from './TokenSearchUtils'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
-import { getExplorerUrl, getNetworkName } from '../../util/networks'
+import { getExplorerUrl, getNetworkName, isNetwork } from '../../util/networks'
 import { Tooltip } from '../common/Tooltip'
 import { StatusBadge } from '../common/StatusBadge'
 import { useBalance } from '../../hooks/useBalance'
@@ -103,7 +103,18 @@ function TokenRow({ style, onClick, token }: TokenRowProps): JSX.Element {
   } = useNetworksAndSigners()
 
   const tokenName = useMemo(() => (token ? token.name : 'Ether'), [token])
-  const tokenSymbol = useMemo(() => (token ? token.symbol : 'ETH'), [token])
+  const tokenSymbol = useMemo(
+    () =>
+      token
+        ? patchTokenSymbol({
+            symbol: token.symbol,
+            tokenAddress: token.address,
+            isDeposit: isDepositMode,
+            isL2ArbitrumOne: isNetwork(l2Network.id).isArbitrumOne
+          })
+        : 'ETH',
+    [token, isDepositMode, l2Network.id]
+  )
   const isL2NativeToken = useMemo(() => token?.isL2Native ?? false, [token])
 
   const {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -38,7 +38,7 @@ import {
   toERC20BridgeToken
 } from './TokenSearchUtils'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
-import { getExplorerUrl, getNetworkName, isNetwork } from '../../util/networks'
+import { getExplorerUrl, getNetworkName } from '../../util/networks'
 import { Tooltip } from '../common/Tooltip'
 import { StatusBadge } from '../common/StatusBadge'
 import { useBalance } from '../../hooks/useBalance'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -7,7 +7,7 @@ import { BigNumber, constants, utils } from 'ethers'
 
 import * as Sentry from '@sentry/react'
 import Image from 'next/image'
-import { Chain } from 'wagmi'
+import { Chain, mainnet } from 'wagmi'
 
 import { useActions, useAppState } from '../../state'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
@@ -46,7 +46,7 @@ import { useAccountType } from '../../hooks/useAccountType'
 import { depositEthEstimateGas } from '../../util/EthDepositUtils'
 import { withdrawEthEstimateGas } from '../../util/EthWithdrawalUtils'
 import { CommonAddress } from '../../util/CommonAddressUtils'
-import { patchTokenSymbol } from '../../util/TokenUtils'
+import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 
 export function SwitchNetworksButton(
   props: React.ButtonHTMLAttributes<HTMLButtonElement>
@@ -268,11 +268,9 @@ function TokenBalance({
       return undefined
     }
 
-    return patchTokenSymbol({
-      symbol: forToken.symbol,
-      tokenAddress: forToken.address,
-      isDeposit: isDepositMode,
-      isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+    return sanitizeTokenSymbol(forToken.symbol, {
+      erc20L1Address: forToken.address,
+      chain: isDepositMode ? mainnet : l2.network
     })
   }, [forToken, l2, isDepositMode])
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -46,6 +46,7 @@ import { useAccountType } from '../../hooks/useAccountType'
 import { depositEthEstimateGas } from '../../util/EthDepositUtils'
 import { withdrawEthEstimateGas } from '../../util/EthWithdrawalUtils'
 import { CommonAddress } from '../../util/CommonAddressUtils'
+import { patchTokenSymbol } from '../../util/TokenUtils'
 
 export function SwitchNetworksButton(
   props: React.ButtonHTMLAttributes<HTMLButtonElement>
@@ -258,23 +259,22 @@ function TokenBalance({
 }) {
   const { l2 } = useNetworksAndSigners()
   const balance = useTokenBalances(forToken?.address)[on]
+  const {
+    app: { isDepositMode }
+  } = useAppState()
 
   const symbol = useMemo(() => {
     if (!forToken) {
       return undefined
     }
 
-    const addressLowercased = forToken.address.toLowerCase()
-    const isUSDC = addressLowercased === CommonAddress.Mainnet.USDC
-    const isL2ArbitrumOne = isNetwork(l2.network.id).isArbitrumOne
-
-    // Special case because token symbol for USDC is different on Mainnet and Arbitrum One
-    if (on === NetworkType.l2 && isUSDC && isL2ArbitrumOne) {
-      return 'USDC.e'
-    }
-
-    return forToken.symbol
-  }, [forToken, on, l2])
+    return patchTokenSymbol({
+      symbol: forToken.symbol,
+      tokenAddress: forToken.address,
+      isDeposit: isDepositMode,
+      isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+    })
+  }, [forToken, l2, isDepositMode])
 
   if (!forToken) {
     return null

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -7,7 +7,7 @@ import { BigNumber, constants, utils } from 'ethers'
 
 import * as Sentry from '@sentry/react'
 import Image from 'next/image'
-import { Chain, mainnet } from 'wagmi'
+import { Chain } from 'wagmi'
 
 import { useActions, useAppState } from '../../state'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -259,9 +259,6 @@ function TokenBalance({
 }) {
   const { l1, l2 } = useNetworksAndSigners()
   const balance = useTokenBalances(forToken?.address)[on]
-  const {
-    app: { isDepositMode }
-  } = useAppState()
 
   const symbol = useMemo(() => {
     if (!forToken) {
@@ -270,9 +267,9 @@ function TokenBalance({
 
     return sanitizeTokenSymbol(forToken.symbol, {
       erc20L1Address: forToken.address,
-      chain: isDepositMode ? l1.network : l2.network
+      chain: on == NetworkType.l1 ? l1.network : l2.network
     })
-  }, [forToken, l1, l2, isDepositMode])
+  }, [forToken, on, l1, l2])
 
   if (!forToken) {
     return null
@@ -319,8 +316,6 @@ export enum TransferPanelMainErrorMessage {
   WITHDRAW_ONLY,
   SC_WALLET_ETH_NOT_SUPPORTED
 }
-
-const USDC_L1_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
 
 export function TransferPanelMain({
   amount,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -267,7 +267,7 @@ function TokenBalance({
 
     return sanitizeTokenSymbol(forToken.symbol, {
       erc20L1Address: forToken.address,
-      chain: on == NetworkType.l1 ? l1.network : l2.network
+      chain: on === NetworkType.l1 ? l1.network : l2.network
     })
   }, [forToken, on, l1, l2])
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -257,7 +257,7 @@ function TokenBalance({
   on: NetworkType
   prefix?: string
 }) {
-  const { l2 } = useNetworksAndSigners()
+  const { l1, l2 } = useNetworksAndSigners()
   const balance = useTokenBalances(forToken?.address)[on]
   const {
     app: { isDepositMode }
@@ -270,9 +270,9 @@ function TokenBalance({
 
     return sanitizeTokenSymbol(forToken.symbol, {
       erc20L1Address: forToken.address,
-      chain: isDepositMode ? mainnet : l2.network
+      chain: isDepositMode ? l1.network : l2.network
     })
-  }, [forToken, l2, isDepositMode])
+  }, [forToken, l1, l2, isDepositMode])
 
   if (!forToken) {
     return null

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -295,7 +295,7 @@ export function TransferPanelSummary({
           <span>
             {formatAmount(amount, {
               symbol: sanitizeTokenSymbol(token?.symbol || 'ETH', {
-                erc20L1Address: token?.address || '',
+                erc20L1Address: token?.address,
                 chain: app.isDepositMode ? mainnet : l2.network
               })
             })}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -16,6 +16,7 @@ import { depositTokenEstimateGas } from '../../util/TokenDepositUtils'
 import { depositEthEstimateGas } from '../../util/EthDepositUtils'
 import { withdrawTokenEstimateGas } from '../../util/TokenWithdrawalUtils'
 import { withdrawEthEstimateGas } from '../../util/EthWithdrawalUtils'
+import { patchTokenSymbol } from '../../util/TokenUtils'
 
 export type GasEstimationStatus = 'idle' | 'loading' | 'success' | 'error'
 
@@ -253,7 +254,7 @@ export function TransferPanelSummary({
 
   const { app } = useAppState()
   const { ethToUSD } = useETHPrice()
-  const { l1 } = useNetworksAndSigners()
+  const { l1, l2 } = useNetworksAndSigners()
 
   const { isMainnet } = isNetwork(l1.network.id)
 
@@ -291,7 +292,14 @@ export function TransferPanelSummary({
         <span className="w-2/5 font-light">You’re moving</span>
         <div className="flex w-3/5 flex-row justify-between">
           <span>
-            {formatAmount(amount, { symbol: token?.symbol || 'ETH' })}
+            {formatAmount(amount, {
+              symbol: patchTokenSymbol({
+                symbol: token?.symbol || 'ETH',
+                tokenAddress: token?.address || '',
+                isDeposit: app.isDepositMode,
+                isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+              })
+            })}
           </span>
           {/* Only show USD price for ETH */}
           {isETH && isMainnet && (

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { BigNumber, constants, utils } from 'ethers'
 import { InformationCircleIcon } from '@heroicons/react/24/outline'
 import { useLatest } from 'react-use'
+import { mainnet } from 'wagmi'
 
 import { Tooltip } from '../common/Tooltip'
 import { useAppState } from '../../state'
@@ -16,7 +17,7 @@ import { depositTokenEstimateGas } from '../../util/TokenDepositUtils'
 import { depositEthEstimateGas } from '../../util/EthDepositUtils'
 import { withdrawTokenEstimateGas } from '../../util/TokenWithdrawalUtils'
 import { withdrawEthEstimateGas } from '../../util/EthWithdrawalUtils'
-import { patchTokenSymbol } from '../../util/TokenUtils'
+import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 
 export type GasEstimationStatus = 'idle' | 'loading' | 'success' | 'error'
 
@@ -293,11 +294,9 @@ export function TransferPanelSummary({
         <div className="flex w-3/5 flex-row justify-between">
           <span>
             {formatAmount(amount, {
-              symbol: patchTokenSymbol({
-                symbol: token?.symbol || 'ETH',
-                tokenAddress: token?.address || '',
-                isDeposit: app.isDepositMode,
-                isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+              symbol: sanitizeTokenSymbol(token?.symbol || 'ETH', {
+                erc20L1Address: token?.address || '',
+                chain: app.isDepositMode ? mainnet : l2.network
               })
             })}
           </span>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -258,6 +258,17 @@ export function TransferPanelSummary({
 
   const { isMainnet } = isNetwork(l1.network.id)
 
+  const tokenSymbol = useMemo(
+    () =>
+      token
+        ? sanitizeTokenSymbol(token.symbol, {
+            erc20L1Address: token.address,
+            chain: app.isDepositMode ? l1.network : l2.network
+          })
+        : 'ETH',
+    [token, app.isDepositMode, l1.network, l2.network]
+  )
+
   if (status === 'loading') {
     const bgClassName = app.isDepositMode ? 'bg-ocl-blue' : 'bg-eth-dark'
 
@@ -293,10 +304,7 @@ export function TransferPanelSummary({
         <div className="flex w-3/5 flex-row justify-between">
           <span>
             {formatAmount(amount, {
-              symbol: sanitizeTokenSymbol(token?.symbol || 'ETH', {
-                erc20L1Address: token?.address,
-                chain: app.isDepositMode ? l1.network : l2.network
-              })
+              symbol: tokenSymbol
             })}
           </span>
           {/* Only show USD price for ETH */}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { BigNumber, constants, utils } from 'ethers'
 import { InformationCircleIcon } from '@heroicons/react/24/outline'
 import { useLatest } from 'react-use'
-import { mainnet } from 'wagmi'
 
 import { Tooltip } from '../common/Tooltip'
 import { useAppState } from '../../state'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -296,7 +296,7 @@ export function TransferPanelSummary({
             {formatAmount(amount, {
               symbol: sanitizeTokenSymbol(token?.symbol || 'ETH', {
                 erc20L1Address: token?.address,
-                chain: app.isDepositMode ? mainnet : l2.network
+                chain: app.isDepositMode ? l1.network : l2.network
               })
             })}
           </span>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardConfirmed.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardConfirmed.tsx
@@ -23,8 +23,8 @@ export function WithdrawalCardConfirmed({ tx }: { tx: MergedTransaction }) {
 
   const tokenSymbol = useMemo(
     () =>
-      sanitizeTokenSymbol(tx.asset.toUpperCase(), {
-        erc20L1Address: tx.tokenAddress || '',
+      sanitizeTokenSymbol(tx.asset, {
+        erc20L1Address: tx.tokenAddress,
         chain: l2.network
       }),
     [tx, l2]

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardConfirmed.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardConfirmed.tsx
@@ -7,8 +7,7 @@ import { useClaimWithdrawal } from '../../hooks/useClaimWithdrawal'
 import { Button } from '../common/Button'
 import { Tooltip } from '../common/Tooltip'
 import { formatAmount } from '../../util/NumberUtils'
-import { patchTokenSymbol } from '../../util/TokenUtils'
-import { isNetwork } from '../../util/networks'
+import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 
 export function WithdrawalCardConfirmed({ tx }: { tx: MergedTransaction }) {
   const { l2, isConnectedToArbitrum } = useNetworksAndSigners()
@@ -24,11 +23,9 @@ export function WithdrawalCardConfirmed({ tx }: { tx: MergedTransaction }) {
 
   const tokenSymbol = useMemo(
     () =>
-      patchTokenSymbol({
-        symbol: tx.asset.toUpperCase(),
-        tokenAddress: tx.tokenAddress || '',
-        isDeposit: false,
-        isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+      sanitizeTokenSymbol(tx.asset.toUpperCase(), {
+        erc20L1Address: tx.tokenAddress || '',
+        chain: l2.network
       }),
     [tx, l2]
   )

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardConfirmed.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardConfirmed.tsx
@@ -7,9 +7,11 @@ import { useClaimWithdrawal } from '../../hooks/useClaimWithdrawal'
 import { Button } from '../common/Button'
 import { Tooltip } from '../common/Tooltip'
 import { formatAmount } from '../../util/NumberUtils'
+import { patchTokenSymbol } from '../../util/TokenUtils'
+import { isNetwork } from '../../util/networks'
 
 export function WithdrawalCardConfirmed({ tx }: { tx: MergedTransaction }) {
-  const { isConnectedToArbitrum } = useNetworksAndSigners()
+  const { l2, isConnectedToArbitrum } = useNetworksAndSigners()
   const { claim, isClaiming } = useClaimWithdrawal()
 
   const isClaimButtonDisabled = useMemo(
@@ -18,6 +20,17 @@ export function WithdrawalCardConfirmed({ tx }: { tx: MergedTransaction }) {
         ? isConnectedToArbitrum
         : true,
     [isConnectedToArbitrum]
+  )
+
+  const tokenSymbol = useMemo(
+    () =>
+      patchTokenSymbol({
+        symbol: tx.asset.toUpperCase(),
+        tokenAddress: tx.tokenAddress || '',
+        isDeposit: false,
+        isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+      }),
+    [tx, l2]
   )
 
   return (
@@ -61,7 +74,7 @@ export function WithdrawalCardConfirmed({ tx }: { tx: MergedTransaction }) {
               Claim{' '}
               <span className="hidden lg:flex">
                 {formatAmount(Number(tx.value), {
-                  symbol: tx.asset.toUpperCase()
+                  symbol: tokenSymbol
                 })}
               </span>
             </div>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardExecuted.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardExecuted.tsx
@@ -26,7 +26,7 @@ export function WithdrawalCardExecuted({ tx }: { tx: MergedTransaction }) {
 
   const tokenSymbol = useMemo(
     () =>
-      sanitizeTokenSymbol(tx.asset.toUpperCase(), {
+      sanitizeTokenSymbol(tx.asset, {
         erc20L1Address: tx.tokenAddress,
         chain: l2.network
       }),

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardExecuted.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardExecuted.tsx
@@ -11,17 +11,30 @@ import { formatAmount } from '../../util/NumberUtils'
 import { useTokenDecimals } from '../../hooks/useTokenDecimals'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { useBalance } from '../../hooks/useBalance'
+import { patchTokenSymbol } from '../../util/TokenUtils'
+import { isNetwork } from '../../util/networks'
 
 export function WithdrawalCardExecuted({ tx }: { tx: MergedTransaction }) {
   const {
     app: { arbTokenBridge }
   } = useAppState()
   const { walletAddress, bridgeTokens } = arbTokenBridge
-  const { l1 } = useNetworksAndSigners()
+  const { l1, l2 } = useNetworksAndSigners()
   const {
     eth: [ethL1Balance],
     erc20: [erc20L1Balances]
   } = useBalance({ provider: l1.provider, walletAddress })
+
+  const tokenSymbol = useMemo(
+    () =>
+      patchTokenSymbol({
+        symbol: tx.asset.toUpperCase(),
+        tokenAddress: tx.tokenAddress || '',
+        isDeposit: false,
+        isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+      }),
+    [tx, l2]
+  )
 
   useEffect(() => {
     // Add token to bridge just in case
@@ -67,7 +80,7 @@ export function WithdrawalCardExecuted({ tx }: { tx: MergedTransaction }) {
             <span className="font-medium">
               {formatAmount(balance, {
                 decimals,
-                symbol: tx.asset.toUpperCase()
+                symbol: tokenSymbol
               })}
             </span>
           ) : (

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardExecuted.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardExecuted.tsx
@@ -27,7 +27,7 @@ export function WithdrawalCardExecuted({ tx }: { tx: MergedTransaction }) {
   const tokenSymbol = useMemo(
     () =>
       sanitizeTokenSymbol(tx.asset.toUpperCase(), {
-        erc20L1Address: tx.tokenAddress || '',
+        erc20L1Address: tx.tokenAddress,
         chain: l2.network
       }),
     [tx, l2]

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardExecuted.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardExecuted.tsx
@@ -11,8 +11,7 @@ import { formatAmount } from '../../util/NumberUtils'
 import { useTokenDecimals } from '../../hooks/useTokenDecimals'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { useBalance } from '../../hooks/useBalance'
-import { patchTokenSymbol } from '../../util/TokenUtils'
-import { isNetwork } from '../../util/networks'
+import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 
 export function WithdrawalCardExecuted({ tx }: { tx: MergedTransaction }) {
   const {
@@ -27,11 +26,9 @@ export function WithdrawalCardExecuted({ tx }: { tx: MergedTransaction }) {
 
   const tokenSymbol = useMemo(
     () =>
-      patchTokenSymbol({
-        symbol: tx.asset.toUpperCase(),
-        tokenAddress: tx.tokenAddress || '',
-        isDeposit: false,
-        isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+      sanitizeTokenSymbol(tx.asset.toUpperCase(), {
+        erc20L1Address: tx.tokenAddress || '',
+        chain: l2.network
       }),
     [tx, l2]
   )

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardUnconfirmed.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardUnconfirmed.tsx
@@ -1,4 +1,4 @@
-import { getNetworkName, isNetwork } from '../../util/networks'
+import { getNetworkName } from '../../util/networks'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { MergedTransaction } from '../../state/app/state'
 import { WithdrawalCountdown } from '../common/WithdrawalCountdown'
@@ -15,8 +15,8 @@ export function WithdrawalCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
 
   const tokenSymbol = useMemo(
     () =>
-      sanitizeTokenSymbol(tx.asset.toUpperCase(), {
-        erc20L1Address: tx.tokenAddress || '',
+      sanitizeTokenSymbol(tx.asset, {
+        erc20L1Address: tx.tokenAddress,
         chain: l2.network
       }),
     [tx, l2]

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardUnconfirmed.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardUnconfirmed.tsx
@@ -1,4 +1,4 @@
-import { getNetworkName } from '../../util/networks'
+import { getNetworkName, isNetwork } from '../../util/networks'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { MergedTransaction } from '../../state/app/state'
 import { WithdrawalCountdown } from '../common/WithdrawalCountdown'
@@ -6,19 +6,31 @@ import { WithdrawalCardContainer, WithdrawalL2TxStatus } from './WithdrawalCard'
 import { Button } from '../common/Button'
 import { Tooltip } from '../common/Tooltip'
 import { formatAmount } from '../../util/NumberUtils'
+import { useMemo } from 'react'
+import { patchTokenSymbol } from '../../util/TokenUtils'
 
 export function WithdrawalCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
-  const { l1 } = useNetworksAndSigners()
+  const { l1, l2 } = useNetworksAndSigners()
   const networkName = getNetworkName(l1.network.id)
+
+  const tokenSymbol = useMemo(
+    () =>
+      patchTokenSymbol({
+        symbol: tx.asset.toUpperCase(),
+        tokenAddress: tx.tokenAddress || '',
+        isDeposit: false,
+        isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+      }),
+    [tx, l2]
+  )
 
   return (
     <WithdrawalCardContainer tx={tx}>
       <div className="flex flex-row flex-wrap items-center justify-between">
         <div className="flex flex-col lg:ml-[-2rem]">
           <span className="ml-8 text-lg text-ocl-blue lg:ml-0 lg:text-2xl">
-            Moving{' '}
-            {formatAmount(Number(tx.value), { symbol: tx.asset.toUpperCase() })}{' '}
-            to {networkName}
+            Moving {formatAmount(Number(tx.value), { symbol: tokenSymbol })} to{' '}
+            {networkName}
           </span>
 
           <span className="animate-pulse text-sm text-gray-dark">
@@ -50,7 +62,7 @@ export function WithdrawalCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
               Claim{' '}
               <span className="hidden lg:flex">
                 {formatAmount(Number(tx.value), {
-                  symbol: tx.asset.toUpperCase()
+                  symbol: tokenSymbol
                 })}
               </span>
             </div>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardUnconfirmed.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCardUnconfirmed.tsx
@@ -7,7 +7,7 @@ import { Button } from '../common/Button'
 import { Tooltip } from '../common/Tooltip'
 import { formatAmount } from '../../util/NumberUtils'
 import { useMemo } from 'react'
-import { patchTokenSymbol } from '../../util/TokenUtils'
+import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 
 export function WithdrawalCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
   const { l1, l2 } = useNetworksAndSigners()
@@ -15,11 +15,9 @@ export function WithdrawalCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
 
   const tokenSymbol = useMemo(
     () =>
-      patchTokenSymbol({
-        symbol: tx.asset.toUpperCase(),
-        tokenAddress: tx.tokenAddress || '',
-        isDeposit: false,
-        isL2ArbitrumOne: isNetwork(l2.network.id).isArbitrumOne
+      sanitizeTokenSymbol(tx.asset.toUpperCase(), {
+        erc20L1Address: tx.tokenAddress || '',
+        chain: l2.network
       }),
     [tx, l2]
   )

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -244,19 +244,23 @@ type SanitizeTokenOptions = {
   chain: Chain // chain for which we want to retrieve the token name / symbol
 }
 
+const isTokenMainnetUSDC = (tokenAddress: string) => {
+  return tokenAddress.toLowerCase() === CommonAddress.Mainnet.USDC.toLowerCase()
+}
+
 // get the exact token symbol for a particular chain
 export function sanitizeTokenSymbol(
   tokenSymbol: string,
-  options?: SanitizeTokenOptions
+  options: SanitizeTokenOptions
 ) {
-  if (typeof options === 'undefined') {
+  if (!options.erc20L1Address) {
     return tokenSymbol.toUpperCase()
   }
 
   const isArbitrumOne = isNetwork(options.chain.id).isArbitrumOne
 
   // only special case for USDC is Arbitrum One
-  if (options.erc20L1Address === CommonAddress.Mainnet.USDC && isArbitrumOne) {
+  if (isTokenMainnetUSDC(options.erc20L1Address) && isArbitrumOne) {
     return 'USDC.e'
   }
 
@@ -266,9 +270,9 @@ export function sanitizeTokenSymbol(
 // get the exact token name for a particular chain
 export function sanitizeTokenName(
   tokenName: string,
-  options?: SanitizeTokenOptions
+  options: SanitizeTokenOptions
 ) {
-  if (typeof options === 'undefined') {
+  if (!options.erc20L1Address) {
     return tokenName
   }
 
@@ -276,10 +280,9 @@ export function sanitizeTokenName(
   const isMainnet = isNetwork(options.chain.id).isMainnet
 
   // only special case for USDC is Arbitrum One / Mainnet
-  if (options.erc20L1Address === CommonAddress.Mainnet.USDC) {
+  if (isTokenMainnetUSDC(options.erc20L1Address)) {
     if (isArbitrumOne) return 'Bridged USDC'
     if (isMainnet) return 'USD Coin'
-    return tokenName
   }
 
   return tokenName

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -4,6 +4,7 @@ import { Erc20Bridger, MultiCaller } from '@arbitrum/sdk'
 import { StandardArbERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/StandardArbERC20__factory'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 import { L1TokenData, L2TokenData } from '../hooks/arbTokenBridge.types'
+import { CommonAddress } from './CommonAddressUtils'
 
 export function getDefaultTokenName(address: string) {
   const lowercased = address.toLowerCase()
@@ -234,4 +235,30 @@ export async function l1TokenIsDisabled({
 }): Promise<boolean> {
   const erc20Bridger = await Erc20Bridger.fromProvider(l2Provider)
   return erc20Bridger.l1TokenIsDisabled(erc20L1Address, l1Provider)
+}
+
+// temporary patch token symbol until our token lists return correct symbols
+export function patchTokenSymbol({
+  symbol,
+  tokenAddress,
+  isL2ArbitrumOne,
+  isDeposit
+}: {
+  symbol: string
+  tokenAddress: string
+  isL2ArbitrumOne: boolean
+  isDeposit: boolean
+}) {
+  // if L2 network is Arbitrum one and we identify USDC/USDC.e
+  // we conditionally patch the token symbol in this case
+  if (
+    isL2ArbitrumOne &&
+    tokenAddress.toLowerCase() === CommonAddress.Mainnet.USDC
+  ) {
+    // Special case because token symbol for USDC is different on Mainnet and Arbitrum One
+    return isDeposit ? 'USDC' : 'USDC.e'
+  }
+
+  // else, just return whatever token symbol was provided
+  return symbol
 }

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -1,10 +1,12 @@
 import { BigNumber, constants } from 'ethers'
+import { Chain } from 'wagmi'
 import { Provider } from '@ethersproject/providers'
 import { Erc20Bridger, MultiCaller } from '@arbitrum/sdk'
 import { StandardArbERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/StandardArbERC20__factory'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 import { L1TokenData, L2TokenData } from '../hooks/arbTokenBridge.types'
 import { CommonAddress } from './CommonAddressUtils'
+import { isNetwork } from './networks'
 
 export function getDefaultTokenName(address: string) {
   const lowercased = address.toLowerCase()
@@ -237,28 +239,26 @@ export async function l1TokenIsDisabled({
   return erc20Bridger.l1TokenIsDisabled(erc20L1Address, l1Provider)
 }
 
-// temporary patch token symbol until our token lists return correct symbols
-export function patchTokenSymbol({
-  symbol,
-  tokenAddress,
-  isL2ArbitrumOne,
-  isDeposit
-}: {
-  symbol: string
-  tokenAddress: string
-  isL2ArbitrumOne: boolean
-  isDeposit: boolean
-}) {
-  // if L2 network is Arbitrum one and we identify USDC/USDC.e
-  // we conditionally patch the token symbol in this case
-  if (
-    isL2ArbitrumOne &&
-    tokenAddress.toLowerCase() === CommonAddress.Mainnet.USDC
-  ) {
-    // Special case because token symbol for USDC is different on Mainnet and Arbitrum One
-    return isDeposit ? 'USDC' : 'USDC.e'
+type SanitizeTokenSymbolOptions = {
+  erc20L1Address: string // token address
+  chain: Chain // chain for which we want to retrieve the token name
+}
+
+// get the exact token symbol for a particular chain
+export function sanitizeTokenSymbol(
+  tokenSymbol: string,
+  options?: SanitizeTokenSymbolOptions
+) {
+  if (typeof options === 'undefined') {
+    return tokenSymbol
   }
 
-  // else, just return whatever token symbol was provided
-  return symbol
+  const isArbitrumOne = isNetwork(options.chain.id).isArbitrumOne
+
+  // only special case for USDC is Arbitrum One
+  if (options.erc20L1Address === CommonAddress.Mainnet.USDC && isArbitrumOne) {
+    return 'USDC.e'
+  }
+
+  return tokenSymbol
 }

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -273,10 +273,13 @@ export function sanitizeTokenName(
   }
 
   const isArbitrumOne = isNetwork(options.chain.id).isArbitrumOne
+  const isMainnet = isNetwork(options.chain.id).isMainnet
 
-  // only special case for USDC is Arbitrum One
-  if (options.erc20L1Address === CommonAddress.Mainnet.USDC && isArbitrumOne) {
-    return 'Bridged USDC'
+  // only special case for USDC is Arbitrum One / Mainnet
+  if (options.erc20L1Address === CommonAddress.Mainnet.USDC) {
+    if (isArbitrumOne) return 'Bridged USDC'
+    if (isMainnet) return 'USD Coin (USDC)'
+    return tokenName
   }
 
   return tokenName

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -278,7 +278,7 @@ export function sanitizeTokenName(
   // only special case for USDC is Arbitrum One / Mainnet
   if (options.erc20L1Address === CommonAddress.Mainnet.USDC) {
     if (isArbitrumOne) return 'Bridged USDC'
-    if (isMainnet) return 'USD Coin (USDC)'
+    if (isMainnet) return 'USD Coin'
     return tokenName
   }
 

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -262,3 +262,22 @@ export function sanitizeTokenSymbol(
 
   return tokenSymbol
 }
+
+// get the exact token name for a particular chain
+export function sanitizeTokenName(
+  tokenName: string,
+  options?: SanitizeTokenSymbolOptions
+) {
+  if (typeof options === 'undefined') {
+    return tokenName
+  }
+
+  const isArbitrumOne = isNetwork(options.chain.id).isArbitrumOne
+
+  // only special case for USDC is Arbitrum One
+  if (options.erc20L1Address === CommonAddress.Mainnet.USDC && isArbitrumOne) {
+    return 'Bridged USDC'
+  }
+
+  return tokenName
+}

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -239,18 +239,18 @@ export async function l1TokenIsDisabled({
   return erc20Bridger.l1TokenIsDisabled(erc20L1Address, l1Provider)
 }
 
-type SanitizeTokenSymbolOptions = {
-  erc20L1Address: string // token address
-  chain: Chain // chain for which we want to retrieve the token name
+type SanitizeTokenOptions = {
+  erc20L1Address?: string | null // token address on L1
+  chain: Chain // chain for which we want to retrieve the token name / symbol
 }
 
 // get the exact token symbol for a particular chain
 export function sanitizeTokenSymbol(
   tokenSymbol: string,
-  options?: SanitizeTokenSymbolOptions
+  options?: SanitizeTokenOptions
 ) {
   if (typeof options === 'undefined') {
-    return tokenSymbol
+    return tokenSymbol.toUpperCase()
   }
 
   const isArbitrumOne = isNetwork(options.chain.id).isArbitrumOne
@@ -260,13 +260,13 @@ export function sanitizeTokenSymbol(
     return 'USDC.e'
   }
 
-  return tokenSymbol
+  return tokenSymbol.toUpperCase()
 }
 
 // get the exact token name for a particular chain
 export function sanitizeTokenName(
   tokenName: string,
-  options?: SanitizeTokenSymbolOptions
+  options?: SanitizeTokenOptions
 ) {
   if (typeof options === 'undefined') {
     return tokenName


### PR DESCRIPTION
Extension of the PR https://github.com/OffchainLabs/arbitrum-token-bridge/pull/937
Covers all cases wherever we show USDC (symbol and name)

### Steps to test
- Log in via any account that has USDC transactions
- Search for USDC in token-search
- Check for the USDC symbol, name in Transfer panel and Tx history, they will now be chain specific.
