### PR TITLE
test: fix withdrawal tests

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsFromEventLogs.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsFromEventLogs.test.ts
@@ -1,14 +1,10 @@
-import {
-  getQueryCoveringClassicOnlyWithoutResults,
-  getQueryCoveringClassicOnlyWithResults,
-  getQueryCoveringClassicAndNitroWithResults
-} from './fetchETHWithdrawalsTestHelpers'
+import { getQueryForBlock } from './fetchETHWithdrawalsTestHelpers'
 import { fetchETHWithdrawalsFromEventLogs } from '../fetchETHWithdrawalsFromEventLogs'
 
 describe('fetchETHWithdrawalsFromEventLogs', () => {
   it('fetches no ETH withdrawals from event logs pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs(
-      getQueryCoveringClassicOnlyWithoutResults()
+      getQueryForBlock(20785774)
     )
 
     expect(result).toHaveLength(0)
@@ -16,7 +12,7 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
 
   it('fetches some ETH withdrawals from event logs pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs(
-      getQueryCoveringClassicOnlyWithResults()
+      getQueryForBlock(20785772)
     )
 
     expect(result).toHaveLength(1)
@@ -30,9 +26,9 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
     )
   })
 
-  it('fetches some ETH withdrawals from event logs pre-nitro and post-nitro', async () => {
+  it('fetches some ETH withdrawals from event logs post-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs(
-      getQueryCoveringClassicAndNitroWithResults()
+      getQueryForBlock(24905369)
     )
 
     expect(result).toHaveLength(1)
@@ -40,7 +36,7 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
       expect.arrayContaining([
         expect.objectContaining({
           transactionHash:
-            '0x7378773d1af4cfbbc91179efdaf63872f8e1cb7f84e9a9511ef3f1ce6dbcb671'
+            '0xf9e53f80b90b95b940573d1a2b76d2fe240a4fe6e96272771553400d4cb17fd0'
         })
       ])
     )

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsFromEventLogs.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsFromEventLogs.test.ts
@@ -35,20 +35,12 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
       getQueryCoveringClassicAndNitroWithResults()
     )
 
-    expect(result).toHaveLength(3)
+    expect(result).toHaveLength(1)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           transactionHash:
             '0x7378773d1af4cfbbc91179efdaf63872f8e1cb7f84e9a9511ef3f1ce6dbcb671'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0xf9e53f80b90b95b940573d1a2b76d2fe240a4fe6e96272771553400d4cb17fd0'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0x021973feaad7c7813ac06a4d4cfac32455fbdf9e13cf427edcebd1bf4e5f12cf'
         })
       ])
     )

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsTestHelpers.ts
@@ -8,15 +8,6 @@ const baseQuery = {
   l2Provider
 }
 
-export function getQueryCoveringClassicOnlyWithoutResults() {
-  // keeping the block range low (not fetching from 0) to make sure we don't run into event-log deadline-exceeded error #904
-  return { ...baseQuery, fromBlock: 20780771, toBlock: 20785771 }
-}
-
-export function getQueryCoveringClassicOnlyWithResults() {
-  return { ...baseQuery, fromBlock: 20785772, toBlock: 22207816 }
-}
-
-export function getQueryCoveringClassicAndNitroWithResults() {
-  return { ...baseQuery, fromBlock: 20785772, toBlock: 21005369 }
+export function getQueryForBlock(block: number) {
+  return { ...baseQuery, fromBlock: block - 1, toBlock: block + 1 }
 }

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsTestHelpers.ts
@@ -18,5 +18,5 @@ export function getQueryCoveringClassicOnlyWithResults() {
 }
 
 export function getQueryCoveringClassicAndNitroWithResults() {
-  return { ...baseQuery, fromBlock: 20785772, toBlock: 24905369 }
+  return { ...baseQuery, fromBlock: 20785772, toBlock: 21005369 }
 }

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchTokenWithdrawalsFromEventLogs.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchTokenWithdrawalsFromEventLogs.test.ts
@@ -1,15 +1,11 @@
 import { fetchTokenWithdrawalsFromEventLogs } from '../fetchTokenWithdrawalsFromEventLogs'
-import {
-  getQueryCoveringClassicOnlyWithoutResults,
-  getQueryCoveringClassicOnlyWithResults,
-  getQueryCoveringClassicAndNitroWithResults
-} from './fetchWithdrawalsTestHelpers'
+import { getQueryForBlock } from './fetchWithdrawalsTestHelpers'
 
 describe('fetchTokenWithdrawalsFromEventLogs', () => {
   it('fetches no token withdrawals from event logs pre-nitro', async () => {
     // TODO: This is a temporary fix, when Event Logs are enabled for custom address
     // we will be able to use the same properties, and remove the need to assign sender to address
-    const query = getQueryCoveringClassicOnlyWithoutResults()
+    const query = getQueryForBlock(19416899)
     const fromAddress = query.sender
     const result = await fetchTokenWithdrawalsFromEventLogs({
       ...query,
@@ -20,7 +16,7 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
   })
 
   it('fetches some token withdrawals from event logs pre-nitro', async () => {
-    const query = getQueryCoveringClassicOnlyWithResults()
+    const query = getQueryForBlock(20961064)
     const fromAddress = query.sender
     const result = await fetchTokenWithdrawalsFromEventLogs({
       ...query,
@@ -39,7 +35,7 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
   })
 
   it('fetches some token withdrawals from event logs pre-nitro and post-nitro', async () => {
-    const query = getQueryCoveringClassicAndNitroWithResults()
+    const query = getQueryForBlock(31946015)
     const fromAddress = query.sender
     const result = await fetchTokenWithdrawalsFromEventLogs({
       ...query,

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchTokenWithdrawalsFromEventLogs.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchTokenWithdrawalsFromEventLogs.test.ts
@@ -46,13 +46,9 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
       fromAddress
     })
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(1)
     expect(result).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          txHash:
-            '0xcf38b3fe57a4d823d0dd4b4ba3792f51640a4575f7da8fb582e5006bf60bceb3'
-        }),
         expect.objectContaining({
           txHash:
             '0xbd809fa3ad466a5a88628f3f0f9fc92df4ab9d9b1bd6b3861cd87cb464a9a7c3'

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsFromSubgraph.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsFromSubgraph.test.ts
@@ -1,15 +1,11 @@
 // Covers both ETH and Token withdrawals from subgraph
 import { fetchWithdrawalsFromSubgraph } from '../fetchWithdrawalsFromSubgraph'
-import {
-  getQueryCoveringClassicOnlyWithoutResults,
-  getQueryCoveringClassicOnlyWithResults,
-  getQueryCoveringClassicAndNitroWithResults
-} from './fetchWithdrawalsTestHelpers'
+import { getQueryForBlock } from './fetchWithdrawalsTestHelpers'
 
 describe('fetchTokenWithdrawalsFromSubgraph', () => {
   it('fetches no withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchWithdrawalsFromSubgraph(
-      getQueryCoveringClassicOnlyWithoutResults()
+      getQueryForBlock(19416905)
     )
 
     expect(result).toHaveLength(0)
@@ -17,7 +13,7 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
 
   it('fetches some withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchWithdrawalsFromSubgraph(
-      getQueryCoveringClassicOnlyWithResults()
+      getQueryForBlock(20961064)
     )
 
     expect(result).toHaveLength(1)
@@ -33,7 +29,7 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
 
   it('fetches some withdrawals from subgraph pre-nitro and post-nitro', async () => {
     const result = await fetchWithdrawalsFromSubgraph(
-      getQueryCoveringClassicAndNitroWithResults()
+      getQueryForBlock(31946015)
     )
 
     expect(result).toHaveLength(1)

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsFromSubgraph.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsFromSubgraph.test.ts
@@ -20,13 +20,9 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
       getQueryCoveringClassicOnlyWithResults()
     )
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(1)
     expect(result).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          l2TxHash:
-            '0x4142fe27aa74108010135eac0c2d10bc518a1c683d7f7d3f90fa00fe383bcb25'
-        }),
         expect.objectContaining({
           l2TxHash:
             '0x98c3c3bf97f177e80ac5a5adb154208e5ad43120455e624fff917a7546273800'
@@ -40,21 +36,9 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
       getQueryCoveringClassicAndNitroWithResults()
     )
 
-    expect(result).toHaveLength(4)
+    expect(result).toHaveLength(1)
     expect(result).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          l2TxHash:
-            '0x42d860059e8f9ec897348590fc34ad48ca0daba965071a6348f2ddc9dd2132d3'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0x7eba6d30f86f39917959c55604f661f429142139473e9eaec332d65c507cb215'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0xcf38b3fe57a4d823d0dd4b4ba3792f51640a4575f7da8fb582e5006bf60bceb3'
-        }),
         expect.objectContaining({
           l2TxHash:
             '0xbd809fa3ad466a5a88628f3f0f9fc92df4ab9d9b1bd6b3861cd87cb464a9a7c3'

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
@@ -21,9 +21,9 @@ export function getQueryCoveringClassicOnlyWithoutResults() {
 }
 
 export function getQueryCoveringClassicOnlyWithResults() {
-  return { ...baseQuery, fromBlock: 19416900, toBlock: 20961064 }
+  return { ...baseQuery, fromBlock: 19916900, toBlock: 20961064 }
 }
 
 export function getQueryCoveringClassicAndNitroWithResults() {
-  return { ...baseQuery, fromBlock: 21114936, toBlock: 35108652 }
+  return { ...baseQuery, fromBlock: 29114936, toBlock: 35108652 }
 }

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
@@ -25,5 +25,5 @@ export function getQueryCoveringClassicOnlyWithResults() {
 }
 
 export function getQueryCoveringClassicAndNitroWithResults() {
-  return { ...baseQuery, fromBlock: 29114936, toBlock: 35108652 }
+  return { ...baseQuery, fromBlock: 29114936, toBlock: 32108652 }
 }

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
@@ -15,15 +15,6 @@ const baseQuery = {
   ]
 }
 
-export function getQueryCoveringClassicOnlyWithoutResults() {
-  // keeping the block range low (not fetching from 0) to make sure we don't run into event-log deadline-exceeded error #904
-  return { ...baseQuery, fromBlock: 19411899, toBlock: 19416899 }
-}
-
-export function getQueryCoveringClassicOnlyWithResults() {
-  return { ...baseQuery, fromBlock: 19916900, toBlock: 20961064 }
-}
-
-export function getQueryCoveringClassicAndNitroWithResults() {
-  return { ...baseQuery, fromBlock: 29114936, toBlock: 32108652 }
+export function getQueryForBlock(block: number) {
+  return { ...baseQuery, fromBlock: block - 1, toBlock: block + 1 }
 }


### PR DESCRIPTION
RPC timeout is more strict now, lowering the block range to only fetch around the specific block not to run into timeout issues