### PR TITLE
ci: run on merge queue

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: ["master"]
   workflow_dispatch:
+  merge_group:
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,6 +7,7 @@ on:
       - opened
       - edited
       - synchronize
+  merge_group:
 
 jobs:
   main:


### PR DESCRIPTION
https://github.com/OffchainLabs/arbitrum-token-bridge/queue/master

CI workflows are currently not running when PR joined merge queue
this should fix it

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions