### PR TITLE
feat: improve insufficient funds error messages

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -36,10 +36,13 @@ import {
   useAppContextState
 } from '../App/AppContext'
 import { trackEvent, shouldTrackAnalytics } from '../../util/AnalyticsUtils'
+import { TransferPanelMain } from './TransferPanelMain'
 import {
-  TransferPanelMain,
-  TransferPanelMainErrorMessage
-} from './TransferPanelMain'
+  TransferPanelMainRichErrorMessage,
+  getInsufficientFundsErrorMessage,
+  getInsufficientFundsForGasFeesErrorMessage,
+  getSmartContractWalletEthTransfersNotSupportedErrorMessage
+} from './TransferPanelMainErrorMessage'
 import { useIsSwitchingL2Chain } from './TransferPanelMainUtils'
 import { NonCanonicalTokensBridgeInfo } from '../../util/fastBridges'
 import { tokenRequiresApprovalOnL2 } from '../../util/L2ApprovalUtils'
@@ -89,10 +92,6 @@ import {
 } from './TransferPanelUtils'
 import { useImportTokenModal } from '../../hooks/TransferPanel/useImportTokenModal'
 import { useSummaryVisibility } from '../../hooks/TransferPanel/useSummaryVisibility'
-import {
-  getInsufficientFundsErrorMessage,
-  getInsufficientFundsForGasFeesErrorMessage
-} from './errorMessages'
 
 const isAllowedL2 = async ({
   l1TokenAddress,
@@ -1234,11 +1233,11 @@ export function TransferPanel() {
 
   const transferPanelMainErrorMessage:
     | string
-    | TransferPanelMainErrorMessage
+    | TransferPanelMainRichErrorMessage
     | undefined = useMemo(() => {
     // ETH transfers using SC wallets not enabled yet
     if (isSmartContractWallet && !selectedToken) {
-      return TransferPanelMainErrorMessage.SC_WALLET_ETH_NOT_SUPPORTED
+      return getSmartContractWalletEthTransfersNotSupportedErrorMessage()
     }
 
     const sourceChain = isDepositMode ? l1Network.name : l2Network.name
@@ -1263,7 +1262,7 @@ export function TransferPanel() {
     // ERC-20
     if (selectedToken) {
       if (isDepositMode && selectedTokenIsWithdrawOnly) {
-        return TransferPanelMainErrorMessage.WITHDRAW_ONLY
+        return TransferPanelMainRichErrorMessage.TOKEN_WITHDRAW_ONLY
       }
 
       // No error while loading balance
@@ -1311,7 +1310,7 @@ export function TransferPanel() {
         return undefined
 
       case 'error':
-        return TransferPanelMainErrorMessage.GAS_ESTIMATION_FAILURE
+        return TransferPanelMainRichErrorMessage.GAS_ESTIMATION_FAILURE
 
       case 'success': {
         const sanitizedEstimatedGasFees = sanitizeEstimatedGasFees(gasSummary, {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -41,7 +41,7 @@ import {
   TransferPanelMainRichErrorMessage,
   getInsufficientFundsErrorMessage,
   getInsufficientFundsForGasFeesErrorMessage,
-  getSmartContractWalletEthTransfersNotSupportedErrorMessage
+  getSmartContractWalletNativeCurrencyTransfersNotSupportedErrorMessage
 } from './TransferPanelMainErrorMessage'
 import { useIsSwitchingL2Chain } from './TransferPanelMainUtils'
 import { NonCanonicalTokensBridgeInfo } from '../../util/fastBridges'
@@ -1235,9 +1235,11 @@ export function TransferPanel() {
     | string
     | TransferPanelMainRichErrorMessage
     | undefined = useMemo(() => {
-    // ETH transfers using SC wallets not enabled yet
+    // native currency (ETH or custom fee token) transfers using SC wallets not enabled yet
     if (isSmartContractWallet && !selectedToken) {
-      return getSmartContractWalletEthTransfersNotSupportedErrorMessage()
+      return getSmartContractWalletNativeCurrencyTransfersNotSupportedErrorMessage(
+        { asset: nativeCurrency.symbol }
+      )
     }
 
     const sourceChain = isDepositMode ? l1Network.name : l2Network.name

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -700,48 +700,45 @@ export function TransferPanelMain({
   ])
 
   const errorMessageText = useMemo(() => {
-    if (typeof errorMessage === 'undefined') {
-      return undefined
-    }
+    switch (errorMessage) {
+      case TransferPanelMainErrorMessage.INSUFFICIENT_FUNDS:
+        return `Insufficient balance, please add more to ${
+          isDepositMode ? parentLayer : layer
+        }.`
 
-    if (errorMessage === TransferPanelMainErrorMessage.GAS_ESTIMATION_FAILURE) {
-      return (
-        <span>
-          Gas estimation failed, join our{' '}
-          <ExternalLink
-            href="https://discord.com/invite/ZpZuw7p"
-            className="underline"
-          >
-            Discord
-          </ExternalLink>{' '}
-          and reach out in #support for assistance.
-        </span>
-      )
-    }
+      case TransferPanelMainErrorMessage.GAS_ESTIMATION_FAILURE:
+        return (
+          <span>
+            Gas estimation failed, join our{' '}
+            <ExternalLink
+              href="https://discord.com/invite/ZpZuw7p"
+              className="underline"
+            >
+              Discord
+            </ExternalLink>{' '}
+            and reach out in #support for assistance.
+          </span>
+        )
 
-    if (errorMessage === TransferPanelMainErrorMessage.WITHDRAW_ONLY) {
-      return (
-        <>
-          <span>This token can&apos;t be bridged over. </span>
-          <button
-            className="arb-hover underline"
-            onClick={openWithdrawOnlyDialog}
-          >
-            Learn more.
-          </button>
-        </>
-      )
-    }
+      case TransferPanelMainErrorMessage.WITHDRAW_ONLY:
+        return (
+          <>
+            <span>This token can&apos;t be bridged over. </span>
+            <button
+              className="arb-hover underline"
+              onClick={openWithdrawOnlyDialog}
+            >
+              Learn more.
+            </button>
+          </>
+        )
 
-    if (
-      errorMessage === TransferPanelMainErrorMessage.SC_WALLET_ETH_NOT_SUPPORTED
-    ) {
-      return "ETH transfers using smart contract wallets aren't supported yet."
-    }
+      case TransferPanelMainErrorMessage.SC_WALLET_ETH_NOT_SUPPORTED:
+        return "ETH transfers using smart contract wallets aren't supported yet."
 
-    return `Insufficient balance, please add more to ${
-      isDepositMode ? parentLayer : layer
-    }.`
+      default:
+        return undefined
+    }
   }, [errorMessage, isDepositMode, layer, openWithdrawOnlyDialog, parentLayer])
 
   const switchNetworksOnTransferPanel = useCallback(() => {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -340,7 +340,6 @@ function NetworkListboxPlusBalancesContainer({
 }
 
 export enum TransferPanelMainErrorMessage {
-  INSUFFICIENT_FUNDS,
   GAS_ESTIMATION_FAILURE,
   WITHDRAW_ONLY,
   SC_WALLET_ETH_NOT_SUPPORTED
@@ -353,12 +352,12 @@ export function TransferPanelMain({
 }: {
   amount: string
   setAmount: (value: string) => void
-  errorMessage?: TransferPanelMainErrorMessage
+  errorMessage?: TransferPanelMainErrorMessage | string
 }) {
   const actions = useActions()
 
   const { l1, l2 } = useNetworksAndSigners()
-  const { parentLayer, layer } = useChainLayers()
+  const { layer } = useChainLayers()
   const isConnectedToArbitrum = useIsConnectedToArbitrum()
   const isConnectedToOrbitChain = useIsConnectedToOrbitChain()
   const { isArbitrumOne, isArbitrumGoerli } = isNetwork(l2.network.id)
@@ -700,12 +699,15 @@ export function TransferPanelMain({
   ])
 
   const errorMessageText = useMemo(() => {
-    switch (errorMessage) {
-      case TransferPanelMainErrorMessage.INSUFFICIENT_FUNDS:
-        return `Insufficient balance, please add more to ${
-          isDepositMode ? parentLayer : layer
-        }.`
+    if (typeof errorMessage === 'undefined') {
+      return undefined
+    }
 
+    if (typeof errorMessage === 'string') {
+      return errorMessage
+    }
+
+    switch (errorMessage) {
       case TransferPanelMainErrorMessage.GAS_ESTIMATION_FAILURE:
         return (
           <span>
@@ -734,12 +736,9 @@ export function TransferPanelMain({
         )
 
       case TransferPanelMainErrorMessage.SC_WALLET_ETH_NOT_SUPPORTED:
-        return "ETH transfers using smart contract wallets aren't supported yet."
-
-      default:
-        return undefined
+        return `ETH transfers using smart contract wallets aren't supported yet.`
     }
-  }, [errorMessage, isDepositMode, layer, openWithdrawOnlyDialog, parentLayer])
+  }, [errorMessage, openWithdrawOnlyDialog])
 
   const switchNetworksOnTransferPanel = useCallback(() => {
     const newFrom = to

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -68,6 +68,7 @@ import {
   NativeCurrencyErc20
 } from '../../hooks/useNativeCurrency'
 import { defaultErc20Decimals } from '../../defaults'
+import { TransferPanelMainRichErrorMessage } from './TransferPanelMainErrorMessage'
 
 enum NetworkType {
   l1 = 'l1',
@@ -339,12 +340,6 @@ function NetworkListboxPlusBalancesContainer({
   )
 }
 
-export enum TransferPanelMainErrorMessage {
-  GAS_ESTIMATION_FAILURE,
-  WITHDRAW_ONLY,
-  SC_WALLET_ETH_NOT_SUPPORTED
-}
-
 export function TransferPanelMain({
   amount,
   setAmount,
@@ -352,7 +347,7 @@ export function TransferPanelMain({
 }: {
   amount: string
   setAmount: (value: string) => void
-  errorMessage?: TransferPanelMainErrorMessage | string
+  errorMessage?: TransferPanelMainRichErrorMessage | string
 }) {
   const actions = useActions()
 
@@ -698,7 +693,7 @@ export function TransferPanelMain({
     isDepositMode
   ])
 
-  const errorMessageText = useMemo(() => {
+  const errorMessageElement = useMemo(() => {
     if (typeof errorMessage === 'undefined') {
       return undefined
     }
@@ -708,7 +703,7 @@ export function TransferPanelMain({
     }
 
     switch (errorMessage) {
-      case TransferPanelMainErrorMessage.GAS_ESTIMATION_FAILURE:
+      case TransferPanelMainRichErrorMessage.GAS_ESTIMATION_FAILURE:
         return (
           <span>
             Gas estimation failed, join our{' '}
@@ -722,7 +717,7 @@ export function TransferPanelMain({
           </span>
         )
 
-      case TransferPanelMainErrorMessage.WITHDRAW_ONLY:
+      case TransferPanelMainRichErrorMessage.TOKEN_WITHDRAW_ONLY:
         return (
           <>
             <span>This token can&apos;t be bridged over. </span>
@@ -734,9 +729,6 @@ export function TransferPanelMain({
             </button>
           </>
         )
-
-      case TransferPanelMainErrorMessage.SC_WALLET_ETH_NOT_SUPPORTED:
-        return `ETH transfers using smart contract wallets aren't supported yet.`
     }
   }, [errorMessage, openWithdrawOnlyDialog])
 
@@ -1104,7 +1096,7 @@ export function TransferPanelMain({
               loading: isMaxAmount || loadingMaxAmount,
               onClick: setMaxAmount
             }}
-            errorMessage={errorMessageText}
+            errorMessage={errorMessageElement}
             disabled={isSwitchingL2Chain}
             value={isMaxAmount ? '' : amount}
             onChange={e => {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -720,7 +720,7 @@ export function TransferPanelMain({
       case TransferPanelMainRichErrorMessage.TOKEN_WITHDRAW_ONLY:
         return (
           <>
-            <span>This token can&apos;t be bridged over. </span>
+            <span>This token can&apos;t be bridged over.</span>{' '}
             <button
               className="arb-hover underline"
               onClick={openWithdrawOnlyDialog}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainErrorMessage.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainErrorMessage.ts
@@ -22,6 +22,10 @@ export function getInsufficientFundsForGasFeesErrorMessage({
   return `Insufficient ${asset} to pay for gas fees. Please add more funds to ${chain}.`
 }
 
-export function getSmartContractWalletEthTransfersNotSupportedErrorMessage() {
-  return `ETH transfers using smart contract wallets aren't supported yet.`
+export function getSmartContractWalletNativeCurrencyTransfersNotSupportedErrorMessage({
+  asset
+}: {
+  asset: string
+}) {
+  return `${asset} transfers using smart contract wallets aren't supported yet.`
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainErrorMessage.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainErrorMessage.ts
@@ -1,3 +1,8 @@
+export enum TransferPanelMainRichErrorMessage {
+  GAS_ESTIMATION_FAILURE,
+  TOKEN_WITHDRAW_ONLY
+}
+
 export type GetInsufficientFundsErrorMessageParams = {
   asset: string
   chain: string
@@ -15,4 +20,8 @@ export function getInsufficientFundsForGasFeesErrorMessage({
   chain
 }: GetInsufficientFundsErrorMessageParams) {
   return `Insufficient ${asset} to pay for gas fees. Please add more to ${chain}.`
+}
+
+export function getSmartContractWalletEthTransfersNotSupportedErrorMessage() {
+  return `ETH transfers using smart contract wallets aren't supported yet.`
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainErrorMessage.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainErrorMessage.ts
@@ -12,14 +12,14 @@ export function getInsufficientFundsErrorMessage({
   asset,
   chain
 }: GetInsufficientFundsErrorMessageParams) {
-  return `Insufficient ${asset}. Please add more to ${chain}.`
+  return `Insufficient ${asset}. Please add more funds to ${chain}.`
 }
 
 export function getInsufficientFundsForGasFeesErrorMessage({
   asset,
   chain
 }: GetInsufficientFundsErrorMessageParams) {
-  return `Insufficient ${asset} to pay for gas fees. Please add more to ${chain}.`
+  return `Insufficient ${asset} to pay for gas fees. Please add more funds to ${chain}.`
 }
 
 export function getSmartContractWalletEthTransfersNotSupportedErrorMessage() {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/errorMessages.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/errorMessages.ts
@@ -1,0 +1,18 @@
+export type GetInsufficientFundsErrorMessageParams = {
+  asset: string
+  chain: string
+}
+
+export function getInsufficientFundsErrorMessage({
+  asset,
+  chain
+}: GetInsufficientFundsErrorMessageParams) {
+  return `Insufficient ${asset}. Please add more to ${chain}.`
+}
+
+export function getInsufficientFundsForGasFeesErrorMessage({
+  asset,
+  chain
+}: GetInsufficientFundsErrorMessageParams) {
+  return `Insufficient ${asset} to pay for gas fees. Please add more to ${chain}.`
+}


### PR DESCRIPTION
### Summary

Closes https://github.com/OffchainLabs/arbitrum-token-bridge/issues/1259.

Right now, we show the exact same error message regardless of whether your balance was less than the amount you were trying to bridge or if you didn't have enough funds to pay for gas. Now that message varies, e.g: 
  * `Insufficient ARB. Please add more funds to Goerli.`
  * `Insufficient ETH to pay for gas fees. Please add more funds to Arbitrum Goerli.`
  
Plus it will work for custom fee token, as it will display a different asset than ETH. I'm not too worried about Orbit chains with long names, as it nicely wraps to the next line.
