### PR TITLE
ci: remove `run_attempt` from artifact cache keys

### DIFF
--- a/.github/actions/build-artifacts/cache/action.yml
+++ b/.github/actions/build-artifacts/cache/action.yml
@@ -9,4 +9,4 @@ runs:
       with:
         path: |
           ./packages/arb-token-bridge-ui/build
-        key: build-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+        key: build-artifacts-${{ github.run_id }}

--- a/.github/actions/build-artifacts/restore/action.yml
+++ b/.github/actions/build-artifacts/restore/action.yml
@@ -9,5 +9,5 @@ runs:
       with:
         path: |
           ./packages/arb-token-bridge-ui/build
-        key: build-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+        key: build-artifacts-${{ github.run_id }}
         fail-on-cache-miss: true


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide some context to facilitate reviews.

  The PR title should be in lowercase and must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).

  For a work-in-progress PR,
  - add (wip) to indicate the wip status, i.e. fix(wip): a bug fix
  - please mark the PR as "Draft" if it is not ready for review
-->
### Summary

If a job depending on `cache artifact` action is failing, when rerun, it will try to restore `build-artifacts-...-2`, which doesn't exist (the artifact was cached with `build-artifacts-...-1`.

I removed the `run_attempt` at the end, so we can safely rerun failed tests depending on `cache artifact`

<!--
  Explain the **motivation** behind this change.
  What existing problem does the pull request solve?
  Any implementation details to explain?
  What code paths or UI flow do the code changes hit?
-->

### Steps to test

<!--
  How did you verify that your PR solves the issue?
  If applicable, share the steps that a reviewer should follow.
  Example: The exact commands you ran and their output, screenshots / gifs / videos if the pull request changes the UI.
-->
