### PR TITLE
fix: show error message on Orbit connection failure

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useNetworksAndSigners.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/useNetworksAndSigners.tsx
@@ -30,10 +30,16 @@ import * as Sentry from '@sentry/react'
 
 import { useIsConnectedToOrbitChain } from './useIsConnectedToOrbitChain'
 import { useIsConnectedToArbitrum } from './useIsConnectedToArbitrum'
-import { chainIdToDefaultL2ChainId, isNetwork, rpcURLs } from '../util/networks'
+import {
+  chainIdToDefaultL2ChainId,
+  getNetworkName,
+  isNetwork,
+  rpcURLs
+} from '../util/networks'
 import { getWagmiChain } from '../util/wagmi/getWagmiChain'
 import { useArbQueryParams } from './useArbQueryParams'
 import { trackEvent } from '../util/AnalyticsUtils'
+import { errorToast } from '../components/common/atoms/Toast'
 
 import { TOS_LOCALSTORAGE_KEY } from '../constants'
 
@@ -344,7 +350,7 @@ export function NetworksAndSignersProvider(
           l2ChainId: chain.chainID
         })
       })
-      .catch(() => {
+      .catch(error => {
         // Web3Provider is connected to a Chain. We instantiate a provider for the ParentChain.
         if (providerChainId !== _selectedL2ChainId && !isConnectedToArbitrum) {
           // Make sure the Chain provider chainid match the selected chainid
@@ -355,6 +361,14 @@ export function NetworksAndSignersProvider(
           })
           return
         }
+
+        // show a toast message if connecting to the valid network resulted in failure
+        if (_selectedL2ChainId && error && error.event === 'noNetwork') {
+          errorToast(
+            `Failed to connect to ${getNetworkName(_selectedL2ChainId)}.`
+          )
+        }
+
         getChain(provider as Web3Provider)
           .then(async chain => {
             const parentChainId = chain.partnerChainID


### PR DESCRIPTION
Currently if the user is trying to connect to an Orbit network without properly setting up the node, we don't show any warning. This PR does that to improve dev-experience.