### PR TITLE
feat: hide ARB on token search panel for Orbit chains

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -180,7 +180,9 @@ function TokensPanel({
 
   const nativeCurrency = useNativeCurrency({ provider: L2Provider })
 
-  const { isArbitrumOne, isArbitrumGoerli } = isNetwork(l2Network.id)
+  const { isArbitrumOne, isArbitrumGoerli, isOrbitChain } = isNetwork(
+    l2Network.id
+  )
 
   const tokensFromUser = useTokensFromUser()
   const tokensFromLists = useTokensFromLists()
@@ -278,9 +280,9 @@ function TokensPanel({
             return true
           }
 
-          // Always show official ARB token
+          // Always show official ARB token except from or to Orbit chain
           if (token?.listIds.has(SPECIAL_ARBITRUM_TOKEN_TOKEN_LIST_ID)) {
-            return true
+            return !isOrbitChain
           }
 
           const balance = getBalance(address)
@@ -336,6 +338,7 @@ function TokensPanel({
     isDepositMode,
     isArbitrumOne,
     isArbitrumGoerli,
+    isOrbitChain,
     getBalance,
     nativeCurrency
   ])

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenLists.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenLists.ts
@@ -5,16 +5,18 @@ import {
   fetchTokenListFromURL,
   TokenListWithId
 } from '../util/TokenListUtils'
+import { isNetwork } from '../util/networks'
 
 export function fetchTokenLists(
   forL2ChainId: number
 ): Promise<TokenListWithId[]> {
   return new Promise(resolve => {
+    const { isOrbitChain } = isNetwork(forL2ChainId)
     const requestListArray = BRIDGE_TOKEN_LISTS.filter(
       bridgeTokenList =>
         bridgeTokenList.originChainID === forL2ChainId ||
-        // Always load the Arbitrum Token token list
-        bridgeTokenList.isArbitrumTokenTokenList
+        // Always load the Arbitrum Token token list except from or to Orbit chain
+        (bridgeTokenList.isArbitrumTokenTokenList && !isOrbitChain)
     )
 
     Promise.all(


### PR DESCRIPTION
On production, ARB is always shown on the Token Search Panel

On this PR, we only want to show it when none of the source and destination chains are an L3 Orbit chain
<img width="567" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/09244922-7546-4281-a423-b380c2d883b4">
<img width="551" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/ed67b7c3-67fb-427b-abe9-ec47bbe18174">
<img width="604" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/f4e2a572-048b-4bdf-b927-a53cdbd5f9b8">
