### PR TITLE
feat: add basic bot prevention for screenings endpoint

### DIFF
--- a/packages/arb-token-bridge-ui/src/pages/api/screenings.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/screenings.ts
@@ -68,7 +68,7 @@ export default async function handler(
   res: NextApiResponse<ApiResponseSuccess | ApiResponseError>
 ) {
   if (requestLooksLikeBot(req)) {
-    res.status(200).send({ blocked: true })
+    res.status(200).send({ blocked: false })
     return
   }
 

--- a/packages/arb-token-bridge-ui/src/pages/api/screenings.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/screenings.ts
@@ -47,7 +47,12 @@ function requestLooksLikeBot(req: NextApiRequest) {
   ]
 
   const userAgent = (req.headers['user-agent'] ?? '').toLowerCase()
-  return httpLibraryUserAgents.some(keyword => userAgent.includes(keyword))
+
+  return (
+    httpLibraryUserAgents
+      // Check if `user-agent` header matches any from the list of common http libraries
+      .some(value => userAgent.includes(value.toLowerCase()))
+  )
 }
 
 export type ApiResponseSuccess = {


### PR DESCRIPTION
### Summary

Adds some super basic bot prevention by checking the user agent header for common HTTP libraries. In reality, the request should always come by a user from a web browser.

### Steps to test

You can test it with Python by running `python` and then in the REPL:

```
>>> import requests
>>> requests.get("https://arbitrum-token-bridge-git-feat-bot-prevention-offchain-labs.vercel.app/api/screenings").text
'{"blocked":false}'
```

Even when you don't provide an address, your request with `python-requests` will instantly return a response.
