### PR TITLE
fix: outbox message not found error on claim

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -100,7 +100,7 @@ export const useArbTokenBridge = (
   params: TokenBridgeParams
 ): ArbTokenBridge => {
   const { l1, l2 } = params
-  const { address: walletAddress, connector } = useAccount()
+  const { address: walletAddress } = useAccount()
   const [bridgeTokens, setBridgeTokens] = useState<
     ContractStorage<ERC20BridgeToken> | undefined
   >(undefined)
@@ -141,14 +141,14 @@ export const useArbTokenBridge = (
   const [pendingWithdrawalsMap, setPendingWithdrawalMap] =
     useState<PendingWithdrawalsMap>({})
 
-  const l1NetworkID = useMemo(() => String(l1.network.id), [l1.network])
-  const l2NetworkID = useMemo(() => String(l2.network.id), [l2.network])
+  const l1NetworkID = useMemo(() => String(l1.network.id), [l1.network.id])
+  const l2NetworkID = useMemo(() => String(l2.network.id), [l2.network.id])
 
   // once the l1/l2/account changes, we need to revalidate the withdrawal list in the store
   // this prevents previous account/chains' transactions to show up in the current account
   // also makes sure the state of app doesn't get incrementally bloated with all accounts' txns loaded up till date
   useEffect(() => {
-    if (!l1NetworkID || !l2NetworkID || !walletAddress) {
+    if (!walletAddress) {
       return
     }
     // reset pending-withdrawal-map and re-fetch for new set of L1/L2/Account combination

--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -141,29 +141,19 @@ export const useArbTokenBridge = (
   const [pendingWithdrawalsMap, setPendingWithdrawalMap] =
     useState<PendingWithdrawalsMap>({})
 
+  const l1NetworkID = useMemo(() => String(l1.network.id), [l1.network])
+  const l2NetworkID = useMemo(() => String(l2.network.id), [l2.network])
+
   // once the l1/l2/account changes, we need to revalidate the withdrawal list in the store
   // this prevents previous account/chains' transactions to show up in the current account
   // also makes sure the state of app doesn't get incrementally bloated with all accounts' txns loaded up till date
   useEffect(() => {
-    if (!connector) {
+    if (!l1NetworkID || !l2NetworkID || !walletAddress) {
       return
     }
-
-    const resetPendingWithdrawalMap = () => {
-      setPendingWithdrawalMap({})
-    }
-
-    /**
-     * https://github.com/wagmi-dev/references/blob/7d02972803714e47a24ea9f5de33d91f384025b9/packages/connectors/src/base.ts#L13
-     * Handler is called whenever network or account change
-     */
-    connector.on('change', resetPendingWithdrawalMap)
-
-    return () => {
-      connector.off('change', resetPendingWithdrawalMap)
-    }
-  }, [connector])
-
+    // reset pending-withdrawal-map and re-fetch for new set of L1/L2/Account combination
+    setPendingWithdrawalMap({})
+  }, [l1NetworkID, l2NetworkID, walletAddress])
   const [
     transactions,
     {
@@ -180,8 +170,6 @@ export const useArbTokenBridge = (
       fetchAndUpdateEthDepositMessageStatus
     }
   ] = useTransactions()
-  const l1NetworkID = useMemo(() => String(l1.network.id), [l1.network])
-  const l2NetworkID = useMemo(() => String(l2.network.id), [l2.network])
 
   const depositEth = async ({
     amount,


### PR DESCRIPTION

Steps to reproduce:
- Load tx history on Arbitrum Goerli (L2). Withdrawal claim button should be disabled.
- Now switch the network to Goerli (L1). Withdrawal claim button is now enabled.
- Click on the newly enabled claim button - you will get the outbox message error as present in screenshot.


To successfully complete the claim process, we require the outbox message to be present in the state. (pendingWithdrawalsMap)

Tx history doesn't reload when we switch from child-to-parent chain, but we still reset the withdrawals (claims) and hence clear the outbox events loaded in the state when wagmi detects the connection change (even from child to parent network). When the claim button is pressed, we cannot find the outbox event and throw the error.

Fix: Instead of listening to wagmi connection (which changes on l1-l2 switch), we now listen to l1-l2-account combination change to reset the pendingWithdrawalsMap.

<img width="300" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/7558499/8db4bd91-97c3-4559-b045-a99af078dcb1">
