### PR TITLE
fix: set `l2ChainId` after connection

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useNetworksAndSigners.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/useNetworksAndSigners.tsx
@@ -337,6 +337,12 @@ export function NetworksAndSignersProvider(
             provider: chainProvider
           }
         })
+
+        // set the child(l2/l3) chain id in query params so that it remembers it when switching back from parent
+        // else, the child chain will reset to default when switching back from parent
+        setQueryParams({
+          l2ChainId: getWagmiChain(chain.chainID).id
+        })
       })
       .catch(() => {
         // Web3Provider is connected to a Chain. We instantiate a provider for the ParentChain.
@@ -375,6 +381,12 @@ export function NetworksAndSignersProvider(
                 network: getWagmiChain(chain.chainID),
                 provider: chainProvider
               }
+            })
+
+            // set the child(l2/l3) chain id in query params so that it remembers it when switching back from parent
+            // else, the child chain will reset to default when switching back from parent
+            setQueryParams({
+              l2ChainId: getWagmiChain(chain.chainID).id
             })
           })
           .catch(() => {

--- a/packages/arb-token-bridge-ui/src/hooks/useNetworksAndSigners.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/useNetworksAndSigners.tsx
@@ -341,7 +341,7 @@ export function NetworksAndSignersProvider(
         // set the child(l2/l3) chain id in query params so that it remembers it when switching back from parent
         // else, the child chain will reset to default when switching back from parent
         setQueryParams({
-          l2ChainId: getWagmiChain(chain.chainID).id
+          l2ChainId: chain.chainID
         })
       })
       .catch(() => {
@@ -386,7 +386,7 @@ export function NetworksAndSignersProvider(
             // set the child(l2/l3) chain id in query params so that it remembers it when switching back from parent
             // else, the child chain will reset to default when switching back from parent
             setQueryParams({
-              l2ChainId: getWagmiChain(chain.chainID).id
+              l2ChainId: chain.chainID
             })
           })
           .catch(() => {


### PR DESCRIPTION
Currently, the child chain resets to the default when switching back from the parent chain.
Eg. when connected to `Nova <> Mainnet`, when the user connects the wallet to `Mainnet`, the pair reverts to `One <> Mainnet` in the Bridge.

This fix sets the child(l2/l3) chain id in query params to remember that when switching back from parent.
Eg. when connected to `Nova <> Mainnet`, when the user connects the wallet to `Mainnet`, the pair is preserved to `Nova <> Mainnet`.


Tested with all pairs
- Mainnet <> One / Nova
- Sepolia <> Arbitrum Sepolia <> Xai / Stylus
