### PR TITLE
fix: correct the deposit countdown timer for testnets

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableDepositRow.tsx
@@ -108,12 +108,7 @@ function DepositRowTime({ tx }: { tx: MergedTransaction }) {
     tx.depositStatus === DepositStatus.L1_PENDING ||
     tx.depositStatus === DepositStatus.L2_PENDING
   ) {
-    return (
-      <DepositCountdown
-        createdAt={tx.createdAt}
-        depositStatus={tx.depositStatus}
-      />
-    )
+    return <DepositCountdown tx={tx} />
   }
 
   return (

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCardPending.tsx
@@ -60,10 +60,7 @@ export function DepositCardPending({ tx }: { tx: MergedTransaction }) {
         </div>
 
         <span className="absolute bottom-0 right-0 max-w-[100px] animate-pulse overflow-hidden text-ellipsis rounded-full bg-orange p-2 px-4 text-sm font-semibold text-ocl-blue lg:max-w-full lg:text-lg">
-          <DepositCountdown
-            createdAt={tx.createdAt}
-            depositStatus={tx.depositStatus}
-          />
+          <DepositCountdown tx={tx} />
         </span>
       </div>
     </DepositCardContainer>

--- a/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
@@ -1,6 +1,7 @@
-import dayjs, { ConfigType as DayJSConfigType } from 'dayjs'
+import dayjs from 'dayjs'
 
-import { DepositStatus } from '../../state/app/state'
+import { DepositStatus, MergedTransaction } from '../../state/app/state'
+import { isNetwork } from '../../util/networks'
 
 function getMinutesRemainingText(minutesRemaining: number): string {
   if (minutesRemaining <= 1) {
@@ -15,21 +16,29 @@ function getMinutesRemainingText(minutesRemaining: number): string {
 }
 
 export function DepositCountdown({
-  createdAt,
-  depositStatus
+  tx
 }: {
-  createdAt: DayJSConfigType
-  depositStatus?: DepositStatus
+  tx: MergedTransaction
 }): JSX.Element | null {
   const now = dayjs()
+  const createdAt = tx.createdAt
+  const depositStatus = tx.depositStatus
   const whenCreated = dayjs(createdAt)
+
+  // check the transaction belongs to which network, and on basis of that show the deposit timer
+  const { chainId, parentChainId } = tx
+  let timerMinutes = 15 // default to 15 mins
+
+  if (chainId && parentChainId && !isNetwork(parentChainId).isMainnet) {
+    timerMinutes = 1 // show only 1 minute deposit timer if this tx has nothing to do with mainnet - eg. L2 and orbit chains
+  }
 
   if (
     depositStatus === DepositStatus.L1_PENDING ||
     depositStatus === DepositStatus.L2_PENDING
   ) {
     // We expect the deposit to be completed within 15 minutes in most cases, so we subtract the diff from 15 minutes
-    const minutesRemaining = 15 - now.diff(whenCreated, 'minutes')
+    const minutesRemaining = timerMinutes - now.diff(whenCreated, 'minutes')
     return (
       <span className="whitespace-nowrap">
         {getMinutesRemainingText(minutesRemaining)}

--- a/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
@@ -26,10 +26,10 @@ export function DepositCountdown({
   const whenCreated = dayjs(createdAt)
 
   // check the transaction belongs to which network, and on basis of that show the deposit timer
-  const { chainId, parentChainId } = tx
+  const { parentChainId } = tx
   let timerMinutes = 15 // default to 15 mins
 
-  if (chainId && parentChainId && !isNetwork(parentChainId).isMainnet) {
+  if (parentChainId && !isNetwork(parentChainId).isMainnet) {
     timerMinutes = 1 // show only 1 minute deposit timer if this tx has nothing to do with mainnet - eg. L2 and orbit chains
   }
 

--- a/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
@@ -29,8 +29,18 @@ export function DepositCountdown({
   const { parentChainId } = tx
   let timerMinutes = 15 // default to 15 mins
 
-  if (parentChainId && !isNetwork(parentChainId).isMainnet) {
-    timerMinutes = 1 // show only 1 minute deposit timer if this tx has nothing to do with mainnet - eg. L2 and orbit chains
+  if (parentChainId) {
+    const { isEthereum, isTestnet } = isNetwork(parentChainId)
+
+    if (isEthereum && isTestnet) {
+      // Ethereum testnets
+      timerMinutes = 10
+    }
+
+    if (!isEthereum) {
+      // Any deposit not originating from L1
+      timerMinutes = 1
+    }
   }
 
   if (

--- a/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
@@ -25,7 +25,7 @@ export function DepositCountdown({
   const depositStatus = tx.depositStatus
   const whenCreated = dayjs(createdAt)
 
-  // check the transaction belongs to which network, and on basis of that show the deposit timer
+  // check which network the tx belongs to, and on basis of that show the deposit timer
   const { parentChainId } = tx
   let timerMinutes = 15 // default to 15 mins
 

--- a/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/DepositCountdown.tsx
@@ -47,7 +47,7 @@ export function DepositCountdown({
     depositStatus === DepositStatus.L1_PENDING ||
     depositStatus === DepositStatus.L2_PENDING
   ) {
-    // We expect the deposit to be completed within 15 minutes in most cases, so we subtract the diff from 15 minutes
+    // Subtract the diff from the initial deposit time
     const minutesRemaining = timerMinutes - now.diff(whenCreated, 'minutes')
     return (
       <span className="whitespace-nowrap">

--- a/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
@@ -89,6 +89,8 @@ export type L2ToL1EventResultPlus = L2ToL1EventResult & {
   symbol: string
   decimals: number
   nodeBlockDeadline?: NodeBlockDeadlineStatus
+  chainId?: number
+  parentChainId?: number
 }
 
 export type WithdrawalInitiated = EventArgs<WithdrawalInitiatedEvent> & {

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -66,6 +66,8 @@ export interface MergedTransaction {
   l1ToL2MsgData?: L1ToL2MessageData
   l2ToL1MsgData?: L2ToL1MessageData
   depositStatus?: DepositStatus
+  chainId?: number // tx's chain id - L2 / L3
+  parentChainId?: number // tx's parent chain - L1 / L2
   cctpData?: {
     sourceChainId: CCTPSupportedChainId
     attestationHash: `0x${string}` | null

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -66,8 +66,8 @@ export interface MergedTransaction {
   l1ToL2MsgData?: L1ToL2MessageData
   l2ToL1MsgData?: L2ToL1MessageData
   depositStatus?: DepositStatus
-  chainId?: number // tx's chain id - L2 / L3
-  parentChainId?: number // tx's parent chain - L1 / L2
+  chainId?: number // tx's chain
+  parentChainId?: number // tx's parent chain
   cctpData?: {
     sourceChainId: CCTPSupportedChainId
     attestationHash: `0x${string}` | null

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -66,8 +66,8 @@ export interface MergedTransaction {
   l1ToL2MsgData?: L1ToL2MessageData
   l2ToL1MsgData?: L2ToL1MessageData
   depositStatus?: DepositStatus
-  chainId?: number // tx's chain
-  parentChainId?: number // tx's parent chain
+  chainId?: number
+  parentChainId?: number
   cctpData?: {
     sourceChainId: CCTPSupportedChainId
     attestationHash: `0x${string}` | null

--- a/packages/arb-token-bridge-ui/src/state/app/utils.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/utils.ts
@@ -78,8 +78,8 @@ export const transformDeposits = (
       l1ToL2MsgData: tx.l1ToL2MsgData,
       l2ToL1MsgData: tx.l2ToL1MsgData,
       depositStatus: getDepositStatus(tx),
-      chainId: Number(tx.l1NetworkID),
-      parentChainId: Number(tx.l2NetworkID)
+      chainId: Number(tx.l2NetworkID),
+      parentChainId: Number(tx.l1NetworkID)
     }
   })
 }

--- a/packages/arb-token-bridge-ui/src/state/app/utils.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/utils.ts
@@ -77,7 +77,9 @@ export const transformDeposits = (
       tokenAddress: tx.tokenAddress || null,
       l1ToL2MsgData: tx.l1ToL2MsgData,
       l2ToL1MsgData: tx.l2ToL1MsgData,
-      depositStatus: getDepositStatus(tx)
+      depositStatus: getDepositStatus(tx),
+      chainId: Number(tx.l1NetworkID),
+      parentChainId: Number(tx.l2NetworkID)
     }
   })
 }
@@ -108,7 +110,9 @@ export const transformWithdrawals = (
       isWithdrawal: true,
       blockNum: tx.ethBlockNum.toNumber(),
       tokenAddress: tx.tokenAddress || null,
-      nodeBlockDeadline: tx.nodeBlockDeadline
+      nodeBlockDeadline: tx.nodeBlockDeadline,
+      chainId: tx.chainId,
+      parentChainId: tx.parentChainId
     }
   })
 }

--- a/packages/arb-token-bridge-ui/src/util/deposits/fetchDeposits.ts
+++ b/packages/arb-token-bridge-ui/src/util/deposits/fetchDeposits.ts
@@ -120,7 +120,10 @@ export const fetchDeposits = async ({
         l2NetworkID: String(l2ChainId),
         blockNumber: Number(tx.blockCreatedAt),
         timestampCreated: tx.timestamp,
-        isClassic: tx.isClassic
+        isClassic: tx.isClassic,
+
+        chainId: l2ChainId,
+        parentChainId: l1ChainId
       }
     }
   )

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/fetchWithdrawals.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/fetchWithdrawals.ts
@@ -49,6 +49,7 @@ export const fetchWithdrawals = async ({
     return []
   }
 
+  const l1ChainID = (await l1Provider.getNetwork()).chainId
   const l2ChainID = (await l2Provider.getNetwork()).chainId
 
   if (!fromBlock) {
@@ -174,5 +175,11 @@ export const fetchWithdrawals = async ({
     )
   )
 
-  return finalL2ToL1Txns
+  return finalL2ToL1Txns.map(tx => ({
+    ...tx,
+
+    // attach the chain ids to the withdrawal object
+    chainId: l2ChainID,
+    parentChainId: l1ChainID
+  }))
 }


### PR DESCRIPTION
Testnets aren't supposed to take 15-ish minutes to deposit. This PR fixes that and shows <1 minute remaining for deposits in case the transaction is not a mainnet transaction.

<img width="300" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/03de9ebe-d966-46e0-ae90-81a8e7a02dac">
