### PR TITLE
refactor: move useCctp to token-bridge-sdk

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../util/TokenApprovalUtils'
 import { TOKEN_APPROVAL_ARTICLE_LINK, ether } from '../../constants'
 import { useChainLayers } from '../../hooks/useChainLayers'
-import { getContracts } from '../../hooks/CCTP/useCCTP'
+import { getContracts } from '@/token-bridge-sdk/cctp'
 import {
   fetchErc20L1GatewayAddress,
   fetchErc20L2GatewayAddress

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../util/TokenApprovalUtils'
 import { TOKEN_APPROVAL_ARTICLE_LINK, ether } from '../../constants'
 import { useChainLayers } from '../../hooks/useChainLayers'
-import { getContracts } from '@/token-bridge-sdk/cctp'
+import { getCctpContracts } from '@/token-bridge-sdk/cctp'
 import {
   fetchErc20L1GatewayAddress,
   fetchErc20L2GatewayAddress
@@ -128,7 +128,9 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
   useEffect(() => {
     const getContractAddress = async function () {
       if (isCctp) {
-        setContractAddress(getContracts(chainId)?.tokenMessengerContractAddress)
+        setContractAddress(
+          getCctpContracts(chainId)?.tokenMessengerContractAddress
+        )
         return
       }
       if (!token?.address) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -69,7 +69,7 @@ import {
 import { getAttestationHashAndMessageFromReceipt } from '../../util/cctp/getAttestationHashAndMessageFromReceipt'
 import { DepositStatus, MergedTransaction } from '../../state/app/state'
 import { getStandardizedTimestamp } from '../../state/app/utils'
-import { getContracts, useCCTP } from '../../hooks/CCTP/useCCTP'
+import { getCctpUtils, getContracts } from '@/token-bridge-sdk/cctp'
 import { useNativeCurrency } from '../../hooks/useNativeCurrency'
 import { AssetType } from '../../hooks/arbTokenBridge.types'
 import { useStyles } from '../../hooks/TransferPanel/useStyles'
@@ -215,7 +215,7 @@ export function TransferPanel() {
     [setQueryParams]
   )
 
-  const { approveForBurn, depositForBurn } = useCCTP({
+  const { approveForBurn, depositForBurn } = getCctpUtils({
     sourceChainId: isDepositMode
       ? latestNetworksAndSigners.current.l1.network.id
       : latestNetworksAndSigners.current.l2.network.id

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -69,7 +69,7 @@ import {
 import { getAttestationHashAndMessageFromReceipt } from '../../util/cctp/getAttestationHashAndMessageFromReceipt'
 import { DepositStatus, MergedTransaction } from '../../state/app/state'
 import { getStandardizedTimestamp } from '../../state/app/utils'
-import { getCctpUtils, getContracts } from '@/token-bridge-sdk/cctp'
+import { getCctpUtils, getCctpContracts } from '@/token-bridge-sdk/cctp'
 import { useNativeCurrency } from '../../hooks/useNativeCurrency'
 import { AssetType } from '../../hooks/arbTokenBridge.types'
 import { useStyles } from '../../hooks/TransferPanel/useStyles'
@@ -591,7 +591,7 @@ export function TransferPanel() {
 
       const recipient = destinationAddress || walletAddress
       const { usdcContractAddress, tokenMessengerContractAddress } =
-        getContracts(sourceChainId)
+        getCctpContracts(sourceChainId)
 
       const allowance = await fetchErc20Allowance({
         address: usdcContractAddress,

--- a/packages/arb-token-bridge-ui/src/hooks/CCTP/fetchCCTPLimits.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/CCTP/fetchCCTPLimits.ts
@@ -2,7 +2,7 @@ import { readContract } from '@wagmi/core'
 import { CCTPSupportedChainId } from '../../state/cctpState'
 import { FiatTokenProxyAbi } from '../../util/cctp/FiatTokenProxyAbi'
 import { TokenMinterAbi } from '../../util/cctp/TokenMinterAbi'
-import { getContracts } from '@/token-bridge-sdk/cctp'
+import { getCctpContracts } from '@/token-bridge-sdk/cctp'
 
 /**
  *
@@ -18,7 +18,7 @@ export function fetchMinterAllowance({
   targetChainId: CCTPSupportedChainId
 }) {
   const { usdcContractAddress, tokenMinterContractAddress } =
-    getContracts(targetChainId)
+    getCctpContracts(targetChainId)
 
   return readContract({
     address: usdcContractAddress,
@@ -35,7 +35,7 @@ export function fetchPerMessageBurnLimit({
   sourceChainId: CCTPSupportedChainId
 }) {
   const { usdcContractAddress, tokenMinterContractAddress } =
-    getContracts(sourceChainId)
+    getCctpContracts(sourceChainId)
 
   return readContract({
     address: tokenMinterContractAddress,

--- a/packages/arb-token-bridge-ui/src/hooks/CCTP/fetchCCTPLimits.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/CCTP/fetchCCTPLimits.ts
@@ -2,7 +2,7 @@ import { readContract } from '@wagmi/core'
 import { CCTPSupportedChainId } from '../../state/cctpState'
 import { FiatTokenProxyAbi } from '../../util/cctp/FiatTokenProxyAbi'
 import { TokenMinterAbi } from '../../util/cctp/TokenMinterAbi'
-import { getContracts } from './useCCTP'
+import { getContracts } from '@/token-bridge-sdk/cctp'
 
 /**
  *

--- a/packages/arb-token-bridge-ui/src/hooks/CCTP/useCCTPIsBlocked.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/CCTP/useCCTPIsBlocked.ts
@@ -1,9 +1,9 @@
 import useSWRImmutable from 'swr/immutable'
 import { ChainId } from '../../util/networks'
-import { useCCTP } from './useCCTP'
+import { getCctpUtils } from '@/token-bridge-sdk/cctp'
 
 export function useCCTPIsBlocked() {
-  const { fetchAttestation } = useCCTP({ sourceChainId: ChainId.Ethereum })
+  const { fetchAttestation } = getCctpUtils({ sourceChainId: ChainId.Ethereum })
 
   return useSWRImmutable(['cctp-check'], async () => {
     // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful

--- a/packages/arb-token-bridge-ui/src/state/cctpState.ts
+++ b/packages/arb-token-bridge-ui/src/state/cctpState.ts
@@ -5,7 +5,7 @@ import useSWRImmutable from 'swr/immutable'
 import * as Sentry from '@sentry/react'
 import { useInterval } from 'react-use'
 
-import { useCCTP } from '../hooks/CCTP/useCCTP'
+import { getCctpUtils } from '@/token-bridge-sdk/cctp'
 import {
   ChainId,
   getBlockTime,
@@ -543,7 +543,7 @@ export function useCctpFetching({
 
 export function useClaimCctp(tx: MergedTransaction) {
   const [isClaiming, setIsClaiming] = useState(false)
-  const { waitForAttestation, receiveMessage } = useCCTP({
+  const { waitForAttestation, receiveMessage } = getCctpUtils({
     sourceChainId: tx.cctpData?.sourceChainId
   })
   const { isSmartContractWallet } = useAccountType()

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/cctp.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/cctp.ts
@@ -74,7 +74,7 @@ export type AttestationResponse =
       status: 'pending_confirmations'
     }
 
-export function getContracts(chainId: ChainId | undefined) {
+export function getCctpContracts(chainId: ChainId | undefined) {
   if (!chainId) {
     return contracts[ChainId.Ethereum]
   }
@@ -89,7 +89,7 @@ export function fetchPerMessageBurnLimit({
   sourceChainId: CCTPSupportedChainId
 }) {
   const { usdcContractAddress, tokenMinterContractAddress } =
-    getContracts(sourceChainId)
+    getCctpContracts(sourceChainId)
 
   return readContract({
     address: tokenMinterContractAddress,
@@ -108,7 +108,7 @@ export const getCctpUtils = ({ sourceChainId }: { sourceChainId?: number }) => {
     attestationApiUrl,
     usdcContractAddress,
     messageTransmitterContractAddress
-  } = getContracts(sourceChainId)
+  } = getCctpContracts(sourceChainId)
 
   const depositForBurn = async ({
     amount,

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/cctp.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/cctp.ts
@@ -1,14 +1,14 @@
-import { utils, BigNumber, Signer } from 'ethers'
-import { useCallback } from 'react'
+import { readContract } from '@wagmi/core'
+import { BigNumber, Signer, utils } from 'ethers'
+import { TokenMinterAbi } from '../util/cctp/TokenMinterAbi'
+import { ChainDomain } from '../pages/api/cctp/[type]'
 import { prepareWriteContract, writeContract } from '@wagmi/core'
-
-import { ChainId } from '../../util/networks'
-import { MessageTransmitterAbi } from '../../util/cctp/MessageTransmitterAbi'
-import { TokenMessengerAbi } from '../../util/cctp/TokenMessengerAbi'
+import { TokenMessengerAbi } from '../util/cctp/TokenMessengerAbi'
+import { MessageTransmitterAbi } from '../util/cctp/MessageTransmitterAbi'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
-import { CommonAddress } from '../../util/CommonAddressUtils'
-import { ChainDomain } from '../../pages/api/cctp/[type]'
-import { CCTPSupportedChainId } from '../../state/cctpState'
+import { CCTPSupportedChainId } from '../state/cctpState'
+import { ChainId } from '../util/networks'
+import { CommonAddress } from '../util/CommonAddressUtils'
 
 // see https://developers.circle.com/stablecoin/docs/cctp-protocol-contract
 type Contracts = {
@@ -83,10 +83,24 @@ export function getContracts(chainId: ChainId | undefined) {
   )
 }
 
-export type UseCCTPParams = {
-  sourceChainId: ChainId | undefined
+export function fetchPerMessageBurnLimit({
+  sourceChainId
+}: {
+  sourceChainId: CCTPSupportedChainId
+}) {
+  const { usdcContractAddress, tokenMinterContractAddress } =
+    getContracts(sourceChainId)
+
+  return readContract({
+    address: tokenMinterContractAddress,
+    chainId: sourceChainId,
+    abi: TokenMinterAbi,
+    functionName: 'burnLimitsPerMessage',
+    args: [usdcContractAddress]
+  })
 }
-export function useCCTP({ sourceChainId }: UseCCTPParams) {
+
+export const getCctpUtils = ({ sourceChainId }: { sourceChainId?: number }) => {
   const {
     tokenMessengerContractAddress,
     targetChainDomain,
@@ -96,90 +110,74 @@ export function useCCTP({ sourceChainId }: UseCCTPParams) {
     messageTransmitterContractAddress
   } = getContracts(sourceChainId)
 
-  const depositForBurn = useCallback(
-    async ({
-      amount,
+  const depositForBurn = async ({
+    amount,
+    signer,
+    recipient
+  }: {
+    amount: BigNumber
+    signer: Signer
+    recipient: string
+  }) => {
+    // CCTP uses 32 bytes addresses, while EVEM uses 20 bytes addresses
+    const mintRecipient = utils.hexlify(
+      utils.zeroPad(recipient, 32)
+    ) as `0x${string}`
+
+    const config = await prepareWriteContract({
+      address: tokenMessengerContractAddress,
+      abi: TokenMessengerAbi,
+      functionName: 'depositForBurn',
       signer,
-      recipient
-    }: {
-      amount: BigNumber
-      signer: Signer
-      recipient: string
-    }) => {
-      // CCTP uses 32 bytes addresses, while EVEM uses 20 bytes addresses
-      const mintRecipient = utils.hexlify(
-        utils.zeroPad(recipient, 32)
-      ) as `0x${string}`
+      args: [amount, targetChainDomain, mintRecipient, usdcContractAddress]
+    })
+    return writeContract(config)
+  }
 
-      const config = await prepareWriteContract({
-        address: tokenMessengerContractAddress,
-        abi: TokenMessengerAbi,
-        functionName: 'depositForBurn',
-        signer,
-        args: [amount, targetChainDomain, mintRecipient, usdcContractAddress]
-      })
-      return writeContract(config)
-    },
-    [tokenMessengerContractAddress, targetChainDomain, usdcContractAddress]
-  )
+  const fetchAttestation = async (attestationHash: `0x${string}`) => {
+    const response = await fetch(
+      `${attestationApiUrl}/attestations/${attestationHash}`,
+      { method: 'GET', headers: { accept: 'application/json' } }
+    )
 
-  const fetchAttestation = useCallback(
-    async (attestationHash: `0x${string}`) => {
-      const response = await fetch(
-        `${attestationApiUrl}/attestations/${attestationHash}`,
-        { method: 'GET', headers: { accept: 'application/json' } }
-      )
+    const attestationResponse: AttestationResponse = await response.json()
+    return attestationResponse
+  }
 
-      const attestationResponse: AttestationResponse = await response.json()
-      return attestationResponse
-    },
-    [attestationApiUrl]
-  )
-
-  const waitForAttestation = useCallback(
-    async (attestationHash: `0x${string}`) => {
-      while (true) {
-        const attestation = await fetchAttestation(attestationHash)
-        if (attestation.status === 'complete') {
-          return attestation.attestation
-        }
-
-        await new Promise(r => setTimeout(r, 30_000))
+  const waitForAttestation = async (attestationHash: `0x${string}`) => {
+    while (true) {
+      const attestation = await fetchAttestation(attestationHash)
+      if (attestation.status === 'complete') {
+        return attestation.attestation
       }
-    },
-    [fetchAttestation]
-  )
 
-  const receiveMessage = useCallback(
-    async ({
-      messageBytes,
-      attestation,
-      signer
-    }: {
-      messageBytes: `0x${string}`
-      attestation: `0x${string}`
-      signer: Signer
-    }) => {
-      const config = await prepareWriteContract({
-        address: messageTransmitterContractAddress,
-        abi: MessageTransmitterAbi,
-        functionName: 'receiveMessage',
-        chainId: targetChainId,
-        signer,
-        args: [messageBytes, attestation]
-      })
-      return writeContract(config)
-    },
-    [messageTransmitterContractAddress, targetChainId]
-  )
+      await new Promise(r => setTimeout(r, 30_000))
+    }
+  }
 
-  const approveForBurn = useCallback(
-    async (amount: BigNumber, signer: Signer) => {
-      const contract = ERC20__factory.connect(usdcContractAddress, signer)
-      return contract.functions.approve(tokenMessengerContractAddress, amount)
-    },
-    [usdcContractAddress, tokenMessengerContractAddress]
-  )
+  const receiveMessage = async ({
+    messageBytes,
+    attestation,
+    signer
+  }: {
+    messageBytes: `0x${string}`
+    attestation: `0x${string}`
+    signer: Signer
+  }) => {
+    const config = await prepareWriteContract({
+      address: messageTransmitterContractAddress,
+      abi: MessageTransmitterAbi,
+      functionName: 'receiveMessage',
+      chainId: targetChainId,
+      signer,
+      args: [messageBytes, attestation]
+    })
+    return writeContract(config)
+  }
+  const approveForBurn = async (amount: BigNumber, signer: Signer) => {
+    const contract = ERC20__factory.connect(usdcContractAddress, signer)
+    return contract.functions.approve(tokenMessengerContractAddress, amount)
+  }
 
   return {
     approveForBurn,

--- a/packages/arb-token-bridge-ui/src/util/TokenApprovalUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenApprovalUtils.ts
@@ -2,7 +2,7 @@ import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__fact
 import { MaxUint256 } from '@ethersproject/constants'
 import { Provider } from '@ethersproject/providers'
 import { BigNumber, constants, Signer } from 'ethers'
-import { getContracts } from '@/token-bridge-sdk/cctp'
+import { getCctpContracts } from '@/token-bridge-sdk/cctp'
 import { CCTPSupportedChainId } from '../state/cctpState'
 import { fetchErc20L1GatewayAddress } from './TokenUtils'
 
@@ -36,7 +36,7 @@ export async function approveCctpEstimateGas(
   signer: Signer
 ) {
   const { usdcContractAddress, tokenMessengerContractAddress } =
-    getContracts(sourceChainId)
+    getCctpContracts(sourceChainId)
   const contract = ERC20__factory.connect(usdcContractAddress, signer)
 
   try {

--- a/packages/arb-token-bridge-ui/src/util/TokenApprovalUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenApprovalUtils.ts
@@ -2,7 +2,7 @@ import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__fact
 import { MaxUint256 } from '@ethersproject/constants'
 import { Provider } from '@ethersproject/providers'
 import { BigNumber, constants, Signer } from 'ethers'
-import { getContracts } from '../hooks/CCTP/useCCTP'
+import { getContracts } from '@/token-bridge-sdk/cctp'
 import { CCTPSupportedChainId } from '../state/cctpState'
 import { fetchErc20L1GatewayAddress } from './TokenUtils'
 

--- a/packages/arb-token-bridge-ui/tsconfig.json
+++ b/packages/arb-token-bridge-ui/tsconfig.json
@@ -13,7 +13,8 @@
     "jsx": "preserve",
     "paths": {
       "@/images/*": ["./public/images/*"],
-      "@/icons/*": ["./public/icons/*"]
+      "@/icons/*": ["./public/icons/*"],
+      "@/token-bridge-sdk/*": ["./src/token-bridge-sdk/*"]
     }
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
PR 1 of n.

This PR introduces the `token-bridge-sdk` into our codebase and we will incrementally build more on top of it.

As the first task, we move the useCctp hook into its utility function inside the SDK and update wherever it's being imported.

In the next PR we will move CCTP Transfer functions inside the SDK and use it in the Transfer-panel.
Next PR: https://github.com/OffchainLabs/arbitrum-token-bridge/pull/1327