### PR TITLE
fix: update networks when switching wallets

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -314,7 +314,13 @@ export function TransferPanelMain({
 
     // Keep the connected L2 chain id in search params, so it takes preference in any L1 => L2 actions
     setQueryParams({ l2ChainId })
-  }, [isConnectedToArbitrum, externalFrom, externalTo, setQueryParams])
+  }, [
+    isConnectedToArbitrum,
+    externalFrom,
+    externalTo,
+    setQueryParams,
+    walletAddress
+  ])
 
   const estimateGas = useCallback(
     async (


### PR DESCRIPTION
### How to test

Step 1. Click the network swapper so that you are in withdrawal mode (Metamask connected to Mainnet):
<img width="1010" alt="Screenshot 2023-06-22 at 14 46 41" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/5dc036f7-eaab-43f3-8903-eff17f096700">

Step 2. Change wallet in metamask. You will notice that you are in deposit mode (the transfer button says 'Move funds to Arbitrum One' but the UI says our origin network is Arbitrum One. The balances are flipped too, so it's just UI issue.
<img width="1010" alt="Screenshot 2023-06-22 at 14 48 44" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/710ea4ec-1047-4015-89fa-610aa41dcd2c">

### Solution
We need to update `to` and `from` states when `walletAddress` changes.
