### PR TITLE
fix: hide cctp on non valid networks

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
@@ -61,6 +61,7 @@ export const TransactionHistory = ({
   const { isLoadingDeposits, depositsError: cctpDepositsError } =
     useCctpFetching({
       l1ChainId: l1.network.id,
+      l2ChainId: l2.network.id,
       walletAddress: address,
       pageSize: 10,
       pageNumber: 0,
@@ -69,6 +70,7 @@ export const TransactionHistory = ({
   const { isLoadingWithdrawals, withdrawalsError: cctpWithdrawalsError } =
     useCctpFetching({
       l1ChainId: l1.network.id,
+      l2ChainId: l2.network.id,
       walletAddress: address,
       pageSize: 10,
       pageNumber: 0,

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableCctp.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableCctp.tsx
@@ -36,6 +36,7 @@ export function TransactionsTableCctp() {
     isLoadingWithdrawals
   } = useCctpFetching({
     l1ChainId: l1.network.id,
+    l2ChainId: l2.network.id,
     walletAddress: address,
     pageSize: pageParams.pageSize,
     pageNumber: pageParams.pageNumber,

--- a/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { TransactionReceipt } from '@ethersproject/providers'
-import { useAccount, useNetwork } from 'wagmi'
+import { useAccount } from 'wagmi'
 
 import { Transaction, txnTypeToLayer } from '../../hooks/useTransactions'
 import { useActions, useAppState } from '../../state'
@@ -11,8 +11,8 @@ import { useCctpState, useUpdateCctpTransactions } from '../../state/cctpState'
 export function PendingTransactionsUpdater(): JSX.Element {
   const actions = useActions()
   const {
-    l1: { provider: l1Provider },
-    l2: { provider: l2Provider }
+    l1: { provider: l1Provider, network: l1Network },
+    l2: { provider: l2Provider, network: l2Network }
   } = useNetworksAndSigners()
   const { updateCctpTransactions } = useUpdateCctpTransactions()
 
@@ -20,16 +20,11 @@ export function PendingTransactionsUpdater(): JSX.Element {
     app: { arbTokenBridge, arbTokenBridgeLoaded }
   } = useAppState()
   const { address } = useAccount()
-  const { chain } = useNetwork()
   const { resetTransfers } = useCctpState()
 
   useEffect(() => {
     resetTransfers()
-  }, [chain?.id, resetTransfers])
-
-  useEffect(() => {
-    resetTransfers()
-  }, [address, resetTransfers])
+  }, [address, l1Network.id, l2Network.id, resetTransfers])
 
   const getTransactionReceipt = useCallback(
     (tx: Transaction) => {

--- a/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { TransactionReceipt } from '@ethersproject/providers'
-import { useAccount } from 'wagmi'
+import { useAccount, useNetwork } from 'wagmi'
 
 import { Transaction, txnTypeToLayer } from '../../hooks/useTransactions'
 import { useActions, useAppState } from '../../state'
@@ -20,7 +20,12 @@ export function PendingTransactionsUpdater(): JSX.Element {
     app: { arbTokenBridge, arbTokenBridgeLoaded }
   } = useAppState()
   const { address } = useAccount()
+  const { chain } = useNetwork()
   const { resetTransfers } = useCctpState()
+
+  useEffect(() => {
+    resetTransfers()
+  }, [chain?.id, resetTransfers])
 
   useEffect(() => {
     resetTransfers()

--- a/packages/arb-token-bridge-ui/src/state/cctpState.ts
+++ b/packages/arb-token-bridge-ui/src/state/cctpState.ts
@@ -454,7 +454,10 @@ export function useCctpFetching({
   type
 }: useCctpFetchingParams) {
   const { isMainnet: isL1Mainnet, isGoerli: isL1Goerli } = isNetwork(l1ChainId)
-  const { isArbitrumOne: isL2ArbitrumOne, isArbitrumGoerli: isL2ArbitrumGoerli } = isNetwork(l2ChainId)
+  const {
+    isArbitrumOne: isL2ArbitrumOne,
+    isArbitrumGoerli: isL2ArbitrumGoerli
+  } = isNetwork(l2ChainId)
   const isValidChainPair =
     (isL1Mainnet && isL2ArbitrumOne) || (isL1Goerli && isL2ArbitrumGoerli)
 
@@ -467,7 +470,7 @@ export function useCctpFetching({
     walletAddress,
     pageNumber,
     pageSize,
-    enabled: type !== 'withdrawals' && isValidChain
+    enabled: type !== 'withdrawals' && isValidChainPair
   })
 
   const {
@@ -479,7 +482,7 @@ export function useCctpFetching({
     walletAddress,
     pageNumber,
     pageSize,
-    enabled: type !== 'deposits' && isValidChain
+    enabled: type !== 'deposits' && isValidChainPair
   })
   const { setTransfers } = useCctpState()
 

--- a/packages/arb-token-bridge-ui/src/state/cctpState.ts
+++ b/packages/arb-token-bridge-ui/src/state/cctpState.ts
@@ -439,6 +439,7 @@ export function useUpdateCctpTransactions() {
 
 type useCctpFetchingParams = {
   l1ChainId: ChainId
+  l2ChainId: ChainId
   walletAddress: `0x${string}` | undefined
   pageSize: number
   pageNumber: number
@@ -446,11 +447,17 @@ type useCctpFetchingParams = {
 }
 export function useCctpFetching({
   l1ChainId,
+  l2ChainId,
   walletAddress,
   pageSize = 10,
   pageNumber,
   type
 }: useCctpFetchingParams) {
+  const { isMainnet, isGoerli } = isNetwork(l1ChainId)
+  const { isArbitrumOne, isArbitrumGoerli } = isNetwork(l2ChainId)
+  const isValidChain =
+    (isMainnet || isGoerli) && (isArbitrumOne || isArbitrumGoerli)
+
   const {
     data: deposits,
     isLoading: isLoadingDeposits,
@@ -460,8 +467,9 @@ export function useCctpFetching({
     walletAddress,
     pageNumber,
     pageSize,
-    enabled: type !== 'withdrawals'
+    enabled: type !== 'withdrawals' && isValidChain
   })
+
   const {
     data: withdrawals,
     isLoading: isLoadingWithdrawals,
@@ -471,7 +479,7 @@ export function useCctpFetching({
     walletAddress,
     pageNumber,
     pageSize,
-    enabled: type !== 'deposits'
+    enabled: type !== 'deposits' && isValidChain
   })
   const { setTransfers } = useCctpState()
 

--- a/packages/arb-token-bridge-ui/src/state/cctpState.ts
+++ b/packages/arb-token-bridge-ui/src/state/cctpState.ts
@@ -453,10 +453,10 @@ export function useCctpFetching({
   pageNumber,
   type
 }: useCctpFetchingParams) {
-  const { isMainnet, isGoerli } = isNetwork(l1ChainId)
-  const { isArbitrumOne, isArbitrumGoerli } = isNetwork(l2ChainId)
-  const isValidChain =
-    (isMainnet || isGoerli) && (isArbitrumOne || isArbitrumGoerli)
+  const { isMainnet: isL1Mainnet, isGoerli: isL1Goerli } = isNetwork(l1ChainId)
+  const { isArbitrumOne: isL2ArbitrumOne, isArbitrumGoerli: isL2ArbitrumGoerli } = isNetwork(l2ChainId)
+  const isValidChainPair =
+    (isL1Mainnet && isL2ArbitrumOne) || (isL1Goerli && isL2ArbitrumGoerli)
 
   const {
     data: deposits,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide some context to facilitate reviews.

  The PR title should be in lowercase and must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).

  For a work-in-progress PR,
  - add (wip) to indicate the wip status, i.e. fix(wip): a bug fix
  - please mark the PR as "Draft" if it is not ready for review
-->

### Summary

Hide CCTP tabs (and prevent fetching) non non-valid networks. CCTP should only be display on
Goerli/ArbitrumGoerli and Mainnet/ArbitrumOne. It should be hidden on other networks, and no call to API (cctp/deposits, cctp/withdrawals) should be made.

<!--
  Explain the **motivation** behind this change.
  What existing problem does the pull request solve?
  Any implementation details to explain?
  What code paths or UI flow do the code changes hit?
-->

### Steps to test

<!--
  How did you verify that your PR solves the issue?
  If applicable, share the steps that a reviewer should follow.
  Example: The exact commands you ran and their output, screenshots / gifs / videos if the pull request changes the UI.
-->
