### PR TITLE
ci: always run test-e2e-success job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -246,14 +246,14 @@ jobs:
         run: |
           docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
           exitcode="$?"
-          echo "JOB exitcode ${job.outputs.exitcode}"
+          echo "steps.test-e2e exitcode ${steps.test-e2e.outputs.exitcode}"
           # if exitcode is not set, set it
-          if [-z ${job.outputs.exitcode+x}]
+          if [-z ${steps.test-e2e.outputs.exitcode+x}]
           then
             echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
           # once it's set, only change exitcode if the test failed
-          # if one test failed, the e2e tests job is considered failed
-          elif [job.outputs.exitcode != 0]
+          # if one test failed, the e2e teststeps.test-e2e is considered failed
+          elif [steps.test-e2e.outputs.exitcode != 0]
           then
             echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -174,7 +174,8 @@ jobs:
       matrix:
         tests:
           ${{ fromJson(needs.load-e2e-files.outputs.matrix) }}
-      result: ${{ steps.test-e2e.outcome }}
+      outputs:
+        result: ${{ steps.test-e2e.outcome }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -175,76 +175,85 @@ jobs:
         tests:
           ${{ fromJson(needs.load-e2e-files.outputs.matrix) }}
     outputs:
-      result: ${{ steps.test-e2e.outcome }}
+      exitcode: ${{ steps.test-e2e.outputs.exitcode }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      # - name: Checkout
+      #   uses: actions/checkout@v3
 
-      - name: Chown workspace
-        run: chown -R $(whoami) .
+      # - name: Chown workspace
+      #   run: chown -R $(whoami) .
 
-      - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v2
+      # - name: Checkout
+      #   uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@v1
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@v1
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # pin@v1
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # pin@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # pin@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-buildx-
+      # - name: Cache Docker layers
+      #   uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # pin@v2
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
+      #     restore-keys: ${{ runner.os }}-buildx-
 
-      - name: Make .e2e.env
-        uses: SpicyPizza/create-envfile@v1.3
-        with:
-          envkey_PRIVATE_KEY_CUSTOM: ${{ secrets.E2E_PRIVATE_KEY }}
-          envkey_PRIVATE_KEY_USER: ${{ secrets.E2E_PRIVATE_KEY_USER }}
-          envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
-          envkey_SKIP_METAMASK_SETUP: true
-          envkey_NEXT_PUBLIC_LOCAL_ETHEREUM_RPC_URL: http://geth:8545
-          envkey_NEXT_PUBLIC_LOCAL_ARBITRUM_RPC_URL: http://sequencer:8547
-          envkey_TEST_FILE: ${{ matrix.tests.file }}
-          envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
-          envkey_NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL: ${{ secrets.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL }}
-          directory: ./packages/arb-token-bridge-ui/
-          file_name: .e2e.env
+      # - name: Make .e2e.env
+      #   uses: SpicyPizza/create-envfile@v1.3
+      #   with:
+      #     envkey_PRIVATE_KEY_CUSTOM: ${{ secrets.E2E_PRIVATE_KEY }}
+      #     envkey_PRIVATE_KEY_USER: ${{ secrets.E2E_PRIVATE_KEY_USER }}
+      #     envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
+      #     envkey_SKIP_METAMASK_SETUP: true
+      #     envkey_NEXT_PUBLIC_LOCAL_ETHEREUM_RPC_URL: http://geth:8545
+      #     envkey_NEXT_PUBLIC_LOCAL_ARBITRUM_RPC_URL: http://sequencer:8547
+      #     envkey_TEST_FILE: ${{ matrix.tests.file }}
+      #     envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
+      #     envkey_NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL: ${{ secrets.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL }}
+      #     directory: ./packages/arb-token-bridge-ui/
+      #     file_name: .e2e.env
 
-      - name: Make .env
-        uses: SpicyPizza/create-envfile@v1.3
-        with:
-          envkey_NEXT_PUBLIC_IS_E2E_TEST: true
-          envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
-          envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
-          envkey_NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL: ${{ secrets.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL }}
-          directory: ./packages/arb-token-bridge-ui/
-          file_name: .env
+      # - name: Make .env
+      #   uses: SpicyPizza/create-envfile@v1.3
+      #   with:
+      #     envkey_NEXT_PUBLIC_IS_E2E_TEST: true
+      #     envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
+      #     envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
+      #     envkey_NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL: ${{ secrets.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL }}
+      #     directory: ./packages/arb-token-bridge-ui/
+      #     file_name: .env
 
-      - name: Make synpress .env
-        uses: SpicyPizza/create-envfile@v1.3
-        with:
-          envkey_CYPRESS_GROUP: medium-resolution
-          envkey_DISPLAY_HEIGHT: 768
-          envkey_DISPLAY_WIDTH: 1366
-          envkey_SE_SCREEN_HEIGHT: 768
-          envkey_SE_SCREEN_WIDTH: 1366
-          file_name: medium-res.env
+      # - name: Make synpress .env
+      #   uses: SpicyPizza/create-envfile@v1.3
+      #   with:
+      #     envkey_CYPRESS_GROUP: medium-resolution
+      #     envkey_DISPLAY_HEIGHT: 768
+      #     envkey_DISPLAY_WIDTH: 1366
+      #     envkey_SE_SCREEN_HEIGHT: 768
+      #     envkey_SE_SCREEN_WIDTH: 1366
+      #     file_name: medium-res.env
 
-      - name: Set up the local node
-        uses: OffchainLabs/actions/run-nitro-test-node@main
+      # - name: Set up the local node
+      #   uses: OffchainLabs/actions/run-nitro-test-node@main
 
-      - name: Restore node_modules
-        uses: OffchainLabs/actions/node-modules/restore@main
+      # - name: Restore node_modules
+      #   uses: OffchainLabs/actions/node-modules/restore@main
 
+      # - name: Run e2e tests
+      #   id: test-e2e
+      #   run: |
+      #     docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
       - name: Run e2e tests
         id: test-e2e
         run: |
-          docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
+          exitcode="0"
+          if [steps.test-e2e.outputs.exitcode != 0]
+          then
+            echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+          fi
+          exit "$exitcode"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPOSE_DOCKER_CLI_BUILD: 1
@@ -258,11 +267,11 @@ jobs:
     if: needs.check-is-hotfix.outputs.is_hotfix == 'false'
     steps:
       - name: E2E Succeeded
-        if: needs.test-e2e.outputs.result == 'success'
+        if: needs.test-e2e.outputs.exitcode == 0
         run: echo "nice"
         
       - name: E2E Failed
-        if: needs.test-e2e.outputs.result != 'success'
+        if: needs.test-e2e.outputs.exitcode != 0
         run: exit 1
 
   clean-up:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -255,11 +255,11 @@ jobs:
     if: always() && needs.check-is-hotfix.result == 'success' && needs.check-is-hotfix.outputs.is_hotfix == 'false'
     steps:
       - name: E2E Succeeded
-        if: ${{ needs.test-e2e.result == 'success' }}
+        if: needs.test-e2e.result == 'success'
         run: echo "nice"
         
       - name: E2E Failed
-        if: ${{ needs.test-e2e.result != 'success' }}
+        if: needs.test-e2e.result != 'success'
         run: exit 1
 
   clean-up:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -246,14 +246,9 @@ jobs:
         run: |
           docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
           exitcode="$?"
-          echo "steps.test-e2e exitcode ${steps.test-e2e.outputs.exitcode}"
-          # if exitcode is not set, set it
-          if [-z ${steps.test-e2e.outputs.exitcode+x}]
-          then
-            echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
-          # once it's set, only change exitcode if the test failed
+          # only change exitcode if the test failed
           # if one test failed, the e2e teststeps.test-e2e is considered failed
-          elif [steps.test-e2e.outputs.exitcode != 0]
+          if [ $exitcode != 0 ]
           then
             echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   check-is-hotfix:
     name: Check if PR is hotfix
-    runs-on: ubuntu-latest         
+    runs-on: ubuntu-latest
     outputs:
       is_hotfix: ${{ steps.check-is-hotfix.outputs.is_hotfix }}
     
@@ -266,11 +266,11 @@ jobs:
     if: always() && needs.check-is-hotfix.result == 'success' && needs.check-is-hotfix.outputs.is_hotfix == 'false'
     steps:
       - name: E2E Succeeded
-        if: needs.test-e2e.outputs.exitcode == 0
+        if: ${{ success() }}
         run: echo "nice"
         
       - name: E2E Failed
-        if: needs.test-e2e.outputs.exitcode != 0
+        if: ${{ failure() }}
         run: exit 1
 
   clean-up:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -246,9 +246,14 @@ jobs:
         run: |
           docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
           exitcode="$?"
-          # only change exitcode if the test failed
+          echo "JOB exitcode ${job.outputs.exitcode}"
+          # if exitcode is not set, set it
+          if [-z ${job.outputs.exitcode+x}]
+          then
+            echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+          # once it's set, only change exitcode if the test failed
           # if one test failed, the e2e tests job is considered failed
-          if [steps.test-e2e.outputs.exitcode != 0]
+          elif [job.outputs.exitcode != 0]
           then
             echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -174,6 +174,8 @@ jobs:
       matrix:
         tests:
           ${{ fromJson(needs.load-e2e-files.outputs.matrix) }}
+    outputs:
+      result: ${{ steps.test-e2e.outputs.result }}
 
     steps:
       - name: Checkout
@@ -255,11 +257,11 @@ jobs:
     if: needs.check-is-hotfix.outputs.is_hotfix == 'false'
     steps:
       - name: E2E Succeeded
-        if: needs.test-e2e.result == 'success'
+        if: needs.test-e2e.outputs.result == 'success'
         run: echo "nice"
         
       - name: E2E Failed
-        if: needs.test-e2e.result != 'success'
+        if: needs.test-e2e.outputs.result != 'success'
         run: exit 1
 
   clean-up:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -252,6 +252,8 @@ jobs:
     name: "Test E2E Success"
     runs-on: ubuntu-latest
     needs: [check-is-hotfix, test-e2e]
+    # because there are two jobs needed, we need to explicitly state all the conditions
+    # https://github.com/actions/runner/issues/2205#issuecomment-1381988186
     if: always() && needs.check-is-hotfix.result == 'success' && needs.check-is-hotfix.outputs.is_hotfix == 'false'
     steps:
       - name: E2E Succeeded

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -259,7 +259,7 @@ jobs:
         run: echo "nice"
         
       - name: E2E Failed
-        if: ${{ needs.test-e2e.result != 'success'  }}
+        if: ${{ needs.test-e2e.result != 'success' }}
         run: exit 1
 
   clean-up:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -178,77 +178,76 @@ jobs:
       exitcode: ${{ steps.test-e2e.outputs.exitcode }}
 
     steps:
-      # - name: Checkout
-      #   uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      # - name: Chown workspace
-      #   run: chown -R $(whoami) .
+      - name: Chown workspace
+        run: chown -R $(whoami) .
 
-      # - name: Checkout
-      #   uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v2
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v2
 
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@v1
 
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # pin@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # pin@v1
 
-      # - name: Cache Docker layers
-      #   uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # pin@v2
-      #   with:
-      #     path: /tmp/.buildx-cache
-      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
-      #     restore-keys: ${{ runner.os }}-buildx-
+      - name: Cache Docker layers
+        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # pin@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
 
-      # - name: Make .e2e.env
-      #   uses: SpicyPizza/create-envfile@v1.3
-      #   with:
-      #     envkey_PRIVATE_KEY_CUSTOM: ${{ secrets.E2E_PRIVATE_KEY }}
-      #     envkey_PRIVATE_KEY_USER: ${{ secrets.E2E_PRIVATE_KEY_USER }}
-      #     envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
-      #     envkey_SKIP_METAMASK_SETUP: true
-      #     envkey_NEXT_PUBLIC_LOCAL_ETHEREUM_RPC_URL: http://geth:8545
-      #     envkey_NEXT_PUBLIC_LOCAL_ARBITRUM_RPC_URL: http://sequencer:8547
-      #     envkey_TEST_FILE: ${{ matrix.tests.file }}
-      #     envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
-      #     envkey_NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL: ${{ secrets.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL }}
-      #     directory: ./packages/arb-token-bridge-ui/
-      #     file_name: .e2e.env
+      - name: Make .e2e.env
+        uses: SpicyPizza/create-envfile@v1.3
+        with:
+          envkey_PRIVATE_KEY_CUSTOM: ${{ secrets.E2E_PRIVATE_KEY }}
+          envkey_PRIVATE_KEY_USER: ${{ secrets.E2E_PRIVATE_KEY_USER }}
+          envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
+          envkey_SKIP_METAMASK_SETUP: true
+          envkey_NEXT_PUBLIC_LOCAL_ETHEREUM_RPC_URL: http://geth:8545
+          envkey_NEXT_PUBLIC_LOCAL_ARBITRUM_RPC_URL: http://sequencer:8547
+          envkey_TEST_FILE: ${{ matrix.tests.file }}
+          envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
+          envkey_NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL: ${{ secrets.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL }}
+          directory: ./packages/arb-token-bridge-ui/
+          file_name: .e2e.env
 
-      # - name: Make .env
-      #   uses: SpicyPizza/create-envfile@v1.3
-      #   with:
-      #     envkey_NEXT_PUBLIC_IS_E2E_TEST: true
-      #     envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
-      #     envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
-      #     envkey_NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL: ${{ secrets.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL }}
-      #     directory: ./packages/arb-token-bridge-ui/
-      #     file_name: .env
+      - name: Make .env
+        uses: SpicyPizza/create-envfile@v1.3
+        with:
+          envkey_NEXT_PUBLIC_IS_E2E_TEST: true
+          envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
+          envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
+          envkey_NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL: ${{ secrets.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL }}
+          directory: ./packages/arb-token-bridge-ui/
+          file_name: .env
 
-      # - name: Make synpress .env
-      #   uses: SpicyPizza/create-envfile@v1.3
-      #   with:
-      #     envkey_CYPRESS_GROUP: medium-resolution
-      #     envkey_DISPLAY_HEIGHT: 768
-      #     envkey_DISPLAY_WIDTH: 1366
-      #     envkey_SE_SCREEN_HEIGHT: 768
-      #     envkey_SE_SCREEN_WIDTH: 1366
-      #     file_name: medium-res.env
+      - name: Make synpress .env
+        uses: SpicyPizza/create-envfile@v1.3
+        with:
+          envkey_CYPRESS_GROUP: medium-resolution
+          envkey_DISPLAY_HEIGHT: 768
+          envkey_DISPLAY_WIDTH: 1366
+          envkey_SE_SCREEN_HEIGHT: 768
+          envkey_SE_SCREEN_WIDTH: 1366
+          file_name: medium-res.env
 
-      # - name: Set up the local node
-      #   uses: OffchainLabs/actions/run-nitro-test-node@main
+      - name: Set up the local node
+        uses: OffchainLabs/actions/run-nitro-test-node@main
 
-      # - name: Restore node_modules
-      #   uses: OffchainLabs/actions/node-modules/restore@main
+      - name: Restore node_modules
+        uses: OffchainLabs/actions/node-modules/restore@main
 
-      # - name: Run e2e tests
-      #   id: test-e2e
-      #   run: |
-      #     docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
       - name: Run e2e tests
         id: test-e2e
         run: |
-          exitcode="0"
+          docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
+          exitcode="$?"
+          # only change exitcode if the test failed
+          # if one test failed, the e2e tests job is considered failed
           if [steps.test-e2e.outputs.exitcode != 0]
           then
             echo "exitcode=$exitcode" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -174,8 +174,6 @@ jobs:
       matrix:
         tests:
           ${{ fromJson(needs.load-e2e-files.outputs.matrix) }}
-    outputs:
-      exitcode: ${{ steps.test-e2e.outputs.exitcode }}
 
     steps:
       - name: Checkout
@@ -242,17 +240,8 @@ jobs:
         uses: OffchainLabs/actions/node-modules/restore@main
 
       - name: Run e2e tests
-        id: test-e2e
         run: |
           docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
-          exitcode="$?"
-          # only change exitcode if the test failed
-          # if one test failed, the e2e teststeps.test-e2e is considered failed
-          if [ $exitcode != 0 ]
-          then
-            echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
-          fi
-          exit "$exitcode"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPOSE_DOCKER_CLI_BUILD: 1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -174,8 +174,8 @@ jobs:
       matrix:
         tests:
           ${{ fromJson(needs.load-e2e-files.outputs.matrix) }}
-      outputs:
-        result: ${{ steps.test-e2e.outcome }}
+    outputs:
+      result: ${{ steps.test-e2e.outcome }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -263,7 +263,7 @@ jobs:
     name: "Test E2E Success"
     runs-on: ubuntu-latest
     needs: [check-is-hotfix, test-e2e]
-    if: needs.check-is-hotfix.outputs.is_hotfix == 'false'
+    if: always() && needs.check-is-hotfix.result == 'success' && needs.check-is-hotfix.outputs.is_hotfix == 'false'
     steps:
       - name: E2E Succeeded
         if: needs.test-e2e.outputs.exitcode == 0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -266,11 +266,11 @@ jobs:
     if: always() && needs.check-is-hotfix.result == 'success' && needs.check-is-hotfix.outputs.is_hotfix == 'false'
     steps:
       - name: E2E Succeeded
-        if: ${{ success() }}
+        if: ${{ needs.test-e2e.result == 'success' }}
         run: echo "nice"
         
       - name: E2E Failed
-        if: ${{ failure() }}
+        if: ${{ needs.test-e2e.result != 'success'  }}
         run: exit 1
 
   clean-up:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -174,8 +174,7 @@ jobs:
       matrix:
         tests:
           ${{ fromJson(needs.load-e2e-files.outputs.matrix) }}
-    outputs:
-      result: ${{ steps.test-e2e.outputs.result }}
+      result: ${{ steps.test-e2e.outcome }}
 
     steps:
       - name: Checkout
@@ -242,6 +241,7 @@ jobs:
         uses: OffchainLabs/actions/node-modules/restore@main
 
       - name: Run e2e tests
+        id: test-e2e
         run: |
           docker-compose -f docker-compose.ci.yml --env-file medium-res.env up --build --exit-code-from synpress
         env:

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/readClassicDeposits.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/readClassicDeposits.cy.ts
@@ -102,8 +102,7 @@ describe('Read classic deposit messages', () => {
         '0x6cecd3bfc3ec73181c4ac0253d3f51e5aa8d26157ca7439ff9ab465de14a436f'
 
       cy.findByLabelText(/l1 transaction status/i).should('contain', 'Success')
-      // deliberate failure
-      cy.findByLabelText(/l3 transaction status/i).should('contain', 'Success')
+      cy.findByLabelText(/l2 transaction status/i).should('contain', 'Success')
 
       cy.findByLabelText(/l1 transaction link/i).should(
         'contain',

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/readClassicDeposits.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/readClassicDeposits.cy.ts
@@ -102,7 +102,8 @@ describe('Read classic deposit messages', () => {
         '0x6cecd3bfc3ec73181c4ac0253d3f51e5aa8d26157ca7439ff9ab465de14a436f'
 
       cy.findByLabelText(/l1 transaction status/i).should('contain', 'Success')
-      cy.findByLabelText(/l2 transaction status/i).should('contain', 'Success')
+      // deliberate failure
+      cy.findByLabelText(/l3 transaction status/i).should('contain', 'Success')
 
       cy.findByLabelText(/l1 transaction link/i).should(
         'contain',


### PR DESCRIPTION
#1223 has attempted to fix this but as the hotfix ci job is added to the dependency of "needs" jobs,
the `test-e2e-success` job is still skipped whenever any of the e2e tests failed