### PR TITLE
refactor: base tx remaining time on tx creation date

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableClaimableRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTable/TransactionsTableClaimableRow.tsx
@@ -170,12 +170,7 @@ function ClaimableRowTime({ tx }: CommonProps) {
         {tx.isCctp ? (
           <>{remainingTime}</>
         ) : (
-          <WithdrawalCountdown
-            nodeBlockDeadline={
-              tx.nodeBlockDeadline ||
-              NodeBlockDeadlineStatusTypes.NODE_NOT_CREATED
-            }
-          />
+          <WithdrawalCountdown createdAt={tx.createdAt} />
         )}
       </div>
     )

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/ClaimableCardUnconfirmed.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/ClaimableCardUnconfirmed.tsx
@@ -99,12 +99,10 @@ export function ClaimableCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
 
         <span className="absolute bottom-0 right-0 max-w-[100px] animate-pulse overflow-hidden text-ellipsis rounded-full bg-orange p-2 px-4 text-sm font-semibold text-ocl-blue lg:max-w-full lg:text-lg">
           <span className="whitespace-nowrap">
-            {tx.nodeBlockDeadline ? (
-              <WithdrawalCountdown nodeBlockDeadline={tx.nodeBlockDeadline} />
-            ) : tx.isCctp ? (
+            {tx.isCctp ? (
               <>{remainingTime}</>
             ) : (
-              <span>Calculating...</span>
+              <WithdrawalCountdown createdAt={tx.createdAt} />
             )}
           </span>
         </span>

--- a/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
@@ -1,3 +1,4 @@
+import { useMedia } from 'react-use'
 import dayjs, { Dayjs } from 'dayjs'
 
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
@@ -52,6 +53,8 @@ export function WithdrawalCountdown({
   const {
     l1: { network: l1Network }
   } = useNetworksAndSigners()
+  const isLargeScreen = useMedia('(min-width: 1024px)')
+  const remainingTextOrEmpty = isLargeScreen ? ' remaining' : ''
 
   // For new txs createAt won't be defined yet, we default to the current time in that case
   const createdAtDate = createdAt ? dayjs(createdAt) : dayjs()
@@ -69,11 +72,17 @@ export function WithdrawalCountdown({
     // There was a date error, e.g. invalid local storage
     timeLeftText = `Estimation failed`
   } else if (daysLeft > 0) {
-    timeLeftText = `~${daysLeft} day${daysLeft === 1 ? '' : 's'}`
+    timeLeftText = `~${daysLeft} day${
+      daysLeft === 1 ? '' : 's'
+    }${remainingTextOrEmpty}`
   } else if (hoursLeft > 0) {
-    timeLeftText = `~${hoursLeft} hour${hoursLeft === 1 ? '' : 's'}`
+    timeLeftText = `~${hoursLeft} hour${
+      hoursLeft === 1 ? '' : 's'
+    }${remainingTextOrEmpty}`
   } else if (minutesLeft > 0) {
-    timeLeftText = `~${minutesLeft} minute${minutesLeft === 1 ? '' : 's'}`
+    timeLeftText = `~${minutesLeft} minute${
+      minutesLeft === 1 ? '' : 's'
+    }${remainingTextOrEmpty}`
   } else {
     timeLeftText = 'Almost there...'
   }

--- a/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
@@ -5,7 +5,7 @@ import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { ChainId } from '../../util/networks'
 
 /**
- * Buffer for after a node is confirmable but isn't yet confirmed; we give 30 minutes, should be usually/always be less in practice.
+ * Buffer for after a node is confirmable but isn't yet confirmed; we give 30 minutes, should usually/always be less in practice.
  */
 const CONFIRMATION_BUFFER_MINUTES = 30
 

--- a/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
@@ -16,14 +16,14 @@ function getTxConfirmationDate({
   createdAt: Dayjs
   parentChainId: number
 }) {
-  const confirmNodeMinutes = chainIdToConfirmNodeMinutes(parentChainId)
+  const confirmNodeMinutes = getNodeConfirmationTimeInMinutes(parentChainId)
 
   return createdAt
     .add(confirmNodeMinutes, 'minute')
     .add(CONFIRMATION_BUFFER_MINUTES, 'minute')
 }
 
-function getTxRemainingMinutes({
+function getTxConfirmationRemainingMinutes({
   createdAt,
   parentChainId
 }: {
@@ -34,7 +34,7 @@ function getTxRemainingMinutes({
   return Math.max(txConfirmationDate.diff(dayjs(), 'minute'), 0)
 }
 
-function chainIdToConfirmNodeMinutes(parentChainId: ChainId) {
+function getNodeConfirmationTimeInMinutes(parentChainId: ChainId) {
   const SEVEN_DAYS_IN_MINUTES = 7 * 24 * 60
 
   if (parentChainId === ChainId.Mainnet) {
@@ -55,14 +55,14 @@ export function WithdrawalCountdown({
   } = useNetworksAndSigners()
   const isLargeScreen = useMedia('(min-width: 1024px)')
 
-  // For new txs createAt won't be defined yet, we default to the current time in that case
+  // For new txs createdAt won't be defined yet, we default to the current time in that case
   const createdAtDate = createdAt ? dayjs(createdAt) : dayjs()
   const txConfirmationDate = getTxConfirmationDate({
     createdAt: createdAtDate,
     parentChainId: l1Network.id
   })
 
-  const minutesLeft = getTxRemainingMinutes({
+  const minutesLeft = getTxConfirmationRemainingMinutes({
     createdAt: createdAtDate,
     parentChainId: l1Network.id
   })

--- a/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
@@ -74,7 +74,7 @@ export function WithdrawalCountdown({
   const hoursLeft = Math.floor(minutesLeft / 60)
   const daysLeft = Math.floor(hoursLeft / 24)
 
-  let timeLeftText = ''
+  let timeLeftText = 'Almost there...'
 
   if (minutesLeft === -1) {
     timeLeftText = 'Estimation failed'
@@ -88,8 +88,6 @@ export function WithdrawalCountdown({
       'minute',
       remainingTextOrEmpty
     )
-  } else {
-    timeLeftText = 'Almost there...'
   }
 
   return <span>{timeLeftText}</span>

--- a/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
@@ -45,6 +45,14 @@ function chainIdToConfirmNodeMinutes(parentChainId: ChainId) {
   return 60
 }
 
+function getRemainingTimeText(
+  value: number,
+  unit: 'minute' | 'hour' | 'day',
+  remainingText: string
+) {
+  return `~${value} ${unit}${value === 1 ? '' : 's'}${remainingText}`
+}
+
 export function WithdrawalCountdown({
   createdAt
 }: {
@@ -66,23 +74,20 @@ export function WithdrawalCountdown({
   const hoursLeft = Math.floor(minutesLeft / 60)
   const daysLeft = Math.floor(hoursLeft / 24)
 
-  let timeLeftText
+  let timeLeftText = ''
 
   if (minutesLeft === -1) {
-    // There was a date error, e.g. invalid local storage
-    timeLeftText = `Estimation failed`
+    timeLeftText = 'Estimation failed'
   } else if (daysLeft > 0) {
-    timeLeftText = `~${daysLeft} day${
-      daysLeft === 1 ? '' : 's'
-    }${remainingTextOrEmpty}`
+    timeLeftText = getRemainingTimeText(daysLeft, 'day', remainingTextOrEmpty)
   } else if (hoursLeft > 0) {
-    timeLeftText = `~${hoursLeft} hour${
-      hoursLeft === 1 ? '' : 's'
-    }${remainingTextOrEmpty}`
+    timeLeftText = getRemainingTimeText(hoursLeft, 'hour', remainingTextOrEmpty)
   } else if (minutesLeft > 0) {
-    timeLeftText = `~${minutesLeft} minute${
-      minutesLeft === 1 ? '' : 's'
-    }${remainingTextOrEmpty}`
+    timeLeftText = getRemainingTimeText(
+      minutesLeft,
+      'minute',
+      remainingTextOrEmpty
+    )
   } else {
     timeLeftText = 'Almost there...'
   }


### PR DESCRIPTION
Some chains, especially testnet L2s, have very volatile block time and there's a significant inaccuracy in estimating the remaining time. Also, it's less accurate when caching these details.

Now we base the withdrawal time on tx creation date. With this we can also skip RPC calls for `firstExecutableBlock` and simply use `createdAt` from tx object (next PR)