### PR TITLE
refactor: extract `switchNetwork` from the `transfer` method

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -388,7 +388,7 @@ export function TransferPanel() {
       await new Promise(r => setTimeout(r, 100))
     }
 
-    await new Promise(r => setTimeout(r, 3000))
+    return new Promise(r => setTimeout(r, 3000))
   }
 
   const transfer = async () => {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -350,10 +350,16 @@ export function TransferPanel() {
   }
 
   async function trySwitchNetworksBeforeTransfer() {
-    const shouldSwitchNetworks =
-      isDepositMode === latestNetworksAndSigners.current.isConnectedToArbitrum
+    function shouldSwitchNetworks() {
+      return (
+        (isDepositMode &&
+          latestNetworksAndSigners.current.isConnectedToArbitrum) ||
+        (!isDepositMode &&
+          !latestNetworksAndSigners.current.isConnectedToArbitrum)
+      )
+    }
 
-    if (!shouldSwitchNetworks) {
+    if (!shouldSwitchNetworks()) {
       return
     }
 
@@ -375,8 +381,7 @@ export function TransferPanel() {
     )
 
     while (
-      isDepositMode ===
-        latestNetworksAndSigners.current.isConnectedToArbitrum ||
+      shouldSwitchNetworks() ||
       !latestEth.current ||
       !arbTokenBridgeLoaded
     ) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -389,8 +389,6 @@ export function TransferPanel() {
     }
 
     await new Promise(r => setTimeout(r, 3000))
-
-    return
   }
 
   const transfer = async () => {

--- a/packages/arb-token-bridge-ui/src/pages/_app.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/_app.tsx
@@ -13,7 +13,6 @@ import 'tippy.js/themes/light.css'
 
 import '@rainbow-me/rainbowkit/styles.css'
 
-import Package from '../../package.json'
 import { registerLocalNetwork } from '../util/networks'
 import { Layout } from '../components/common/Layout'
 
@@ -33,7 +32,6 @@ dayjs.extend(advancedFormat)
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: Package.version,
   integrations: [new BrowserTracing()],
   tracesSampleRate: 0.15,
   beforeSend: event => {


### PR DESCRIPTION
We want to refactor the `transfer` method in the `TransferPanel` to reduce its complexity and improve readability.

As this touches crucial parts of the code, we should tackle this with small PRs.

Here, `switchNetwork` is moved to its own function.

You may notice "flickering" of the transfer panel while switching the network. It also happens in prod so it's not caused by this PR. Issue here: https://github.com/OffchainLabs/arbitrum-token-bridge/issues/949