### PR TITLE
feat: fall back to hard-coded values for gas estimates

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -131,6 +131,9 @@ export function useGasSummary(
         if (isDepositMode) {
           if (token) {
             const estimateGasResult = await depositTokenEstimateGas({
+              amount,
+              address: walletAddress,
+              erc20L1Address: token.address,
               l1Provider: l1.provider,
               l2Provider: l2.provider
             })

--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -88,8 +88,8 @@ export async function depositTokenEstimateGas(
   const erc20Bridger = await Erc20Bridger.fromProvider(l2Provider)
 
   if (await allowanceForL1GatewayIsInsufficient(params)) {
-    console.log(
-      'L1 gateway allowance for token being deposited is too low, falling back to hardcoded estimates.'
+    console.warn(
+      `Gateway allowance for "${erc20L1Address}" is too low, falling back to hardcoded values.`
     )
 
     return fetchFallbackGasEstimates({

--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -108,7 +108,7 @@ export async function depositTokenEstimateGas(
 
   return {
     estimatedL1Gas: await l1Provider.estimateGas(txRequest),
-    estimatedL2Gas: retryableData.gasLimit.mul(retryableData.maxFeePerGas),
+    estimatedL2Gas: retryableData.gasLimit,
     estimatedL2SubmissionCost: retryableData.maxSubmissionCost
   }
 }

--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -1,4 +1,4 @@
-import { Erc20Bridger, getL2Network } from '@arbitrum/sdk'
+import { Erc20Bridger } from '@arbitrum/sdk'
 import { Inbox__factory } from '@arbitrum/sdk/dist/lib/abi/factories/Inbox__factory'
 import { Provider } from '@ethersproject/providers'
 import { BigNumber } from 'ethers'
@@ -6,13 +6,13 @@ import { BigNumber } from 'ethers'
 import { DepositGasEstimates } from '../hooks/arbTokenBridge.types'
 import { fetchErc20Allowance, fetchErc20L1GatewayAddress } from './TokenUtils'
 
-async function getHardcodedEstimates({
+async function fetchFallbackGasEstimates({
   inboxAddress,
   l1Provider
 }: {
   inboxAddress: string
   l1Provider: Provider
-}) {
+}): Promise<DepositGasEstimates> {
   const l1BaseFee = await l1Provider.getGasPrice()
   const inbox = Inbox__factory.connect(inboxAddress, l1Provider)
 
@@ -81,8 +81,11 @@ export async function depositTokenEstimateGas({
   })
 
   if (allowanceForL1Gateway.lt(amount)) {
-    console.log('Gateway allowance too low, using hardcoded estimates.')
-    return getHardcodedEstimates({
+    console.log(
+      'L1 gateway allowance for token being deposited is too low, falling back to hardcoded estimates.'
+    )
+
+    return fetchFallbackGasEstimates({
       inboxAddress: erc20Bridger.l2Network.ethBridge.inbox,
       l1Provider
     })

--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -1,21 +1,20 @@
-import { getL2Network } from '@arbitrum/sdk'
+import { Erc20Bridger, getL2Network } from '@arbitrum/sdk'
 import { Inbox__factory } from '@arbitrum/sdk/dist/lib/abi/factories/Inbox__factory'
 import { Provider } from '@ethersproject/providers'
 import { BigNumber } from 'ethers'
-import { DepositGasEstimates } from '../hooks/arbTokenBridge.types'
 
-export async function depositTokenEstimateGas({
-  l1Provider,
-  l2Provider
+import { DepositGasEstimates } from '../hooks/arbTokenBridge.types'
+import { fetchErc20Allowance, fetchErc20L1GatewayAddress } from './TokenUtils'
+
+async function getHardcodedEstimates({
+  inboxAddress,
+  l1Provider
 }: {
+  inboxAddress: string
   l1Provider: Provider
-  l2Provider: Provider
-}): Promise<DepositGasEstimates> {
-  const [l1BaseFee, l2Network] = await Promise.all([
-    l1Provider.getGasPrice(),
-    getL2Network(l2Provider)
-  ])
-  const inbox = Inbox__factory.connect(l2Network.ethBridge.inbox, l1Provider)
+}) {
+  const l1BaseFee = await l1Provider.getGasPrice()
+  const inbox = Inbox__factory.connect(inboxAddress, l1Provider)
 
   const estimatedL2SubmissionCost = await inbox.calculateRetryableSubmissionFee(
     // Values set by looking at a couple of L1 gateways
@@ -50,5 +49,57 @@ export async function depositTokenEstimateGas({
     // https://arbiscan.io/tx/0x6b13bfe9f22640ac25f77a677a3c36e748913d5e07766b3d6394de09a1398020
     estimatedL2Gas: BigNumber.from(100_000),
     estimatedL2SubmissionCost
+  }
+}
+
+export async function depositTokenEstimateGas({
+  amount,
+  address,
+  erc20L1Address,
+  l1Provider,
+  l2Provider
+}: {
+  amount: BigNumber
+  address: string
+  erc20L1Address: string
+  l1Provider: Provider
+  l2Provider: Provider
+}): Promise<DepositGasEstimates> {
+  const erc20Bridger = await Erc20Bridger.fromProvider(l2Provider)
+
+  const l1Gateway = await fetchErc20L1GatewayAddress({
+    erc20L1Address,
+    l1Provider,
+    l2Provider
+  })
+
+  const allowanceForL1Gateway = await fetchErc20Allowance({
+    address: erc20L1Address,
+    provider: l1Provider,
+    owner: address,
+    spender: l1Gateway
+  })
+
+  if (allowanceForL1Gateway.lt(amount)) {
+    console.log('Gateway allowance too low, using hardcoded estimates.')
+    return getHardcodedEstimates({
+      inboxAddress: erc20Bridger.l2Network.ethBridge.inbox,
+      l1Provider
+    })
+  }
+
+  const depositRequest = await erc20Bridger.getDepositRequest({
+    amount,
+    erc20L1Address,
+    l1Provider,
+    l2Provider,
+    from: address
+  })
+
+  return {
+    estimatedL1Gas: await l1Provider.estimateGas(depositRequest.txRequest),
+    // todo:fix
+    estimatedL2Gas: BigNumber.from(0),
+    estimatedL2SubmissionCost: BigNumber.from(0)
   }
 }

--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -91,7 +91,7 @@ export async function depositTokenEstimateGas({
     })
   }
 
-  const depositRequest = await erc20Bridger.getDepositRequest({
+  const { txRequest, retryableData } = await erc20Bridger.getDepositRequest({
     amount,
     erc20L1Address,
     l1Provider,
@@ -100,9 +100,8 @@ export async function depositTokenEstimateGas({
   })
 
   return {
-    estimatedL1Gas: await l1Provider.estimateGas(depositRequest.txRequest),
-    // todo:fix
-    estimatedL2Gas: BigNumber.from(0),
-    estimatedL2SubmissionCost: BigNumber.from(0)
+    estimatedL1Gas: await l1Provider.estimateGas(txRequest),
+    estimatedL2Gas: retryableData.gasLimit.mul(retryableData.maxFeePerGas),
+    estimatedL2SubmissionCost: retryableData.maxSubmissionCost
   }
 }


### PR DESCRIPTION
### Summary

Currently, we have hard-coded values for token deposit gas estimates, which can be a problem for Orbit chains as the gas limit changes due to the changes in L1 base fee. The reason we had this hard-coding in the first place is not being able to show gas estimates for tokens that the user still hasn't approved to be spent by the gateway. This PR adds a check for that allowance, and falls back to the hard-coded values. Otherwise, we use the actual gas estimates.

The actual transactions were still using the gas estimates from the Arbitrum SDK, so this will just reduce the discrepancy between what was displayed in the gas summary and what the actual transaction had.

It also lays the groundwork for:
  - Showing gas summary even when no wallet is connected
  - Checking allowance for custom fee token

### Steps to test

The user shouldn't really notice much, except for a difference in gas summary values after they approve the token.