### PR TITLE
chore: removes max length from sentry values

### DIFF
--- a/packages/arb-token-bridge-ui/src/pages/_app.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/_app.tsx
@@ -34,6 +34,7 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   integrations: [new BrowserTracing()],
   tracesSampleRate: 0.15,
+  maxValueLength: 0,
   beforeSend: event => {
     if (event.message) {
       if (


### PR DESCRIPTION
- Sets maxValueLength to `0`, which is passed into [`truncate`](https://github.com/getsentry/sentry-javascript/blob/a57b66d48d6ba95f35f07145e6e6ae7f864280a3/packages/utils/src/string.ts#L12) so it is not truncated.
- closes #1173