### PR TITLE
fix: Add second parameter when instantiating providers

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useNetworksAndSigners.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/useNetworksAndSigners.tsx
@@ -304,7 +304,8 @@ export function NetworksAndSignersProvider(
 
         // Web3Provider is connected to a ParentChain. We instantiate a provider for the Chain.
         const chainProvider = new StaticJsonRpcProvider(
-          rpcURLs[_selectedL2ChainId!] // _selectedL2ChainId is defined here because of L185
+          rpcURLs[_selectedL2ChainId!], // _selectedL2ChainId is defined here because of L185,
+          _selectedL2ChainId
         )
         const chain = await getChain(chainProvider)
 
@@ -319,7 +320,8 @@ export function NetworksAndSignersProvider(
         // from the ParentChain, instantiate the provider for that too
         // - done to feed into a consistent l1-l2 network-signer result state both having signer+providers
         const parentProvider = new StaticJsonRpcProvider(
-          rpcURLs[parentChain.chainID]
+          rpcURLs[parentChain.chainID],
+          parentChain.chainID
         )
 
         if (thisInvocation !== invocationCounter.current) {
@@ -353,12 +355,14 @@ export function NetworksAndSignersProvider(
           .then(async chain => {
             const parentChainId = chain.partnerChainID
             const parentProvider = new StaticJsonRpcProvider(
-              rpcURLs[parentChainId]
+              rpcURLs[parentChainId],
+              parentChainId
             )
             const parentChain = await getParentChain(parentProvider)
 
             const chainProvider = new StaticJsonRpcProvider(
-              rpcURLs[chain.chainID]
+              rpcURLs[chain.chainID],
+              chain.chainID
             )
 
             if (thisInvocation !== invocationCounter.current) {

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -1,6 +1,6 @@
 import { BigNumber, constants } from 'ethers'
 import { Chain } from 'wagmi'
-import { JsonRpcProvider, Provider } from '@ethersproject/providers'
+import { Provider } from '@ethersproject/providers'
 import { Erc20Bridger, MultiCaller } from '@arbitrum/sdk'
 import { StandardArbERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/StandardArbERC20__factory'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchETHWithdrawalsTestHelpers.ts
@@ -1,7 +1,11 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
+import { ChainId } from '../../networks'
 
 const toAddress = '0xd898275e8b9428429155752f89fe0899ce232830'
-const l2Provider = new StaticJsonRpcProvider('https://arb1.arbitrum.io/rpc')
+const l2Provider = new StaticJsonRpcProvider(
+  'https://arb1.arbitrum.io/rpc',
+  ChainId.ArbitrumOne
+)
 
 const baseQuery = {
   toAddress,

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchWithdrawalsTestHelpers.ts
@@ -1,12 +1,15 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
+import { ChainId } from '../../networks'
 
 const sender = '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299'
-const l2Provider = new StaticJsonRpcProvider('https://arb1.arbitrum.io/rpc')
-const l2ChainId = 42161
+const l2Provider = new StaticJsonRpcProvider(
+  'https://arb1.arbitrum.io/rpc',
+  ChainId.ArbitrumOne
+)
 
 const baseQuery = {
   sender,
-  l2ChainId,
+  l2ChainId: ChainId.ArbitrumOne,
   l2Provider,
   l2GatewayAddresses: [
     '0x09e9222E96E7B4AE2a407B98d48e330053351EEe', // L2 Standard Gateway

--- a/packages/arb-token-bridge-ui/synpress.config.ts
+++ b/packages/arb-token-bridge-ui/synpress.config.ts
@@ -109,8 +109,8 @@ export default defineConfig({
 const ethRpcUrl = process.env.NEXT_PUBLIC_LOCAL_ETHEREUM_RPC_URL
 const arbRpcUrl = process.env.NEXT_PUBLIC_LOCAL_ARBITRUM_RPC_URL
 
-const ethProvider = new StaticJsonRpcProvider(ethRpcUrl)
-const arbProvider = new StaticJsonRpcProvider(arbRpcUrl)
+const ethProvider = new StaticJsonRpcProvider(ethRpcUrl, 'any')
+const arbProvider = new StaticJsonRpcProvider(arbRpcUrl, 'any')
 
 if (!process.env.PRIVATE_KEY_CUSTOM) {
   throw new Error('PRIVATE_KEY_CUSTOM variable missing.')


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide some context to facilitate reviews.

  The PR title should be in lowercase and must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).

  For a work-in-progress PR,
  - add (wip) to indicate the wip status, i.e. fix(wip): a bug fix
  - please mark the PR as "Draft" if it is not ready for review
-->

### Summary

Adding `any` to the provider instantiation might cause more issues than it solve. ("but please be aware that there are many edge cases your dapp should be handling that you may not be").

See https://github.com/ethers-io/ethers.js/issues/866

<!--
  Explain the **motivation** behind this change.
  What existing problem does the pull request solve?
  Any implementation details to explain?
  What code paths or UI flow do the code changes hit?
-->

### Steps to test

<!--
  How did you verify that your PR solves the issue?
  If applicable, share the steps that a reviewer should follow.
  Example: The exact commands you ran and their output, screenshots / gifs / videos if the pull request changes the UI.
-->
