### PR TITLE
fix: deposit update for custom gas tokens

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -670,7 +670,7 @@ export const useTransactionHistory = (
       }
 
       // ETH deposit
-      if (tx.asset === AssetType.ETH) {
+      if (tx.assetType === AssetType.ETH) {
         const updatedEthDeposit = await getUpdatedEthDeposit(tx)
         updateCachedTransaction(updatedEthDeposit)
         return


### PR DESCRIPTION
Custom gas token deposits wouldn't update because `tx.asset` is a different token. We need to check for `tx.assetType` which is always `ETH`.