### PR TITLE
fix: show USDCe for Arbitrum Goerli as well

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -271,11 +271,14 @@ export function sanitizeTokenSymbol(
     return tokenSymbol
   }
 
-  const isArbitrumOne = isNetwork(options.chain.id).isArbitrumOne
+  const { isArbitrumOne, isArbitrumGoerli } = isNetwork(options.chain.id)
 
-  if (isTokenMainnetUSDC(options.erc20L1Address)) {
-    // It should be `USDC` on all chains except Arbitrum One
-    if (isArbitrumOne) return 'USDC.e'
+  if (
+    isTokenMainnetUSDC(options.erc20L1Address) ||
+    isTokenGoerliUSDC(options.erc20L1Address)
+  ) {
+    // It should be `USDC` on all chains except Arbitrum One/Arbitrum Goerli
+    if (isArbitrumOne || isArbitrumGoerli) return 'USDC.e'
     return 'USDC'
   }
 
@@ -291,11 +294,14 @@ export function sanitizeTokenName(
     return tokenName
   }
 
-  const isArbitrumOne = isNetwork(options.chain.id).isArbitrumOne
+  const { isArbitrumOne, isArbitrumGoerli } = isNetwork(options.chain.id)
 
-  if (isTokenMainnetUSDC(options.erc20L1Address)) {
-    // It should be `USD Coin` on all chains except Arbitrum One
-    if (isArbitrumOne) return 'Bridged USDC'
+  if (
+    isTokenMainnetUSDC(options.erc20L1Address) ||
+    isTokenGoerliUSDC(options.erc20L1Address)
+  ) {
+    // It should be `USD Coin` on all chains except Arbitrum One/Arbitrum Goerli
+    if (isArbitrumOne || isArbitrumGoerli) return 'Bridged USDC'
     return 'USD Coin'
   }
 


### PR DESCRIPTION
We needed to sanitize the USDC token name and symbol for Goerli as well, it was left out since Goerli support for USDC/e came a bit after our sanitize functions.

### Before
<p float="left">
<img width="200" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/3c969d11-61ef-4d4c-b619-43a6c46fbb70">
<img width="200" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/f4b1ac05-2018-4bf9-a5db-7e0b494951cb">
</p>

### After
<p float="left">
<img width="200" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/d064dd3d-7985-481d-a84c-b147f170528f">
<img width="200" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/23fc0433-766f-4cc1-9c05-4edcaca88524">
</p>
