### PR TITLE
ci: use older version of nitro-testnode

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-     
+
       - id: set-matrix
         run: |
           content=`cat packages/arb-token-bridge-ui/tests/e2e/specfiles.json | jq --compact-output .`
@@ -146,7 +146,7 @@ jobs:
       matrix:
         tests:
           ${{ fromJson(needs.load-e2e-files.outputs.matrix) }}
-  
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -207,6 +207,8 @@ jobs:
 
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
+        with:
+          nitro-testnode-ref: '520f2589411d76bf2ce740c65658ee81bea433df'
 
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main


### PR DESCRIPTION
Pinning the ref for `nitro-testnode` to an older one until we add the necessary additional config to make it work.