### PR TITLE
refactor: clean up utils for fetching erc-20 data

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
@@ -99,11 +99,13 @@ export function TokenImportDialog({
       return
     }
 
-    if (!(await isValidErc20({ address: l1Address, provider: l1.provider }))) {
-      throw new Error(`${l1Address} is not a valid ERC-20 token}`)
+    const erc20Params = { address: l1Address, provider: l1.provider }
+
+    if (!(await isValidErc20(erc20Params))) {
+      throw new Error(`${l1Address} is not a valid ERC-20 token`)
     }
 
-    return fetchErc20Data({ address: l1Address, provider: l1.provider })
+    return fetchErc20Data(erc20Params)
   }, [l1, walletAddress, l1Address])
 
   const searchForTokenInLists = useCallback(

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
@@ -12,16 +12,15 @@ import { useERC20L1Address } from '../../hooks/useERC20L1Address'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { useActions, useAppState } from '../../state'
 import { getExplorerUrl } from '../../util/networks'
-import { getL1TokenData } from '../../util/TokenUtils'
+import {
+  erc20DataToErc20BridgeToken,
+  fetchErc20Data
+} from '../../util/TokenUtils'
 import { Loader } from '../common/atoms/Loader'
 import { Dialog, UseDialogProps } from '../common/Dialog'
 import { SafeImage } from '../common/SafeImage'
 import GrumpyCat from '@/images/grumpy-cat.webp'
-import {
-  toERC20BridgeToken,
-  useTokensFromLists,
-  useTokensFromUser
-} from './TokenSearchUtils'
+import { useTokensFromLists, useTokensFromUser } from './TokenSearchUtils'
 import { ERC20BridgeToken } from '../../hooks/arbTokenBridge.types'
 import { warningToast } from '../common/atoms/Toast'
 
@@ -99,13 +98,8 @@ export function TokenImportDialog({
       return
     }
 
-    return getL1TokenData({
-      account: walletAddress,
-      erc20L1Address: l1Address,
-      l1Provider: l1.provider,
-      l2Provider: l2.provider
-    })
-  }, [l1, l2, walletAddress, l1Address])
+    return fetchErc20Data({ address: l1Address, provider: l1.provider })
+  }, [l1, walletAddress, l1Address])
 
   const searchForTokenInLists = useCallback(
     (erc20L1Address: string): TokenListSearchResult => {
@@ -186,7 +180,7 @@ export function TokenImportDialog({
 
         // We couldn't find the address within our lists
         setStatus(ImportStatus.UNKNOWN)
-        setTokenToImport(toERC20BridgeToken(data))
+        setTokenToImport(erc20DataToErc20BridgeToken(data))
       })
       .catch(() => {
         setStatus(ImportStatus.ERROR)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
@@ -14,7 +14,8 @@ import { useActions, useAppState } from '../../state'
 import { getExplorerUrl } from '../../util/networks'
 import {
   erc20DataToErc20BridgeToken,
-  fetchErc20Data
+  fetchErc20Data,
+  isValidErc20
 } from '../../util/TokenUtils'
 import { Loader } from '../common/atoms/Loader'
 import { Dialog, UseDialogProps } from '../common/Dialog'
@@ -96,6 +97,10 @@ export function TokenImportDialog({
   const getL1TokenDataFromL1Address = useCallback(async () => {
     if (!l1Address || !walletAddress) {
       return
+    }
+
+    if (!(await isValidErc20({ address: l1Address, provider: l1.provider }))) {
+      throw new Error(`${l1Address} is not a valid ERC-20 token}`)
     }
 
     return fetchErc20Data({ address: l1Address, provider: l1.provider })

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -19,16 +19,13 @@ import {
   SPECIAL_ARBITRUM_TOKEN_TOKEN_LIST_ID
 } from '../../util/TokenListUtils'
 import {
-  getL1TokenData,
+  fetchErc20Data,
+  erc20DataToErc20BridgeToken,
   isTokenArbitrumOneNativeUSDC,
   isTokenArbitrumGoerliNativeUSDC
 } from '../../util/TokenUtils'
 import { Button } from '../common/Button'
-import {
-  useTokensFromLists,
-  useTokensFromUser,
-  toERC20BridgeToken
-} from './TokenSearchUtils'
+import { useTokensFromLists, useTokensFromUser } from './TokenSearchUtils'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import { useBalance } from '../../hooks/useBalance'
 import { ERC20BridgeToken, TokenType } from '../../hooks/arbTokenBridge.types'
@@ -469,8 +466,7 @@ export function TokenSearch({
   } = useActions()
   const { l1, l2 } = useNetworksAndSigners()
   const { updateUSDCBalances } = useUpdateUSDCBalances({ walletAddress })
-  const { isSmartContractWallet, isLoading: isLoadingAccountType } =
-    useAccountType()
+  const { isLoading: isLoadingAccountType } = useAccountType()
 
   const { isValidating: isFetchingTokenLists } = useTokenLists(l2.network.id) // to show a small loader while token-lists are loading when search panel opens
 
@@ -525,17 +521,15 @@ export function TokenSearch({
         return
       }
 
-      const data = await getL1TokenData({
-        account: walletAddress,
-        erc20L1Address: _token.address,
-        l1Provider: l1.provider,
-        l2Provider: l2.provider
+      const data = await fetchErc20Data({
+        address: _token.address,
+        provider: l1.provider
       })
 
       if (data) {
         token.updateTokenData(_token.address)
         setSelectedToken({
-          ...toERC20BridgeToken(data),
+          ...erc20DataToErc20BridgeToken(data),
           l2Address: _token.l2Address
         })
       }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
@@ -4,7 +4,6 @@ import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 import {
   ContractStorage,
   ERC20BridgeToken,
-  L1TokenData,
   TokenType
 } from '../../hooks/arbTokenBridge.types'
 import { useTokenLists } from '../../hooks/useTokenLists'
@@ -139,15 +138,4 @@ function tokenListsToSearchableTokenStorage(
     },
     {}
   )
-}
-
-export function toERC20BridgeToken(data: L1TokenData): ERC20BridgeToken {
-  return {
-    name: data.name,
-    type: TokenType.ERC20,
-    symbol: data.symbol,
-    address: data.address,
-    decimals: data.decimals,
-    listIds: new Set()
-  }
 }

--- a/packages/arb-token-bridge-ui/src/components/common/AddCustomChain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/AddCustomChain.tsx
@@ -19,7 +19,7 @@ import {
   rpcURLs
 } from '../../util/networks'
 import { Loader } from './atoms/Loader'
-import { fetchErc20Data } from '../../util/TokenUtils'
+import { Erc20Data, fetchErc20Data } from '../../util/TokenUtils'
 
 type Contracts = {
   customGateway: string
@@ -170,12 +170,11 @@ function mapOrbitConfigToOrbitChain(data: OrbitConfig): ChainWithRpcUrl {
   }
 }
 
-async function fetchNativeToken(data: OrbitConfig): Promise<
+async function fetchNativeToken(
+  data: OrbitConfig
+): Promise<
   | { nativeToken: undefined; nativeTokenData: undefined }
-  | {
-      nativeToken: string
-      nativeTokenData: { name: string; symbol: string; decimals: number }
-    }
+  | { nativeToken: string; nativeTokenData: Erc20Data }
 > {
   const nativeToken = data.chainInfo.nativeToken
   const nativeTokenIsEther =

--- a/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/arbTokenBridge.types.ts
@@ -117,13 +117,6 @@ export interface ERC20BridgeToken extends BridgeToken {
   decimals: number
 }
 
-export interface L1TokenData {
-  name: string
-  symbol: string
-  decimals: number
-  address: string
-}
-
 export interface L2TokenData {
   balance: BigNumber
   contract: StandardArbERC20

--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -41,7 +41,8 @@ import {
   getL1ERC20Address,
   fetchErc20L2GatewayAddress,
   getL2ERC20Address,
-  l1TokenIsDisabled
+  l1TokenIsDisabled,
+  isValidErc20
 } from '../util/TokenUtils'
 import { getL2NativeToken } from '../util/L2NativeUtils'
 import { CommonAddress } from '../util/CommonAddressUtils'
@@ -804,11 +805,13 @@ export const useArbTokenBridge = (
     }
 
     const bridgeTokensToAdd: ContractStorage<ERC20BridgeToken> = {}
+    const erc20Params = { address: l1Address, provider: l1.provider }
 
-    const { name, symbol, decimals } = await fetchErc20Data({
-      address: l1Address,
-      provider: l1.provider
-    })
+    if (!(await isValidErc20(erc20Params))) {
+      throw new Error(`${l1Address} is not a valid ERC-20 token`)
+    }
+
+    const { name, symbol, decimals } = await fetchErc20Data(erc20Params)
 
     const isDisabled = await l1TokenIsDisabled({
       erc20L1Address: l1Address,

--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -37,7 +37,7 @@ import {
 } from './arbTokenBridge.types'
 import { useBalance } from './useBalance'
 import {
-  getL1TokenData,
+  fetchErc20Data,
   getL1ERC20Address,
   fetchErc20L2GatewayAddress,
   getL2ERC20Address,
@@ -350,11 +350,9 @@ export const useArbTokenBridge = (
       l1Signer
     })
 
-    const { symbol } = await getL1TokenData({
-      account: walletAddress,
-      erc20L1Address,
-      l1Provider: l1.provider,
-      l2Provider: l2.provider
+    const { symbol } = await fetchErc20Data({
+      address: erc20L1Address,
+      provider: l1.provider
     })
 
     addTransaction({
@@ -394,11 +392,9 @@ export const useArbTokenBridge = (
     })
     const contract = await ERC20__factory.connect(l2Address, l2Signer)
     const tx = await contract.functions.approve(gatewayAddress, MaxUint256)
-    const { symbol } = await getL1TokenData({
-      account: walletAddress,
-      erc20L1Address,
-      l1Provider: l1.provider,
-      l2Provider: l2.provider
+    const { symbol } = await fetchErc20Data({
+      address: erc20L1Address,
+      provider: l1.provider
     })
 
     addTransaction({
@@ -438,11 +434,9 @@ export const useArbTokenBridge = (
     const erc20Bridger = await Erc20Bridger.fromProvider(l2.provider)
 
     try {
-      const { symbol, decimals } = await getL1TokenData({
-        account: walletAddress,
-        erc20L1Address,
-        l1Provider: l1.provider,
-        l2Provider: l2.provider
+      const { symbol, decimals } = await fetchErc20Data({
+        address: erc20L1Address,
+        provider: l1.provider
       })
 
       const depositRequest = await erc20Bridger.getDepositRequest({
@@ -535,11 +529,9 @@ export const useArbTokenBridge = (
           const { symbol, decimals } = bridgeToken
           return { symbol, decimals }
         }
-        const { symbol, decimals } = await getL1TokenData({
-          account: walletAddress,
-          erc20L1Address,
-          l1Provider: l1.provider,
-          l2Provider: l2.provider
+        const { symbol, decimals } = await fetchErc20Data({
+          address: erc20L1Address,
+          provider: l1.provider
         })
 
         addToken(erc20L1Address)
@@ -804,11 +796,9 @@ export const useArbTokenBridge = (
 
     const bridgeTokensToAdd: ContractStorage<ERC20BridgeToken> = {}
 
-    const { name, symbol, decimals } = await getL1TokenData({
-      account: walletAddress,
-      erc20L1Address: l1Address,
-      l1Provider: l1.provider,
-      l2Provider: l2.provider
+    const { name, symbol, decimals } = await fetchErc20Data({
+      address: l1Address,
+      provider: l1.provider
     })
 
     const isDisabled = await l1TokenIsDisabled({
@@ -896,11 +886,9 @@ export const useArbTokenBridge = (
 
     const res = await messageWriter.execute(l2.provider)
 
-    const { symbol, decimals } = await getL1TokenData({
-      account: walletAddress,
-      erc20L1Address: tokenAddress as string,
-      l1Provider: l1.provider,
-      l2Provider: l2.provider
+    const { symbol, decimals } = await fetchErc20Data({
+      address: tokenAddress as string,
+      provider: l1.provider
     })
 
     addTransaction({

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -34,7 +34,7 @@ export type Erc20Data = {
   address: string
 }
 
-const erc20DataCacheLocalStorageKey = 'arbitrum:bridge:erc-20-cache'
+const erc20DataCacheLocalStorageKey = 'arbitrum:bridge:erc20-cache'
 
 type Erc20DataCache = {
   [cacheKey: string]: Erc20Data
@@ -59,26 +59,19 @@ function getErc20DataCache(
   )
 
   if (typeof params !== 'undefined') {
-    const { chainId, address } = params
-    return cache[getErc20DataCacheKey({ chainId, address })] ?? null
+    return cache[getErc20DataCacheKey(params)] ?? null
   }
 
   return cache
 }
 
-type SetErc20DataCacheParams = {
-  chainId: number
-  address: string
+type SetErc20DataCacheParams = GetErc20DataCacheParams & {
   erc20Data: Erc20Data
 }
 
-function setErc20DataCache({
-  chainId,
-  address,
-  erc20Data
-}: SetErc20DataCacheParams) {
+function setErc20DataCache({ erc20Data, ...params }: SetErc20DataCacheParams) {
   const cache = getErc20DataCache()
-  cache[getErc20DataCacheKey({ chainId, address })] = erc20Data
+  cache[getErc20DataCacheKey(params)] = erc20Data
   localStorage.setItem(erc20DataCacheLocalStorageKey, JSON.stringify(cache))
 }
 

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -55,7 +55,8 @@ function getErc20DataCache(
   params?: GetErc20DataCacheParams
 ): Erc20DataCache | (Erc20Data | null) {
   const cache: Erc20DataCache = JSON.parse(
-    localStorage.getItem(erc20DataCacheLocalStorageKey) ?? '{}'
+    // intentionally using || instead of ?? for it to work with an empty string
+    localStorage.getItem(erc20DataCacheLocalStorageKey) || '{}'
   )
 
   if (typeof params !== 'undefined') {

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -169,39 +169,6 @@ export async function fetchErc20Allowance(params: FetchErc20AllowanceParams) {
 }
 
 /**
- * Retrieves data about an ERC-20 token using its L2 address. Throws if fails to retrieve balance.
- * @param erc20L2Address
- * @returns
- */
-export async function getL2TokenData({
-  account,
-  erc20L2Address,
-  l2Provider
-}: {
-  account: string
-  erc20L2Address: string
-  l2Provider: Provider
-}): Promise<L2TokenData> {
-  const contract = StandardArbERC20__factory.connect(erc20L2Address, l2Provider)
-
-  const multiCaller = await MultiCaller.fromProvider(l2Provider)
-  const [tokenData] = await multiCaller.getTokenData([erc20L2Address], {
-    balanceOf: { account }
-  })
-
-  if (tokenData && typeof tokenData.balance === 'undefined') {
-    throw new Error(
-      `getL2TokenData: No balance method available for ${erc20L2Address}`
-    )
-  }
-
-  return {
-    balance: tokenData?.balance ?? constants.Zero,
-    contract
-  }
-}
-
-/**
  * Retrieves the L1 address of an ERC-20 token using its L2 address.
  * @param erc20L2Address
  * @param l2Provider

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -130,6 +130,8 @@ export async function isValidErc20({
 
   try {
     await Promise.all([
+      // we don't reallly care about the balance in this call, so we're just using vitalik.eth
+      // didn't want to use address zero in case contracts have checks for it
       erc20.balanceOf('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'),
       erc20.totalSupply()
     ])

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -81,17 +81,6 @@ function setErc20DataCache({
   localStorage.setItem(erc20DataCacheLocalStorageKey, JSON.stringify(cache))
 }
 
-export function erc20DataToErc20BridgeToken(data: Erc20Data): ERC20BridgeToken {
-  return {
-    name: data.name,
-    type: TokenType.ERC20,
-    symbol: data.symbol,
-    address: data.address,
-    decimals: data.decimals,
-    listIds: new Set()
-  }
-}
-
 export type FetchErc20DataProps = {
   /**
    * Address of the ERC-20 token contract.
@@ -315,4 +304,15 @@ export function sanitizeTokenName(
   }
 
   return tokenName
+}
+
+export function erc20DataToErc20BridgeToken(data: Erc20Data): ERC20BridgeToken {
+  return {
+    name: data.name,
+    type: TokenType.ERC20,
+    symbol: data.symbol,
+    address: data.address,
+    decimals: data.decimals,
+    listIds: new Set()
+  }
 }

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -33,7 +33,7 @@ export type Erc20Data = {
   address: string
 }
 
-const erc20DataCacheLocalStorageKey = 'arbitrum:bridge:erc20-cache'
+const erc20DataCacheLocalStorageKey = 'arbitrum:bridge:erc-20-cache'
 
 type Erc20DataCache = {
   [cacheKey: string]: Erc20Data

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -91,8 +91,6 @@ export async function fetchErc20Data({
   provider
 }: FetchErc20DataProps): Promise<Erc20Data> {
   const chainId = (await provider.getNetwork()).chainId
-  const multiCaller = await MultiCaller.fromProvider(provider)
-
   const cachedErc20Data = getErc20DataCache({ chainId, address })
 
   if (cachedErc20Data) {
@@ -100,6 +98,7 @@ export async function fetchErc20Data({
   }
 
   // todo: fall back if there is no multicall?
+  const multiCaller = await MultiCaller.fromProvider(provider)
   const [tokenData] = await multiCaller.getTokenData([address], {
     name: true,
     symbol: true,

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -2,6 +2,7 @@ import { constants } from 'ethers'
 import { Chain } from 'wagmi'
 import { Provider } from '@ethersproject/providers'
 import { Erc20Bridger, MultiCaller } from '@arbitrum/sdk'
+import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 
 import { CommonAddress } from './CommonAddressUtils'
 import { isNetwork } from './networks'
@@ -127,6 +128,24 @@ export async function fetchErc20Data({
   }
 
   return erc20Data
+}
+
+export async function isValidErc20({
+  address,
+  provider
+}: FetchErc20DataProps): Promise<boolean> {
+  const erc20 = ERC20__factory.connect(address, provider)
+
+  try {
+    await Promise.all([
+      erc20.balanceOf('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'),
+      erc20.totalSupply()
+    ])
+
+    return true
+  } catch (err) {
+    return false
+  }
 }
 
 export type FetchErc20AllowanceParams = FetchErc20DataProps & {

--- a/packages/arb-token-bridge-ui/src/util/deposits/helpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/deposits/helpers.ts
@@ -11,7 +11,7 @@ import {
 import { Provider } from '@ethersproject/providers'
 import { AssetType } from '../../hooks/arbTokenBridge.types'
 import { Transaction } from '../../hooks/useTransactions'
-import { getL1TokenData } from '../TokenUtils'
+import { fetchErc20Data } from '../TokenUtils'
 
 export const updateAdditionalDepositData = async (
   depositTx: Transaction,
@@ -144,14 +144,11 @@ const updateTokenDepositStatusData = async ({
   }
 
   // fallback to on-chain token information if subgraph doesn't have it
-  const { sender, tokenAddress, assetName } = updatedDepositTx
+  const { tokenAddress, assetName } = updatedDepositTx
   if (!assetName && tokenAddress) {
-    const { symbol } = await getL1TokenData({
-      account: sender,
-      erc20L1Address: tokenAddress,
-      l1Provider,
-      l2Provider,
-      throwOnInvalidERC20: false
+    const { symbol } = await fetchErc20Data({
+      address: tokenAddress,
+      provider: l1Provider
     })
     updatedDepositTx.assetName = symbol
   }

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -9,6 +9,7 @@ import {
 } from '@arbitrum/sdk/dist/lib/dataEntities/networks'
 
 import { loadEnvironmentVariableWithFallback } from './index'
+import { Erc20Data } from './TokenUtils'
 
 export const customChainLocalStorageKey = 'arbitrum:custom:chains'
 
@@ -24,11 +25,7 @@ const SEPOLIA_INFURA_RPC_URL = `https://sepolia.infura.io/v3/${INFURA_KEY}`
 
 export type ChainWithRpcUrl = Chain & {
   rpcUrl: string
-  nativeTokenData?: {
-    name: string
-    symbol: string
-    decimals: number
-  }
+  nativeTokenData?: Erc20Data
 }
 
 export function getCustomChainsFromLocalStorage(): ChainWithRpcUrl[] {

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/helpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/helpers.ts
@@ -3,7 +3,7 @@ import { Provider } from '@ethersproject/providers'
 import { BigNumber } from '@ethersproject/bignumber'
 import { L2ToL1MessageReader, L2TransactionReceipt } from '@arbitrum/sdk'
 import { FetchWithdrawalsFromSubgraphResult } from './fetchWithdrawalsFromSubgraph'
-import { getL1TokenData } from '../TokenUtils'
+import { fetchErc20Data } from '../TokenUtils'
 import {
   AssetType,
   L2ToL1EventResult,
@@ -173,13 +173,9 @@ export async function mapTokenWithdrawalFromEventLogsToL2ToL1EventResult(
   l2Provider: Provider,
   l2ChainID: number
 ): Promise<L2ToL1EventResultPlus | undefined> {
-  const { symbol, decimals } = await getL1TokenData({
-    // we don't care about allowance in this call, so we're just using vitalik.eth
-    // didn't want to use address zero in case contracts have checks for it
-    account: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
-    erc20L1Address: result.l1Token,
-    l1Provider,
-    l2Provider
+  const { symbol, decimals } = await fetchErc20Data({
+    address: result.l1Token,
+    provider: l1Provider
   })
 
   const txReceipt = await l2Provider.getTransactionReceipt(result.txHash)
@@ -270,12 +266,11 @@ export async function mapWithdrawalToL2ToL1EventResult(
 
   if (withdrawal.type === 'TokenWithdrawal' && withdrawal?.l1Token?.id) {
     // Token withdrawal
-    const { symbol, decimals } = await getL1TokenData({
-      account: withdrawal.sender,
-      erc20L1Address: withdrawal.l1Token.id,
-      l1Provider,
-      l2Provider
+    const { symbol, decimals } = await fetchErc20Data({
+      address: withdrawal.l1Token.id,
+      provider: l1Provider
     })
+
     return {
       ...event,
       sender: withdrawal.sender,


### PR DESCRIPTION
### Summary

In this PR:
  * Removed `getL2TokenData` as it was unused
  * Removed `getL1TokenData` in favor of `isValidErc20` and `fetchErc20Data`
    * It was doing two things: 1) validating that the provided address houses a valid erc-20 contract; 2) fetching the data for that erc-20, so it was a bit hard to understand that looking from a high level
    * Now we use `isValidErc20` in places where we were relying on `getL1TokenData` to throw in case of invalid erc-20 (adding token through search field and importing through query param)
    * Refactored the code around storing to cache a bit, using local storage instead of session storage now
  * Moved some types and utils into `TokenUtils` 

### Steps to test

Everything should work the same.