### PR TITLE
fix: use native currency, not always ETH on error msg

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
@@ -375,7 +375,7 @@ export function useTransferReadiness({
         if (total > ethBalanceFloat) {
           return notReady({
             errorMessage: getInsufficientFundsForGasFeesErrorMessage({
-              asset: ether.symbol,
+              asset: nativeCurrency.symbol,
               chain: sourceChain
             })
           })


### PR DESCRIPTION
Refer to comment on L371:

```typescript
// Everything is in the same currency
// This case also handles custom fee token withdrawals, as `ethBalanceFloat` will reflect the custom fee token balance on the Orbit chain
```

closes #1319 