### PR TITLE
fix: align tx history table headers

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
@@ -333,7 +333,7 @@ export const TransactionHistoryTable = ({
               dataKey="token"
               width={144}
               headerRenderer={() => (
-                <TableHeader className="pl-10 ">Token</TableHeader>
+                <TableHeader className="pl-10">Token</TableHeader>
               )}
             />
             <Column

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
@@ -325,7 +325,7 @@ export const TransactionHistoryTable = ({
               dataKey="date"
               width={228}
               headerRenderer={() => (
-                <TableHeader className="pl-6">Date</TableHeader>
+                <TableHeader className="pl-4">Date</TableHeader>
               )}
             />
             <Column
@@ -333,7 +333,7 @@ export const TransactionHistoryTable = ({
               dataKey="token"
               width={144}
               headerRenderer={() => (
-                <TableHeader className="pl-12">Token</TableHeader>
+                <TableHeader className="pl-10 ">Token</TableHeader>
               )}
             />
             <Column
@@ -341,7 +341,7 @@ export const TransactionHistoryTable = ({
               dataKey="networks"
               width={100}
               headerRenderer={() => (
-                <TableHeader className="pl-6">Networks</TableHeader>
+                <TableHeader className="pl-9">Networks</TableHeader>
               )}
             />
           </Table>

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableClaimableRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableClaimableRow.tsx
@@ -339,7 +339,7 @@ export function TransactionsTableClaimableRow({
     <div
       data-testid={`withdrawal-row-${tx.txId}`}
       className={twMerge(
-        'relative grid h-full grid-cols-[150px_250px_140px_280px_150px] border-b border-dark text-sm text-dark',
+        'relative grid h-full grid-cols-[150px_250px_140px_290px_140px] border-b border-dark text-sm text-dark',
         className,
         bgClassName
       )}

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableDepositRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableDepositRow.tsx
@@ -299,7 +299,7 @@ export function TransactionsTableDepositRow({
     <div
       data-testid={`deposit-row-${tx.txId}`}
       className={twMerge(
-        'relative grid h-full grid-cols-[150px_250px_140px_280px_150px] border-b border-dark text-sm text-dark',
+        'relative grid h-full grid-cols-[150px_250px_140px_290px_140px] border-b border-dark text-sm text-dark',
         bgClassName,
         className
       )}


### PR DESCRIPTION
### Before
<img width="995" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/93239942-b571-472a-8346-4116b9861aea">


### After
<img width="995" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/540b4c2a-6099-4444-90a6-f5ffaf6df46d">

### Also fixed
![image](https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/ac157c69-21e8-4631-9b93-9d79c231d31d)

