### PR TITLE
fix: resolve issue with disabled claim button for Orbit

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableRowAction.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableRowAction.tsx
@@ -57,8 +57,7 @@ export function TransactionsTableRowAction({
   const { claim: claimCctp, isClaiming: isClaimingCctp } = useClaimCctp(tx)
   const { isConfirmed } = useRemainingTime(tx)
 
-  const { isEthereum, isArbitrumOne, isArbitrum, isArbitrumGoerli } =
-    isNetwork(chainId)
+  const { isEthereum, isArbitrum } = isNetwork(chainId)
 
   const currentChainIsValid = useMemo(() => {
     const isWithdrawalSourceOrbitChain = isNetwork(l2Network.id).isOrbitChain
@@ -69,17 +68,10 @@ export function TransactionsTableRowAction({
     }
 
     return (
-      (type === 'deposits' && (isArbitrumOne || isArbitrumGoerli)) ||
+      (type === 'deposits' && isArbitrum) ||
       (type === 'withdrawals' && isEthereum)
     )
-  }, [
-    isArbitrum,
-    isArbitrumGoerli,
-    isArbitrumOne,
-    isEthereum,
-    l2Network.id,
-    type
-  ])
+  }, [isArbitrum, isEthereum, l2Network.id, type])
 
   const isClaimButtonDisabled = useMemo(() => {
     return isClaiming || isClaimingCctp || !currentChainIsValid || !isConfirmed

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableRowAction.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableRowAction.tsx
@@ -57,10 +57,29 @@ export function TransactionsTableRowAction({
   const { claim: claimCctp, isClaiming: isClaimingCctp } = useClaimCctp(tx)
   const { isConfirmed } = useRemainingTime(tx)
 
-  const { isEthereum, isArbitrumOne, isArbitrumGoerli } = isNetwork(chainId)
-  const currentChainIsValid =
-    (type === 'deposits' && (isArbitrumOne || isArbitrumGoerli)) ||
-    (type === 'withdrawals' && isEthereum)
+  const { isEthereum, isArbitrumOne, isArbitrum, isArbitrumGoerli } =
+    isNetwork(chainId)
+
+  const currentChainIsValid = useMemo(() => {
+    const isWithdrawalSourceOrbitChain = isNetwork(l2Network.id).isOrbitChain
+
+    if (isWithdrawalSourceOrbitChain) {
+      // Enable claim if withdrawn from an Orbit chain and is connected to L2
+      return isArbitrum
+    }
+
+    return (
+      (type === 'deposits' && (isArbitrumOne || isArbitrumGoerli)) ||
+      (type === 'withdrawals' && isEthereum)
+    )
+  }, [
+    isArbitrum,
+    isArbitrumGoerli,
+    isArbitrumOne,
+    isEthereum,
+    l2Network.id,
+    type
+  ])
 
   const isClaimButtonDisabled = useMemo(() => {
     return isClaiming || isClaimingCctp || !currentChainIsValid || !isConfirmed


### PR DESCRIPTION
Only affecting the tx rows, pending cards are claimable.

Implemented the same behavior as in [the pending claimable card](https://github.com/OffchainLabs/arbitrum-token-bridge/blob/master/packages/arb-token-bridge-ui/src/components/TransferPanel/ClaimableCardConfirmed.tsx#L56)

Before:
<img width="873" alt="Screenshot 2023-09-13 at 19 57 29" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/591d9ee9-bd6f-4436-8d55-25d5250c882b">

After:
<img width="873" alt="Screenshot 2023-09-13 at 19 57 43" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/b355ebfd-09d8-46cb-a1ab-cc7d0bdcbfb5">

