### PR TITLE
fix: Reset USDC checkboxes modals

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/USDCDeposit/USDCDepositConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/USDCDeposit/USDCDepositConfirmationDialog.tsx
@@ -40,9 +40,7 @@ export function USDCDepositConfirmationDialog(props: Props) {
   const toNetworkName = getNetworkName(to.id)
 
   useEffect(() => {
-    if (!props.isOpen) {
-      setAllCheckboxesChecked(false)
-    }
+    setAllCheckboxesChecked(false)
   }, [props.isOpen])
 
   if (!selectedToken) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/USDCDeposit/USDCDepositConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/USDCDeposit/USDCDepositConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Tab, Dialog as HeadlessUIDialog } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 
@@ -38,6 +38,12 @@ export function USDCDepositConfirmationDialog(props: Props) {
   const from = l1.network
   const to = l2.network
   const toNetworkName = getNetworkName(to.id)
+
+  useEffect(() => {
+    if (!props.isOpen) {
+      setAllCheckboxesChecked(false)
+    }
+  }, [props.isOpen])
 
   if (!selectedToken) {
     return null

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/USDCWithdrawal/USDCWithdrawalConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/USDCWithdrawal/USDCWithdrawalConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Tab, Dialog as HeadlessUIDialog } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
@@ -33,6 +33,10 @@ export function USDCWithdrawalConfirmationDialog(
   const to = l1.network
   const toNetworkName = getNetworkName(to.id)
   const tokenSymbol = SpecialTokenSymbol.USDC
+
+  useEffect(() => {
+    setAllCheckboxesChecked(false)
+  }, [props.isOpen])
 
   const fastBridges: FastBridgeInfo[] = USDCFastBridges.map(USDCFastBridge => ({
     name: USDCFastBridge.name,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide some context to facilitate reviews.

  The PR title should be in lowercase and must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).

  For a work-in-progress PR,
  - add (wip) to indicate the wip status, i.e. fix(wip): a bug fix
  - please mark the PR as "Draft" if it is not ready for review
-->

### Summary

USDC modals confirm button should be disabled when the modal is opened, and state should be updated to enabled when all checkboxes for the current tab are checked.
Currently, if all checkboxes are checked, and modal is closed, on reopening the modal, the button is enabled.

<!--
  Explain the **motivation** behind this change.
  What existing problem does the pull request solve?
  Any implementation details to explain?
  What code paths or UI flow do the code changes hit?
-->

### Steps to test

- Open USDC modals (select USDC.e, or native USDC and start a transfer)
- Check all checkboxes and close the modal (either with cancel or confirm)
- On reopening the modal, confirm button should be disabled. Checkboxes should be unchecked

<!--
  How did you verify that your PR solves the issue?
  If applicable, share the steps that a reviewer should follow.
  Example: The exact commands you ran and their output, screenshots / gifs / videos if the pull request changes the UI.
-->
