### PR TITLE
refactor: rename and rearrange token utils

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
@@ -27,7 +27,7 @@ import { useChainLayers } from '../../hooks/useChainLayers'
 import { getContracts } from '../../hooks/CCTP/useCCTP'
 import {
   fetchErc20L1GatewayAddress,
-  getL2GatewayAddress
+  fetchErc20L2GatewayAddress
 } from '../../util/TokenUtils'
 import { shortenTxHash } from '../../util/CommonUtils'
 
@@ -146,7 +146,7 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
         return
       }
       setContractAddress(
-        await getL2GatewayAddress({
+        await fetchErc20L2GatewayAddress({
           erc20L1Address: token.address,
           l2Provider: l2.provider
         })

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
@@ -25,7 +25,10 @@ import {
 import { TOKEN_APPROVAL_ARTICLE_LINK } from '../../constants'
 import { useChainLayers } from '../../hooks/useChainLayers'
 import { getContracts } from '../../hooks/CCTP/useCCTP'
-import { getL1GatewayAddress, getL2GatewayAddress } from '../../util/TokenUtils'
+import {
+  fetchErc20L1GatewayAddress,
+  getL2GatewayAddress
+} from '../../util/TokenUtils'
 import { shortenTxHash } from '../../util/CommonUtils'
 
 export type TokenApprovalDialogProps = UseDialogProps & {
@@ -134,7 +137,7 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
       }
       if (isDepositMode) {
         setContractAddress(
-          await getL1GatewayAddress({
+          await fetchErc20L1GatewayAddress({
             erc20L1Address: token.address,
             l1Provider: l1.provider,
             l2Provider: l2.provider

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -41,9 +41,9 @@ import { NonCanonicalTokensBridgeInfo } from '../../util/fastBridges'
 import { tokenRequiresApprovalOnL2 } from '../../util/L2ApprovalUtils'
 import {
   getL2ERC20Address,
-  getL2GatewayAddress,
   fetchErc20Allowance,
   fetchErc20L1GatewayAddress,
+  fetchErc20L2GatewayAddress,
   isTokenArbitrumGoerliNativeUSDC,
   isTokenArbitrumOneNativeUSDC,
   isTokenGoerliUSDC,
@@ -96,7 +96,7 @@ const isAllowedL2 = async ({
 }) => {
   const token = ERC20__factory.connect(l2TokenAddress, l2Provider)
 
-  const gatewayAddress = await getL2GatewayAddress({
+  const gatewayAddress = await fetchErc20L2GatewayAddress({
     erc20L1Address: l1TokenAddress,
     l2Provider
   })

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -40,10 +40,10 @@ import { useIsSwitchingL2Chain } from './TransferPanelMainUtils'
 import { NonCanonicalTokensBridgeInfo } from '../../util/fastBridges'
 import { tokenRequiresApprovalOnL2 } from '../../util/L2ApprovalUtils'
 import {
-  getL1TokenAllowance,
   getL2ERC20Address,
   getL2GatewayAddress,
   fetchErc20Allowance,
+  fetchErc20L1GatewayAddress,
   isTokenArbitrumGoerliNativeUSDC,
   isTokenArbitrumOneNativeUSDC,
   isTokenGoerliUSDC,
@@ -786,14 +786,20 @@ export function TransferPanel() {
             }
           }
 
-          const allowance = await getL1TokenAllowance({
-            account: walletAddress,
+          const l1GatewayAddress = await fetchErc20L1GatewayAddress({
             erc20L1Address: selectedToken.address,
-            l1Provider: l1Provider,
-            l2Provider: l2Provider
+            l1Provider,
+            l2Provider
           })
 
-          if (!allowance.gte(amountRaw)) {
+          const allowanceForL1Gateway = await fetchErc20Allowance({
+            address: selectedToken.address,
+            provider: l1Provider,
+            owner: walletAddress,
+            spender: l1GatewayAddress
+          })
+
+          if (!allowanceForL1Gateway.gte(amountRaw)) {
             setAllowance(allowance)
             const waitForInput = openTokenApprovalDialog()
             const [confirmed] = await waitForInput()

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -43,7 +43,7 @@ import {
   getL1TokenAllowance,
   getL2ERC20Address,
   getL2GatewayAddress,
-  getTokenAllowanceForSpender,
+  fetchErc20Allowance,
   isTokenArbitrumGoerliNativeUSDC,
   isTokenArbitrumOneNativeUSDC,
   isTokenGoerliUSDC,
@@ -495,10 +495,10 @@ export function TransferPanel() {
       const { usdcContractAddress, tokenMessengerContractAddress } =
         getContracts(sourceChainId)
 
-      const allowance = await getTokenAllowanceForSpender({
-        account: walletAddress,
-        erc20Address: usdcContractAddress,
+      const allowance = await fetchErc20Allowance({
+        address: usdcContractAddress,
         provider: type === 'deposits' ? l1Provider : l2Provider,
+        owner: walletAddress,
         spender: tokenMessengerContractAddress
       })
 

--- a/packages/arb-token-bridge-ui/src/defaults.ts
+++ b/packages/arb-token-bridge-ui/src/defaults.ts
@@ -1,0 +1,1 @@
+export const defaultErc20Decimals = 0

--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -39,7 +39,7 @@ import { useBalance } from './useBalance'
 import {
   getL1TokenData,
   getL1ERC20Address,
-  getL2GatewayAddress,
+  fetchErc20L2GatewayAddress,
   getL2ERC20Address,
   l1TokenIsDisabled
 } from '../util/TokenUtils'
@@ -384,7 +384,7 @@ export const useArbTokenBridge = (
     if (!bridgeToken) throw new Error('Bridge token not found')
     const { l2Address } = bridgeToken
     if (!l2Address) throw new Error('L2 address not found')
-    const gatewayAddress = await getL2GatewayAddress({
+    const gatewayAddress = await fetchErc20L2GatewayAddress({
       erc20L1Address,
       l2Provider: l2.provider
     })

--- a/packages/arb-token-bridge-ui/src/util/TokenApprovalUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenApprovalUtils.ts
@@ -1,10 +1,10 @@
-import { Erc20Bridger } from '@arbitrum/sdk'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 import { MaxUint256 } from '@ethersproject/constants'
 import { Provider } from '@ethersproject/providers'
 import { BigNumber, constants, Signer } from 'ethers'
 import { getContracts } from '../hooks/CCTP/useCCTP'
 import { CCTPSupportedChainId } from '../state/cctpState'
+import { fetchErc20L1GatewayAddress } from './TokenUtils'
 
 export const approveTokenEstimateGas = async ({
   erc20L1Address,
@@ -17,12 +17,11 @@ export const approveTokenEstimateGas = async ({
   l1Provider: Provider
   l2Provider: Provider
 }) => {
-  const erc20Bridger = await Erc20Bridger.fromProvider(l2Provider)
-
-  const l1GatewayAddress = await erc20Bridger.getL1GatewayAddress(
+  const l1GatewayAddress = await fetchErc20L1GatewayAddress({
     erc20L1Address,
-    l1Provider
-  )
+    l1Provider,
+    l2Provider
+  })
 
   const contract = ERC20__factory.connect(erc20L1Address, l1Provider)
 

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -148,7 +148,7 @@ export type FetchErc20AllowanceParams = FetchErc20DataProps & {
   /**
    * Address of the spender of the ERC-20 tokens.
    */
-  spender: string | 'gateway'
+  spender: string
 }
 
 /**

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -1,4 +1,4 @@
-import { BigNumber, constants } from 'ethers'
+import { constants } from 'ethers'
 import { Chain } from 'wagmi'
 import { Provider } from '@ethersproject/providers'
 import { Erc20Bridger, MultiCaller } from '@arbitrum/sdk'
@@ -167,39 +167,6 @@ export async function fetchErc20Allowance(params: FetchErc20AllowanceParams) {
 }
 
 /**
- * Retrieves token allowance of an ERC-20 token using its L1 address.
- * @param account,
- * @param erc20L1Address,
- * @param l1Provider,
- * @param l2Provider,
- */
-export async function getL1TokenAllowance({
-  account,
-  erc20L1Address,
-  l1Provider,
-  l2Provider
-}: {
-  account: string
-  erc20L1Address: string
-  l1Provider: Provider
-  l2Provider: Provider
-}): Promise<BigNumber> {
-  const erc20Bridger = await Erc20Bridger.fromProvider(l2Provider)
-
-  const l1GatewayAddress = await erc20Bridger.getL1GatewayAddress(
-    erc20L1Address,
-    l1Provider
-  )
-
-  return fetchErc20Allowance({
-    address: erc20L1Address,
-    provider: l1Provider,
-    owner: account,
-    spender: l1GatewayAddress
-  })
-}
-
-/**
  * Retrieves data about an ERC-20 token using its L2 address. Throws if fails to retrieve balance.
  * @param erc20L2Address
  * @returns
@@ -256,7 +223,7 @@ export async function getL1ERC20Address({
 /*
  Retrieves the L1 gateway of an ERC-20 token using its L1 address.
 */
-export async function getL1GatewayAddress({
+export async function fetchErc20L1GatewayAddress({
   erc20L1Address,
   l1Provider,
   l2Provider

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -239,7 +239,7 @@ export async function fetchErc20L1GatewayAddress({
 /*
  Retrieves the L2 gateway of an ERC-20 token using its L1 address.
 */
-export async function getL2GatewayAddress({
+export async function fetchErc20L2GatewayAddress({
   erc20L1Address,
   l2Provider
 }: {

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -49,7 +49,7 @@ const setTokenDataCache = (erc20L1Address: string, tokenData: L1TokenData) => {
 export type FetchErc20DataProps = {
   /**
    * Address of the ERC-20 token contract.
-   * */
+   */
   address: string
   /**
    * Provider for the chain where the ERC-20 token contract is deployed.

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -103,11 +103,13 @@ export async function getL1TokenData({
 
   // else, call on-chain method to retrieve token data
   const contract = ERC20__factory.connect(erc20L1Address, l1Provider)
-  const erc20Bridger = await Erc20Bridger.fromProvider(l2Provider)
-  const l1GatewayAddress = await erc20Bridger.getL1GatewayAddress(
+
+  const l1GatewayAddress = await fetchErc20L1GatewayAddress({
     erc20L1Address,
-    l1Provider
-  )
+    l1Provider,
+    l2Provider
+  })
+
   const multiCaller = await MultiCaller.fromProvider(l1Provider)
   const [tokenData] = await multiCaller.getTokenData([erc20L1Address], {
     decimals: true,

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -1,6 +1,6 @@
 import { BigNumber, constants } from 'ethers'
 import { Chain } from 'wagmi'
-import { JsonRpcProvider, Provider } from '@ethersproject/providers'
+import { Provider } from '@ethersproject/providers'
 import { Erc20Bridger, MultiCaller } from '@arbitrum/sdk'
 import { StandardArbERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/StandardArbERC20__factory'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
@@ -8,6 +8,7 @@ import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__fact
 import { L1TokenData, L2TokenData } from '../hooks/arbTokenBridge.types'
 import { CommonAddress } from './CommonAddressUtils'
 import { isNetwork } from './networks'
+import { defaultErc20Decimals } from '../defaults'
 
 export function getDefaultTokenName(address: string) {
   const lowercased = address.toLowerCase()
@@ -43,6 +44,37 @@ const setTokenDataCache = (erc20L1Address: string, tokenData: L1TokenData) => {
   l1TokenDataCache[erc20L1Address] = tokenData
 
   sessionStorage.setItem('l1TokenDataCache', JSON.stringify(l1TokenDataCache))
+}
+
+export type FetchErc20DataProps = {
+  /**
+   * Address of the ERC-20 token contract.
+   * */
+  address: string
+  /**
+   * Provider for the chain where the ERC-20 token contract is deployed.
+   */
+  provider: Provider
+}
+
+export async function fetchErc20Data({
+  address,
+  provider
+}: FetchErc20DataProps) {
+  const multiCaller = await MultiCaller.fromProvider(provider)
+
+  // todo: fall back if there is no multicall?
+  const [tokenData] = await multiCaller.getTokenData([address], {
+    name: true,
+    symbol: true,
+    decimals: true
+  })
+
+  return {
+    name: tokenData?.name ?? getDefaultTokenName(address),
+    symbol: tokenData?.symbol ?? getDefaultTokenSymbol(address),
+    decimals: tokenData?.decimals ?? defaultErc20Decimals
+  }
 }
 
 /**
@@ -94,7 +126,7 @@ export async function getL1TokenData({
   const finalTokenData = {
     name: tokenData?.name ?? getDefaultTokenName(erc20L1Address),
     symbol: tokenData?.symbol ?? getDefaultTokenSymbol(erc20L1Address),
-    decimals: tokenData?.decimals ?? 0,
+    decimals: tokenData?.decimals ?? defaultErc20Decimals,
     address: contract.address
   }
 
@@ -108,27 +140,27 @@ export async function getL1TokenData({
   return finalTokenData
 }
 
+export type FetchErc20AllowanceParams = FetchErc20DataProps & {
+  /**
+   * Address of the owner of the ERC-20 tokens.
+   */
+  owner: string
+  /**
+   * Address of the spender of the ERC-20 tokens.
+   */
+  spender: string | 'gateway'
+}
+
 /**
- * Retrieves token allowance for a given contract of an ERC-20 token using its L1/L2 address.
- * @param account,
- * @param erc20Address,
- * @param provider,
- * @param spender
+ * Fetches allowance for an ERC-20 token.
  */
-export async function getTokenAllowanceForSpender({
-  account,
-  erc20Address,
-  spender,
-  provider
-}: {
-  account: string
-  erc20Address: string
-  spender: string
-  provider: Provider
-}) {
+export async function fetchErc20Allowance(params: FetchErc20AllowanceParams) {
+  const { address, provider, owner, spender } = params
+
+  // todo: fall back if there is no multicall?
   const multiCaller = await MultiCaller.fromProvider(provider)
-  const [tokenData] = await multiCaller.getTokenData([erc20Address], {
-    allowance: { owner: account, spender }
+  const [tokenData] = await multiCaller.getTokenData([address], {
+    allowance: { owner, spender }
   })
 
   return tokenData?.allowance ?? constants.Zero
@@ -158,10 +190,11 @@ export async function getL1TokenAllowance({
     erc20L1Address,
     l1Provider
   )
-  return getTokenAllowanceForSpender({
-    account,
-    erc20Address: erc20L1Address,
+
+  return fetchErc20Allowance({
+    address: erc20L1Address,
     provider: l1Provider,
+    owner: account,
     spender: l1GatewayAddress
   })
 }


### PR DESCRIPTION
### Summary

* Renamed `getTokenAllowanceForSpender` to `fetchErc20Allowance`
  * Made the parameters more aligned with the actual contract method parameters
* Removed `getL1TokenAllowance`
  * It was used only once, and it confused me, as I thought it could fetch allowance for any spender, but the spender was hard-coded to the L1 gateway
  * Now we just use `fetchErc20Allowance` and we fetch the L1 gateway address right before that
* Renamed `getL1GatewayAddress` to `fetchErc20L1GatewayAddress`
* Renamed `getL2GatewayAddress` to `fetchErc20L2GatewayAddress`
  * Changed prefix to `fetch` as imo it's more intuitive that it's doing some async fetch
* Created `fetchErc20Data` to fetch `name`, `symbol` and `decimals` for a token
  * Currently unused, but will be used in the custom fee token pull request

### Steps to test

Everything should work the same.
