### PR TITLE
chore: update foundation links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Arbitrum Bridge UI Support
-    url: https://arbitrumfoundation.zendesk.com/hc/en-gb/requests/new?ticket_form_id=18155929976987
+    url: https://support.arbitrum.io/hc/en-gb/requests/new?ticket_form_id=18155929976987
     about: Please ask your specific questions here.

--- a/packages/arb-token-bridge-ui/src/constants.ts
+++ b/packages/arb-token-bridge-ui/src/constants.ts
@@ -3,23 +3,23 @@ export const TOS_VERSION = 1
 export const TOS_LOCALSTORAGE_KEY = 'arbitrum:bridge:tos-v' + TOS_VERSION
 
 export const GET_HELP_LINK =
-  'https://arbitrumfoundation.zendesk.com/hc/en-us/requests/new?ticket_form_id=18155929976987'
+  'https://support.arbitrum.io/hc/en-us/requests/new?ticket_form_id=18155929976987'
 
 export const DOCS_DOMAIN = 'https://docs.arbitrum.io'
 
 export const USDC_LEARN_MORE_LINK = `${DOCS_DOMAIN}/bridge-tokens/concepts/usdc-concept`
 
 export const FAST_BRIDGE_ARTICLE_LINK =
-  'https://arbitrumfoundation.zendesk.com/hc/en-us/articles/18213771832987'
+  'https://support.arbitrum.io/hc/en-us/articles/18213771832987'
 
 export const TOKEN_APPROVAL_ARTICLE_LINK =
-  'https://arbitrumfoundation.zendesk.com/hc/en-us/articles/18213893952923'
+  'https://support.arbitrum.io/hc/en-us/articles/18213893952923'
 
 export const ETH_BALANCE_ARTICLE_LINK =
-  'https://arbitrumfoundation.zendesk.com/hc/en-us/articles/18213854684699'
+  'https://support.arbitrum.io/hc/en-us/articles/18213854684699'
 
 export const CONFIRMATION_PERIOD_ARTICLE_LINK =
-  'https://arbitrumfoundation.zendesk.com/hc/en-us/articles/18213843096091'
+  'https://support.arbitrum.io/hc/en-us/articles/18213843096091'
 
 export const ORBIT_QUICKSTART_LINK =
   'https://docs.arbitrum.io/launch-orbit-chain/orbit-quickstart'

--- a/packages/arb-token-bridge-ui/src/constants.ts
+++ b/packages/arb-token-bridge-ui/src/constants.ts
@@ -2,24 +2,21 @@ export const TOS_VERSION = 1
 
 export const TOS_LOCALSTORAGE_KEY = 'arbitrum:bridge:tos-v' + TOS_VERSION
 
-export const GET_HELP_LINK =
-  'https://support.arbitrum.io/hc/en-us/requests/new?ticket_form_id=18155929976987'
+const SUPPORT_LINK_BASE = 'https://support.arbitrum.io'
+
+export const GET_HELP_LINK = `${SUPPORT_LINK_BASE}/hc/en-us/requests/new?ticket_form_id=18155929976987`
 
 export const DOCS_DOMAIN = 'https://docs.arbitrum.io'
 
 export const USDC_LEARN_MORE_LINK = `${DOCS_DOMAIN}/bridge-tokens/concepts/usdc-concept`
 
-export const FAST_BRIDGE_ARTICLE_LINK =
-  'https://support.arbitrum.io/hc/en-us/articles/18213771832987'
+export const FAST_BRIDGE_ARTICLE_LINK = `${SUPPORT_LINK_BASE}/hc/en-us/articles/18213771832987`
 
-export const TOKEN_APPROVAL_ARTICLE_LINK =
-  'https://support.arbitrum.io/hc/en-us/articles/18213893952923'
+export const TOKEN_APPROVAL_ARTICLE_LINK = `${SUPPORT_LINK_BASE}/hc/en-us/articles/18213893952923`
 
-export const ETH_BALANCE_ARTICLE_LINK =
-  'https://support.arbitrum.io/hc/en-us/articles/18213854684699'
+export const ETH_BALANCE_ARTICLE_LINK = `${SUPPORT_LINK_BASE}/hc/en-us/articles/18213854684699`
 
-export const CONFIRMATION_PERIOD_ARTICLE_LINK =
-  'https://support.arbitrum.io/hc/en-us/articles/18213843096091'
+export const CONFIRMATION_PERIOD_ARTICLE_LINK = `${SUPPORT_LINK_BASE}/hc/en-us/articles/18213843096091`
 
 export const ORBIT_QUICKSTART_LINK =
   'https://docs.arbitrum.io/launch-orbit-chain/orbit-quickstart'


### PR DESCRIPTION
All old foundation links redirect to support.arbitrum.io now