### PR TITLE
fix: require only connected network's signer with scw

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -373,6 +373,8 @@ export function TransferPanel() {
   }
 
   const transfer = async () => {
+    const signerUndefinedError = 'Signer is undefined'
+
     if (!isConnected) {
       return
     }
@@ -382,8 +384,8 @@ export function TransferPanel() {
       return
     }
 
-    if (!l1Signer || !l2Signer) {
-      throw 'Signer is undefined'
+    if (!isSmartContractWallet && (!l1Signer || !l2Signer)) {
+      throw signerUndefinedError
     }
 
     const destinationAddressError = await getDestinationAddressError({
@@ -414,6 +416,10 @@ export function TransferPanel() {
 
     try {
       if (isDepositMode) {
+        if (!l1Signer) {
+          throw signerUndefinedError
+        }
+
         const warningToken =
           selectedToken && warningTokens[selectedToken.address.toLowerCase()]
         if (warningToken) {
@@ -596,6 +602,10 @@ export function TransferPanel() {
           })
         }
       } else {
+        if (!l2Signer) {
+          throw signerUndefinedError
+        }
+
         if (!isConnectedToArbitrum.current) {
           if (shouldTrackAnalytics(l2NetworkName)) {
             trackEvent('Switch Network and Transfer', {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -384,7 +384,8 @@ export function TransferPanel() {
       return
     }
 
-    if (!isSmartContractWallet && (!l1Signer || !l2Signer)) {
+    const hasBothSigners = l1Signer && l2Signer
+    if (isEOA && !hasBothSigners) {
       throw signerUndefinedError
     }
 


### PR DESCRIPTION
Some external change to WC caused it to only provide an L1 signer if connected to Ethereum, and an L2 signer if connected to Arbitrum.

In our `transfer()` method we've been checking for both L1 and L2 signers, regardless of the account type. Currently SCW are throwing when trying to transfer.

We need to keep the current implementation for EOA, and only check for L1 (for deposits) and L2 (for withdrawals) when using SCW.