### PR TITLE
chore: bump sdk version to orbit

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.11",
-    "@arbitrum/sdk": "^3.1.10-beta.0",
+    "@arbitrum/sdk": "^3.1.12-orbit.1",
     "@ethersproject/providers": "^5.7.0",
     "@headlessui/react": "^1.7.8",
     "@headlessui/tailwindcss": "^0.1.2",

--- a/packages/arb-token-bridge-ui/src/pages/index.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/index.tsx
@@ -52,17 +52,6 @@ export default function Index() {
     } catch (error: any) {
       console.error(`Failed to register Xai Testnet: ${error.message}`)
     }
-
-    try {
-      addCustomNetwork({ customL2Network: stylusTestnet })
-    } catch (error: any) {
-      console.error(`Failed to register Stylus Testnet: ${error.message}`)
-    }
-    try {
-      addCustomChain({ customChain: stylusTestnet })
-    } catch (error: any) {
-      console.error(`Failed to register Stylus Testnet: ${error.message}`)
-    }
   }, [])
 
   return <App />

--- a/packages/arb-token-bridge-ui/src/pages/index.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/index.tsx
@@ -4,11 +4,7 @@ import { addCustomChain, addCustomNetwork } from '@arbitrum/sdk'
 
 import { AppConnectionFallbackContainer } from '../components/App/AppConnectionFallbackContainer'
 import { Loader } from '../components/common/atoms/Loader'
-import {
-  getCustomChainsFromLocalStorage,
-  stylusTestnet,
-  xaiTestnet
-} from '../util/networks'
+import { getCustomChainsFromLocalStorage, xaiTestnet } from '../util/networks'
 import { mapCustomChainToNetworkData } from '../util/networks'
 
 const App = dynamic(() => import('../components/App/App'), {

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -358,43 +358,6 @@ export const xaiTestnet: Chain = {
   depositTimeout: 1800000
 }
 
-export const stylusTestnet: Chain = {
-  chainID: 23011913,
-  confirmPeriodBlocks: 20,
-  ethBridge: {
-    bridge: '0x35aa95ac4747D928E2Cd42FE4461F6D9d1826346',
-    inbox: '0xe1e3b1CBaCC870cb6e5F4Bdf246feB6eB5cD351B',
-    outbox: '0x98fcA8bFF38a987B988E54273Fa228A52b62E43b',
-    rollup: '0x94db9E36d9336cD6F9FfcAd399dDa6Cc05299898',
-    sequencerInbox: '0x00A0F15b79d1D3e5991929FaAbCF2AA65623530c'
-  },
-  explorerUrl: 'https://stylus-testnet-explorer.arbitrum.io',
-  isArbitrum: true,
-  isCustom: true,
-  name: 'Stylus Testnet',
-  partnerChainID: 421614,
-  retryableLifetimeSeconds: 604800,
-  tokenBridge: {
-    l1CustomGateway: '0xd624D491A5Bc32de52a2e1481846752213bF7415',
-    l1ERC20Gateway: '0x7348Fdf6F3e090C635b23D970945093455214F3B',
-    l1GatewayRouter: '0x0057892cb8bb5f1cE1B3C6f5adE899732249713f',
-    l1MultiCall: '0xBEbe3BfBF52FFEA965efdb3f14F2101c0264c940',
-    l1ProxyAdmin: '0xB9E77732f32831f09e2a50D6E71B2Cca227544bf',
-    l1Weth: '0x980B62Da83eFf3D4576C647993b0c1D7faf17c73',
-    l1WethGateway: '0x39845e4a230434D218b907459a305eBA61A790d4',
-    l2CustomGateway: '0xF6dbB0e312dF4652d59ce405F5E00CC3430f19c5',
-    l2ERC20Gateway: '0xe027f79CE40a1eF8e47B51d0D46Dc4ea658C5860',
-    l2GatewayRouter: '0x4c3a1f7011F02Fe4769fC704359c3696a6A60D89',
-    l2Multicall: '0xEb4A260FD16aaf18c04B1aeaDFE20E622e549bd3',
-    l2ProxyAdmin: '0xE914c0d417E8250d0237d2F4827ed3612e6A9C3B',
-    l2Weth: '0x61Dc4b961D2165623A25EB775260785fE78BD37C',
-    l2WethGateway: '0x7021B4Edd9f047772242fc948441d6e0b9121175'
-  },
-  nitroGenesisBlock: 0,
-  nitroGenesisL1Block: 0,
-  depositTimeout: 900000
-}
-
 export type RegisterLocalNetworkParams = {
   l1Network: L1Network
   l2Network: L2Network

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,14 +39,15 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@arbitrum/sdk@^3.1.10-beta.0":
-  version "3.1.10-beta.0"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.1.10-beta.0.tgz#70fc8c9bd8fce737ffae8498d4987e2eea5ad93f"
-  integrity sha512-ezWIIuAy6OPeSNjHM6Rhz9d5WFnsU0tYZ9WZDhMDKGZZopnyRXB8fCY2GhqVINU9v940TQeZpwZxJfvq4vUKpQ==
+"@arbitrum/sdk@^3.1.12-orbit.1":
+  version "3.1.12-orbit.1"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.1.12-orbit.1.tgz#e0c0deecf36ae0f4c45f16111d29e35b66038bee"
+  integrity sha512-paRmiqUSXCRWXIkxiBBrIEcrxqfJaMc5bGV5d7doVhhQvyWRNE05pbQUHZoNQrKpdLN+gmS2lnD1dRXM6azFpw==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"
     "@ethersproject/bytes" "^5.0.8"
+    async-mutex "^0.4.0"
     ethers "^5.1.0"
 
 "@babel/code-frame@7.12.11":
@@ -3315,6 +3316,13 @@ async-mutex@^0.2.6:
   integrity sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==
   dependencies:
     tslib "^2.0.0"
+
+async-mutex@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.4.0.tgz#ae8048cd4d04ace94347507504b3cf15e631c25f"
+  integrity sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==
+  dependencies:
+    tslib "^2.4.0"
 
 async@^2.6.1:
   version "2.6.4"


### PR DESCRIPTION
https://github.com/OffchainLabs/arbitrum-sdk/pull/343 is the main upgrade that greatly reduces the number of outgoing rpc calls when fetching withdrawals from event logs.

It also scales and saves more requests the more pages we fetch. Some comparisons (with 5 claimable withdrawals), the number of RPC calls you see is the total number per session (including previous pages):

1st page:
<img width="87" alt="Screenshot 2023-10-05 at 14 16 47" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/1c85a3e9-6192-4e2c-b9fa-4741ed44e5ef">
vs
<img width="87" alt="Screenshot 2023-10-05 at 14 13 37" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/a792bd3a-1996-437a-b5b2-6fc4b06cb0e5">

2nd page:
<img width="87" alt="Screenshot 2023-10-05 at 14 17 14" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/2d5ded73-b771-47fb-a817-476e3ac18ad3">
vs
<img width="87" alt="Screenshot 2023-10-05 at 14 14 35" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/b5ebc5ed-0b11-47b4-9331-78b9a55202c1">

3rd page:
<img width="87" alt="Screenshot 2023-10-05 at 14 17 26" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/bc7f5963-d6c7-41ff-8e92-d0a06c3d4f39">
vs
<img width="87" alt="Screenshot 2023-10-05 at 14 16 05" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/38bf528e-7889-4a51-b025-ed4a6571e8fe">


Also, adding Stylus as a custom network was removed because it's now included in the new SDK version.