### PR TITLE
fix: fixes optional catch binding error

### DIFF
--- a/packages/arb-token-bridge-ui/src/pages/index.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/index.tsx
@@ -30,14 +30,14 @@ export default function Index() {
       try {
         addCustomChain({ customChain: chain })
         mapCustomChainToNetworkData(chain)
-      } catch {
+      } catch (_) {
         // already added
       }
 
       try {
         // adding to L2 networks too to be fully compatible with the sdk
         addCustomNetwork({ customL2Network: chain })
-      } catch {
+      } catch (_) {
         // already added
       }
     })

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -8,7 +8,7 @@ export async function addressIsSmartContract(
 ) {
   try {
     return (await provider.getCode(address)).length > 2
-  } catch {
+  } catch (_) {
     return false
   }
 }

--- a/packages/arb-token-bridge-ui/src/util/RetryableUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/RetryableUtils.ts
@@ -78,7 +78,7 @@ export const getRetryableTicketExpiration = async ({
     daysUntilExpired = dayjs(expirationDate).diff(now, 'days')
 
     if (daysUntilExpired >= 0) isExpired = false
-  } catch {
+  } catch (_) {
     isLoadingError = true
   }
 


### PR DESCRIPTION
- Adds an unused parameter declaration of `_` in catch blocks in order to prevent errors in some browsers (see [caniuse for this feature](https://caniuse.com/?search=optional%20catch%20binding))
- We could also modify our `tsconfig.json` in order to build a higher compatibility bundle, but that's a much larger change. 
- closes #1181 