### PR TITLE
feat: replace L2 with network name

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenRow.tsx
@@ -402,7 +402,8 @@ export function TokenRow({
                       />
                     ) : (
                       <span className="text-xs text-gray-900">
-                        This token hasn&apos;t been bridged to L2.
+                        This token hasn&apos;t been bridged to{' '}
+                        {getNetworkName(l2Network.id)}.
                       </span>
                     )}
                   </>


### PR DESCRIPTION
Production:
<img width="537" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/61cfcd0d-449a-47b5-b232-0fc7c0b134c4">

This PR:
<img width="510" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/76c1c43a-9da6-4198-92b8-1398ffec122d">
<img width="586" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/bcb5b4b2-5145-43e8-9e81-cf9a883e20d7">


Closes #1265