### PR TITLE
fix: display correct card details for Orbit withdrawals

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/ClaimableCardUnconfirmed.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/ClaimableCardUnconfirmed.tsx
@@ -32,7 +32,6 @@ export function ClaimableCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
   }
 
   const networkName = getNetworkName(toNetworkId)
-  const { isEthereum: isWithdrawal } = isNetwork(toNetworkId)
 
   const isOrbitChainSelected = isNetwork(l2.network.id).isOrbitChain
 
@@ -40,9 +39,9 @@ export function ClaimableCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
     () =>
       sanitizeTokenSymbol(tx.asset, {
         erc20L1Address: tx.tokenAddress,
-        chain: isWithdrawal ? l2.network : l1.network
+        chain: tx.isWithdrawal ? l2.network : l1.network
       }),
-    [tx.asset, tx.tokenAddress, isWithdrawal, l1.network, l2.network]
+    [tx.asset, tx.tokenAddress, tx.isWithdrawal, l1.network, l2.network]
   )
 
   const { remainingTime } = useRemainingTime(tx)
@@ -62,7 +61,7 @@ export function ClaimableCardUnconfirmed({ tx }: { tx: MergedTransaction }) {
 
           <div className="h-2" />
           <div className="flex flex-col font-light">
-            {isWithdrawal ? (
+            {tx.isWithdrawal ? (
               <>
                 <span className="flex flex-nowrap gap-1 text-sm text-ocl-blue lg:text-base">
                   {layer} transaction: <WithdrawalL2TxStatus tx={tx} />


### PR DESCRIPTION
![image](https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/4d0d6296-d850-45c4-bc3b-8bad715b6479)

Wrong transaction IDs are shown when withdrawing from Orbit chains because deposit card details were shown instead.

Closes https://github.com/OffchainLabs/arbitrum-token-bridge/issues/1121