### PR TITLE
ci: run job after e2e is successful

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -213,10 +213,16 @@ jobs:
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64
 
+  test-e2e-success:
+    name: "Test E2E Success"
+    runs-on: ubuntu-latest
+    needs: [test-e2e]
+    if: needs.test-e2e.result == 'success'
+
   clean-up:
     name: "Clean Up"
     runs-on: ubuntu-latest
-    needs: [test-ui, test-e2e]
+    needs: [test-ui]
     if: always()
     steps:
       - name: Checkout

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -218,6 +218,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-e2e]
     if: needs.test-e2e.result == 'success'
+    steps:
+      - run: echo "nice"
 
   clean-up:
     name: "Clean Up"


### PR DESCRIPTION
### Summary

Adds a new job `Test E2E Success` that runs only if all E2E tests were successful. Then we can have `Test E2E Success` be required to merge PR instead of having to list out all the E2E tests.