### PR TITLE
feat: show token explorer link for both networks

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -287,8 +287,8 @@ function TokenBalance({
   tokenSymbolOverride?: string
 }) {
   const { l1, l2 } = useNetworksAndSigners()
-  const isL1 = on === NetworkType.l1
-  const chain = isL1 ? l1.network : l2.network
+  const isParentChain = on === NetworkType.l1
+  const chain = isParentChain ? l1.network : l2.network
 
   const isERC20BridgeToken = (
     token: ERC20BridgeToken | NativeCurrencyErc20 | null
@@ -329,10 +329,10 @@ function TokenBalance({
       isERC20BridgeToken(forToken) &&
       !isTokenUSDC(forToken.address) ? (
         <ExternalLink
-          className="underline hover:text-white/70"
+          className="arb-hover underline"
           href={`${removeLinkForwardSlash(
             chain.blockExplorers.default.url
-          )}/token/${isL1 ? forToken.address : forToken.l2Address}`}
+          )}/token/${isParentChain ? forToken.address : forToken.l2Address}`}
         >
           <span>{symbol}</span>
         </ExternalLink>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -60,7 +60,10 @@ import {
   ether
 } from '../../constants'
 import { NetworkListbox, NetworkListboxProps } from './NetworkListbox'
-import { removeLinkForwardSlash, shortenAddress } from '../../util/CommonUtils'
+import {
+  createBlockExplorerUrlForToken,
+  shortenAddress
+} from '../../util/CommonUtils'
 import { OneNovaTransferDialog } from './OneNovaTransferDialog'
 import { useUpdateUSDCBalances } from '../../hooks/CCTP/useUpdateUSDCBalances'
 import { useChainLayers } from '../../hooks/useChainLayers'
@@ -325,14 +328,16 @@ function TokenBalance({
           decimals: forToken.decimals
         })}
       </span>{' '}
-      {chain.blockExplorers &&
-      isERC20BridgeToken(forToken) &&
-      !isTokenUSDC(forToken.address) ? (
+      {/* we don't want to show explorer link for native currency (either ETH or custom token), or USDC because user can bridge USDC to USDC.e or native USDC, vice versa */}
+      {isERC20BridgeToken(forToken) && !isTokenUSDC(forToken.address) ? (
         <ExternalLink
           className="arb-hover underline"
-          href={`${removeLinkForwardSlash(
-            chain.blockExplorers.default.url
-          )}/token/${isParentChain ? forToken.address : forToken.l2Address}`}
+          href={createBlockExplorerUrlForToken({
+            explorerLink: chain.blockExplorers
+              ? chain.blockExplorers.default.url
+              : undefined,
+            tokenAddress: isParentChain ? forToken.address : forToken.l2Address
+          })}
         >
           <span>{symbol}</span>
         </ExternalLink>

--- a/packages/arb-token-bridge-ui/src/components/common/ExternalLink.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/ExternalLink.tsx
@@ -1,9 +1,13 @@
 export function ExternalLink({
   children,
+  href,
   ...props
 }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  if (!href) {
+    return children
+  }
   return (
-    <a target="_blank" rel="noopener noreferrer" {...props}>
+    <a target="_blank" href={href} rel="noopener noreferrer" {...props}>
       {children}
     </a>
   )

--- a/packages/arb-token-bridge-ui/src/util/CommonUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/CommonUtils.ts
@@ -18,3 +18,10 @@ export function shortenTxHash(txHash: string) {
 
 export const isTestingEnvironment =
   !!window.Cypress || process.env.NODE_ENV !== 'production'
+
+export const removeLinkForwardSlash = (link: string) => {
+  if (link.endsWith('/')) {
+    return link.substring(0, link.length - 1)
+  }
+  return link
+}

--- a/packages/arb-token-bridge-ui/src/util/CommonUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/CommonUtils.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/react'
+
 export function shortenAddress(address: string) {
   const addressLength = address.length
 
@@ -32,7 +34,12 @@ export const createBlockExplorerUrlForToken = ({
   if (!tokenAddress) {
     return undefined
   }
-  const url = new URL(explorerLink)
-  url.pathname += `token/${tokenAddress}`
-  return url.toString()
+  try {
+    const url = new URL(explorerLink)
+    url.pathname += `token/${tokenAddress}`
+    return url.toString()
+  } catch (error) {
+    Sentry.captureException(error)
+    return undefined
+  }
 }

--- a/packages/arb-token-bridge-ui/src/util/CommonUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/CommonUtils.ts
@@ -19,9 +19,20 @@ export function shortenTxHash(txHash: string) {
 export const isTestingEnvironment =
   !!window.Cypress || process.env.NODE_ENV !== 'production'
 
-export const removeLinkForwardSlash = (link: string) => {
-  if (link.endsWith('/')) {
-    return link.substring(0, link.length - 1)
+export const createBlockExplorerUrlForToken = ({
+  explorerLink,
+  tokenAddress
+}: {
+  explorerLink: string | undefined
+  tokenAddress: string | undefined
+}): string | undefined => {
+  if (!explorerLink) {
+    return undefined
   }
-  return link
+  if (!tokenAddress) {
+    return undefined
+  }
+  const url = new URL(explorerLink)
+  url.pathname += `token/${tokenAddress}`
+  return url.toString()
 }

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -289,6 +289,15 @@ export const isTokenArbitrumGoerliNativeUSDC = (
   tokenAddress?.toLowerCase() ===
   CommonAddress.ArbitrumGoerli.USDC.toLowerCase()
 
+export const isTokenUSDC = (tokenAddress: string | undefined) => {
+  return (
+    isTokenMainnetUSDC(tokenAddress) ||
+    isTokenGoerliUSDC(tokenAddress) ||
+    isTokenArbitrumOneNativeUSDC(tokenAddress) ||
+    isTokenArbitrumGoerliNativeUSDC(tokenAddress)
+  )
+}
+
 // get the exact token symbol for a particular chain
 export function sanitizeTokenSymbol(
   tokenSymbol: string,

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
@@ -26,12 +26,7 @@ describe('Deposit ERC20 Token', () => {
         wethTokenAddressL1,
         getL1NetworkConfig().multiCall,
         Cypress.env('ETH_RPC_URL')
-      ).then(
-        val =>
-          (l1ERC20bal = formatAmount(val, {
-            symbol: 'WETH'
-          }))
-      )
+      ).then(val => (l1ERC20bal = formatAmount(val)))
     })
 
     it('should show L1 and L2 chains, and ETH correctly', () => {


### PR DESCRIPTION
Doesn't show for custom fee token chain native currency / ETH / USDC

<img width="613" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/d6043e54-44a8-4081-98d3-25b30ab2ffff">

closes #1304