### PR TITLE
chore: add Stylus banner

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/Layout.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Layout.tsx
@@ -6,6 +6,7 @@ import { Header } from './Header'
 import { Footer } from './Footer'
 import { ExternalLink } from './ExternalLink'
 import { Toast } from './atoms/Toast'
+import { SiteBanner } from './SiteBanner'
 
 import 'react-toastify/dist/ReactToastify.css'
 
@@ -36,6 +37,17 @@ export function Layout(props: LayoutProps) {
       style={{ backgroundImage: 'url(/images/space.webp)' }}
       className="background-image relative flex min-h-screen flex-col overflow-hidden bg-repeat"
     >
+      <SiteBanner>
+        The Stylus testnet is officially live, build EVM-compatible apps in Rust
+        by visiting the{' '}
+        <ExternalLink
+          href="https://docs.arbitrum.io/stylus/"
+          className="arb-hover underline"
+        >
+          Stylus docs.
+        </ExternalLink>
+      </SiteBanner>
+
       <Header />
 
       <div className="bg-gradient-overlay flex min-h-[calc(100vh-80px)] flex-col">


### PR DESCRIPTION
Adds Stylus banner on the Bridge UI.

<img width="300" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/13139ed4-9898-4336-8b70-998e428cc06e">
