### PR TITLE
feat: orbit support for network selection dropdown

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -880,7 +880,8 @@ export function TransferPanel() {
           )
 
           while (
-            isConnectedToEthereum ||
+            (!isConnectedToArbitrum.current &&
+              !isConnectedToOrbitChain.current) ||
             (isConnectedToArbitrum.current && isOrbitChain) ||
             !latestEth.current ||
             !arbTokenBridgeLoaded

--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -7,7 +7,8 @@ import {
   ChainId,
   getNetworkLogo,
   getNetworkName,
-  getSupportedNetworks
+  getSupportedNetworks,
+  isNetwork
 } from '../../util/networks'
 import { useSwitchNetworkWithConfig } from '../../hooks/useSwitchNetworkWithConfig'
 import { useAccountType } from '../../hooks/useAccountType'
@@ -23,6 +24,25 @@ export const NetworkSelectionContainer = ({
     chainId => chainId !== chain?.id
   )
   const { isSmartContractWallet } = useAccountType()
+
+  const isTestnet = chain?.id ? isNetwork(chain.id).isTestnet : false
+
+  const l1Networks = supportedNetworks.filter(
+    network => isNetwork(network).isEthereum
+  )
+  const l2Networks = supportedNetworks.filter(
+    network => isNetwork(network).isArbitrum
+  )
+
+  const orbitNetworks = supportedNetworks.filter(
+    network => isNetwork(network).isOrbitChain
+  )
+
+  const finalNetworks = [
+    { id: 'l1', title: 'L1', networks: l1Networks },
+    { id: 'l2', title: 'L2', networks: l2Networks },
+    { id: 'orbit', title: 'Orbit', networks: orbitNetworks }
+  ]
 
   const handleClick = useCallback(
     (
@@ -52,38 +72,57 @@ export const NetworkSelectionContainer = ({
       </Popover.Button>
 
       <Transition>
-        <Popover.Panel className="relative flex flex-col rounded-md lg:absolute lg:ml-1 lg:mt-1 lg:bg-white lg:shadow-[0px_4px_20px_rgba(0,0,0,0.2)]">
+        <Popover.Panel className="relative flex w-full flex-col justify-between rounded-md lg:absolute lg:ml-1 lg:mt-1 lg:w-max lg:flex-row lg:gap-3 lg:bg-white lg:p-2 lg:shadow-[0px_4px_20px_rgba(0,0,0,0.2)]">
           {({ close }) => (
             <>
-              {supportedNetworks?.map(chainId => (
-                <button
-                  key={chainId}
-                  className="flex h-12 cursor-pointer flex-nowrap items-center justify-start space-x-3 px-12 text-lg font-light text-white first:rounded-t-md last:rounded-b-md hover:bg-[rgba(0,0,0,0.2)] focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-4 lg:px-4 lg:text-base lg:font-normal lg:text-dark"
-                  onClick={() => {
-                    handleClick(chainId, close)
-                  }}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter' || e.keyCode === 13) {
-                      handleClick(chainId, close)
-                    }
-                  }}
-                  type="button"
-                  aria-label={`Switch to ${getNetworkName(Number(chainId))}`}
-                >
-                  <div className="flex h-6 w-6 items-center justify-center lg:h-8 lg:w-8">
-                    <Image
-                      src={getNetworkLogo(Number(chainId))}
-                      alt={`${getNetworkName(Number(chainId))} logo`}
-                      className="h-full w-auto"
-                      width={24}
-                      height={24}
-                    />
+              {finalNetworks.map(networkType => {
+                //if no networks present in l1/l2/l3, just don't show that column
+                if (!networkType.networks.length) return null
+
+                // else show the column with networks listed
+                return (
+                  <div key={networkType.id} className="shrink-0">
+                    {/* Only show the L1/L2/L3 title if testnet is connected */}
+                    {isTestnet && (
+                      <div className="p-2 px-12 text-xl lg:px-4">
+                        {networkType.title}
+                      </div>
+                    )}
+
+                    {networkType.networks.map(chainId => (
+                      <button
+                        key={chainId}
+                        className="flex h-10 cursor-pointer flex-nowrap items-center justify-start space-x-3 px-12 text-lg font-light text-white first:rounded-t-md hover:bg-[rgba(0,0,0,0.2)] focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-4 lg:px-4 lg:text-base lg:font-normal lg:text-dark"
+                        onClick={() => {
+                          handleClick(chainId, close)
+                        }}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter' || e.keyCode === 13) {
+                            handleClick(chainId, close)
+                          }
+                        }}
+                        type="button"
+                        aria-label={`Switch to ${getNetworkName(
+                          Number(chainId)
+                        )}`}
+                      >
+                        <div className="flex h-6 w-6 items-center justify-center lg:h-6 lg:w-6">
+                          <Image
+                            src={getNetworkLogo(Number(chainId))}
+                            alt={`${getNetworkName(Number(chainId))} logo`}
+                            className="h-full w-auto"
+                            width={24}
+                            height={24}
+                          />
+                        </div>
+                        <span className="whitespace-nowrap">
+                          {getNetworkName(Number(chainId))}
+                        </span>
+                      </button>
+                    ))}
                   </div>
-                  <span className="whitespace-nowrap">
-                    {getNetworkName(Number(chainId))}
-                  </span>
-                </button>
-              ))}
+                )
+              })}
             </>
           )}
         </Popover.Panel>

--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -35,7 +35,6 @@ export const NetworkSelectionContainer = ({
   const l2Networks = supportedNetworks.filter(
     network => isNetwork(network).isArbitrum
   )
-
   const orbitNetworks = supportedNetworks.filter(
     network => isNetwork(network).isOrbitChain
   )
@@ -45,11 +44,9 @@ export const NetworkSelectionContainer = ({
   if (l1Networks.length > 0) {
     finalNetworks.push({ id: 'l1', title: 'L1', networks: l1Networks })
   }
-
   if (l2Networks.length > 0) {
     finalNetworks.push({ id: 'l2', title: 'L2', networks: l2Networks })
   }
-
   if (orbitNetworks.length > 0) {
     finalNetworks.push({ id: 'orbit', title: 'Orbit', networks: orbitNetworks })
   }

--- a/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
@@ -52,7 +52,9 @@ export const SettingsDialog = () => {
     if (!isConnectedToTestnet) {
       setIsTestnetMode(false)
     } else {
-      warningToast('Cannot disable Testnet mode while connected to a testnet.')
+      warningToast(
+        'Cannot disable Testnet mode while connected to a testnet network'
+      )
     }
   }, [isConnectedToTestnet, setIsTestnetMode])
 

--- a/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
@@ -1,3 +1,4 @@
+import { twMerge } from 'tailwind-merge'
 import useLocalStorage from '@rehooks/local-storage'
 
 import { THEME_CONFIG, useTheme, classicThemeKey } from '../../hooks/useTheme'
@@ -8,6 +9,8 @@ import { Switch } from './atoms/Switch'
 import { SidePanel } from './SidePanel'
 import { useArbQueryParams } from '../../hooks/useArbQueryParams'
 
+export const testnetModeLocalStorageKey = 'arbitrum:bridge:settings:testnetMode'
+
 const SectionTitle = ({ children }: { children: React.ReactNode }) => (
   <div className="heading mb-4 text-lg">{children}</div>
 )
@@ -17,6 +20,9 @@ export const SettingsDialog = () => {
 
   const [isArbitrumStatsVisible, setIsArbitrumStatsVisible] =
     useLocalStorage<boolean>(statsLocalStorageKey)
+  const [isTestnetMode, setIsTestnetMode] = useLocalStorage<boolean>(
+    testnetModeLocalStorageKey
+  )
 
   const [_selectedTheme, setTheme] = useTheme()
   const selectedTheme =
@@ -28,6 +34,14 @@ export const SettingsDialog = () => {
 
   const closeArbitrumStats = () => {
     setIsArbitrumStatsVisible(false)
+  }
+
+  const enableTestnetMode = () => {
+    setIsTestnetMode(true)
+  }
+
+  const disableTestnetMode = () => {
+    setIsTestnetMode(false)
   }
 
   function closeSettings() {
@@ -75,8 +89,25 @@ export const SettingsDialog = () => {
           />
         </div>
 
-        {/* Add custom chain */}
+        {/* Show testnets toggle */}
         <div className="w-full">
+          <SectionTitle>Developer Mode</SectionTitle>
+
+          <Switch
+            label="Turn on testnet mode"
+            description="Show testnet networks and enable other testnet features."
+            checked={!!isTestnetMode}
+            onChange={isTestnetMode ? disableTestnetMode : enableTestnetMode}
+          />
+        </div>
+
+        {/* Add custom chain */}
+        <div
+          className={twMerge(
+            'w-full',
+            isTestnetMode ? '' : 'pointer-events-none opacity-20'
+          )}
+        >
           <SectionTitle>Add Testnet Orbit Chain</SectionTitle>
 
           <AddCustomChain />

--- a/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
@@ -9,7 +9,6 @@ import { AddCustomChain } from './AddCustomChain'
 import { Radio } from './atoms/Radio'
 import { Switch } from './atoms/Switch'
 import { SidePanel } from './SidePanel'
-import { Tooltip } from './Tooltip'
 import { useArbQueryParams } from '../../hooks/useArbQueryParams'
 import { isNetwork } from '../../util/networks'
 
@@ -115,22 +114,12 @@ export const SettingsDialog = () => {
         >
           <SectionTitle>Developer Mode</SectionTitle>
 
-          <Tooltip
-            content={
-              isConnectedToTestnet ? (
-                <span>
-                  Cannot disable Testnet mode if already connected to a testnet.
-                </span>
-              ) : null
-            }
-          >
-            <Switch
-              label="Turn on Testnet mode"
-              description="Show testnet networks and enable other testnet features."
-              checked={!!isTestnetMode}
-              onChange={isTestnetMode ? disableTestnetMode : enableTestnetMode}
-            />
-          </Tooltip>
+          <Switch
+            label="Turn on Testnet mode"
+            description="Show testnet networks and enable other testnet features."
+            checked={!!isTestnetMode}
+            onChange={isTestnetMode ? disableTestnetMode : enableTestnetMode}
+          />
         </div>
 
         {/* Add custom chain */}

--- a/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
@@ -11,6 +11,7 @@ import { Switch } from './atoms/Switch'
 import { SidePanel } from './SidePanel'
 import { useArbQueryParams } from '../../hooks/useArbQueryParams'
 import { isNetwork } from '../../util/networks'
+import { warningToast } from './atoms/Toast'
 
 export const testnetModeLocalStorageKey = 'arbitrum:bridge:settings:testnetMode'
 
@@ -50,6 +51,8 @@ export const SettingsDialog = () => {
     // can't turn test mode off if connected to testnet
     if (!isConnectedToTestnet) {
       setIsTestnetMode(false)
+    } else {
+      warningToast('Cannot disable Testnet mode while connected to a testnet.')
     }
   }, [isConnectedToTestnet, setIsTestnetMode])
 
@@ -109,7 +112,7 @@ export const SettingsDialog = () => {
         <div
           className={twMerge(
             'w-full',
-            isConnectedToTestnet ? 'cursor-not-allowed' : ''
+            isConnectedToTestnet ? 'cursor-not-allowed opacity-20' : ''
           )}
         >
           <SectionTitle>Developer Mode</SectionTitle>

--- a/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SettingsDialog.tsx
@@ -9,6 +9,7 @@ import { AddCustomChain } from './AddCustomChain'
 import { Radio } from './atoms/Radio'
 import { Switch } from './atoms/Switch'
 import { SidePanel } from './SidePanel'
+import { Tooltip } from './Tooltip'
 import { useArbQueryParams } from '../../hooks/useArbQueryParams'
 import { isNetwork } from '../../util/networks'
 
@@ -109,17 +110,27 @@ export const SettingsDialog = () => {
         <div
           className={twMerge(
             'w-full',
-            isConnectedToTestnet ? 'pointer-events-none' : ''
+            isConnectedToTestnet ? 'cursor-not-allowed' : ''
           )}
         >
           <SectionTitle>Developer Mode</SectionTitle>
 
-          <Switch
-            label="Turn on testnet mode"
-            description="Show testnet networks and enable other testnet features."
-            checked={!!isTestnetMode}
-            onChange={isTestnetMode ? disableTestnetMode : enableTestnetMode}
-          />
+          <Tooltip
+            content={
+              isConnectedToTestnet ? (
+                <span>
+                  Cannot disable Testnet mode if already connected to a testnet.
+                </span>
+              ) : null
+            }
+          >
+            <Switch
+              label="Turn on Testnet mode"
+              description="Show testnet networks and enable other testnet features."
+              checked={!!isTestnetMode}
+              onChange={isTestnetMode ? disableTestnetMode : enableTestnetMode}
+            />
+          </Tooltip>
         </div>
 
         {/* Add custom chain */}

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -443,16 +443,24 @@ export function getNetworkLogo(
   }
 }
 
-export function getSupportedNetworks(chainId = 0) {
+export function getSupportedNetworks(chainId = 0, includeTestnets = false) {
+  const testnetNetworks = [
+    ChainId.Goerli,
+    ChainId.ArbitrumGoerli,
+    ChainId.Sepolia,
+    ChainId.ArbitrumSepolia,
+    ...getCustomChainsFromLocalStorage().map(chain => chain.chainID)
+  ]
+
+  const mainnetNetworks = [
+    ChainId.Mainnet,
+    ChainId.ArbitrumOne,
+    ChainId.ArbitrumNova
+  ]
+
   return isNetwork(chainId).isTestnet
-    ? [
-        ChainId.Goerli,
-        ChainId.ArbitrumGoerli,
-        ChainId.Sepolia,
-        ChainId.ArbitrumSepolia,
-        ...getCustomChainsFromLocalStorage().map(chain => chain.chainID)
-      ]
-    : [ChainId.Mainnet, ChainId.ArbitrumOne, ChainId.ArbitrumNova]
+    ? [...mainnetNetworks, ...testnetNetworks]
+    : [...mainnetNetworks, ...(includeTestnets ? testnetNetworks : [])]
 }
 
 export function mapCustomChainToNetworkData(chain: ChainWithRpcUrl) {


### PR DESCRIPTION
## Before
<img width="300" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/3249b78b-eae4-44b8-bc00-cc815171a5b2">


## After

### No visible impact when connected to Mainnet.
<img width="300" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/d47e21d6-6c24-43cd-8be6-21f55c08a986">

### New layout kicks in when connected to Testnets
<img width="300" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/b72d6f60-811b-4da4-9b57-f7dd4fb5c01d">
