### PR TITLE
fix: update ETH balances when wallet changes

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -333,14 +333,14 @@ export function TransferPanelMain({
     : walletAddress
 
   const {
-    eth: [ethL1Balance, updateEthL1Balance],
+    eth: [ethL1Balance],
     erc20: [erc20L1Balances, updateErc20L1Balances]
   } = useBalance({
     provider: l1.provider,
     walletAddress: l1WalletAddress
   })
   const {
-    eth: [ethL2Balance, updateEthL2Balance],
+    eth: [ethL2Balance],
     erc20: [erc20L2Balances, updateErc20L2Balances]
   } = useBalance({
     provider: l2.provider,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -333,14 +333,14 @@ export function TransferPanelMain({
     : walletAddress
 
   const {
-    eth: [ethL1Balance],
+    eth: [ethL1Balance, updateEthL1Balance],
     erc20: [erc20L1Balances, updateErc20L1Balances]
   } = useBalance({
     provider: l1.provider,
     walletAddress: l1WalletAddress
   })
   const {
-    eth: [ethL2Balance],
+    eth: [ethL2Balance, updateEthL2Balance],
     erc20: [erc20L2Balances, updateErc20L2Balances]
   } = useBalance({
     provider: l2.provider,
@@ -360,6 +360,11 @@ export function TransferPanelMain({
     updateErc20L2Balances,
     destinationAddressOrWalletAddress
   ])
+
+  useEffect(() => {
+    updateEthL1Balance()
+    updateEthL2Balance()
+  }, [walletAddress])
 
   const isSwitchingL2Chain = useIsSwitchingL2Chain()
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -361,11 +361,6 @@ export function TransferPanelMain({
     destinationAddressOrWalletAddress
   ])
 
-  useEffect(() => {
-    updateEthL1Balance()
-    updateEthL2Balance()
-  }, [walletAddress])
-
   const isSwitchingL2Chain = useIsSwitchingL2Chain()
 
   const selectedTokenBalances = useMemo(() => {
@@ -420,7 +415,8 @@ export function TransferPanelMain({
     externalFrom,
     externalTo,
     setQueryParams,
-    walletAddress
+    l1.provider,
+    l2.provider
   ])
 
   const estimateGas = useCallback(


### PR DESCRIPTION
Issue: Network not updating in the transfer panel

Reason: `walletAddress` dependency would go to `undefined` when switching networks and trigger `useEffect`, which would override the expected network with `externalFrom` and `externalTo`