### PR TITLE
fix: early return on empty api results

### DIFF
--- a/packages/arb-token-bridge-ui/src/pages/api/cctp/[type].ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/cctp/[type].ts
@@ -139,7 +139,7 @@ export default async function handler(
     }
 
     // if invalid pageSize, send empty data instead of error
-    if (!Number(pageSize)) {
+    if (isNaN(Number(pageSize)) || Number(pageSize) === 0) {
       res.status(200).json({
         data: {
           pending: [],

--- a/packages/arb-token-bridge-ui/src/pages/api/cctp/[type].ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/cctp/[type].ts
@@ -147,6 +147,7 @@ export default async function handler(
         },
         error: null
       })
+      return
     }
 
     const l1Subgraph = getSubgraphClient(

--- a/packages/arb-token-bridge-ui/src/pages/api/cctp/[type].ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/cctp/[type].ts
@@ -138,6 +138,17 @@ export default async function handler(
       return
     }
 
+    // if invalid pageSize, send empty data instead of error
+    if (!Number(pageSize)) {
+      res.status(200).json({
+        data: {
+          pending: [],
+          completed: []
+        },
+        error: null
+      })
+    }
+
     const l1Subgraph = getSubgraphClient(
       l1ChainId === ChainId.Ethereum ? 'cctp-mainnet' : 'cctp-sepolia'
     )

--- a/packages/arb-token-bridge-ui/src/pages/api/deposits.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/deposits.ts
@@ -57,6 +57,7 @@ export default async function handler(
         message: `incomplete request: ${errorMessage.join(', ')}`,
         data: []
       })
+      return
     }
 
     // if invalid pageSize, send empty data instead of error
@@ -64,6 +65,7 @@ export default async function handler(
       res.status(200).json({
         data: []
       })
+      return
     }
 
     const additionalFilters = `${

--- a/packages/arb-token-bridge-ui/src/pages/api/deposits.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/deposits.ts
@@ -60,7 +60,7 @@ export default async function handler(
     }
 
     // if invalid pageSize, send empty data instead of error
-    if (!Number(pageSize)) {
+    if (isNaN(Number(pageSize)) || Number(pageSize) === 0) {
       res.status(200).json({
         data: []
       })

--- a/packages/arb-token-bridge-ui/src/pages/api/deposits.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/deposits.ts
@@ -59,6 +59,13 @@ export default async function handler(
       })
     }
 
+    // if invalid pageSize, send empty data instead of error
+    if (!Number(pageSize)) {
+      res.status(200).json({
+        data: []
+      })
+    }
+
     const additionalFilters = `${
       typeof fromBlock !== 'undefined'
         ? `blockCreatedAt_gte: ${Number(fromBlock)},`

--- a/packages/arb-token-bridge-ui/src/pages/api/withdrawals.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/withdrawals.ts
@@ -57,6 +57,7 @@ export default async function handler(
         message: `incomplete request: ${errorMessage.join(', ')}`,
         data: []
       })
+      return
     }
 
     // if invalid pageSize, send empty data instead of error
@@ -64,6 +65,7 @@ export default async function handler(
       res.status(200).json({
         data: []
       })
+      return
     }
 
     const additionalFilters = `${

--- a/packages/arb-token-bridge-ui/src/pages/api/withdrawals.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/withdrawals.ts
@@ -60,7 +60,7 @@ export default async function handler(
     }
 
     // if invalid pageSize, send empty data instead of error
-    if (!Number(pageSize)) {
+    if (isNaN(Number(pageSize)) || Number(pageSize) === 0) {
       res.status(200).json({
         data: []
       })

--- a/packages/arb-token-bridge-ui/src/pages/api/withdrawals.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/withdrawals.ts
@@ -59,6 +59,13 @@ export default async function handler(
       })
     }
 
+    // if invalid pageSize, send empty data instead of error
+    if (!Number(pageSize)) {
+      res.status(200).json({
+        data: []
+      })
+    }
+
     const additionalFilters = `${
       typeof fromBlock !== 'undefined'
         ? `l2BlockNum_gte: ${Number(fromBlock)},`

--- a/packages/arb-token-bridge-ui/src/util/cctp/fetchCCTP.ts
+++ b/packages/arb-token-bridge-ui/src/util/cctp/fetchCCTP.ts
@@ -44,7 +44,7 @@ async function fetchCCTP({
     })
   )
 
-  if (!pageSize) return { pending: [], completed: [] } // don't query subgraph if nothing requested
+  if (pageSize === 0) return { pending: [], completed: [] } // don't query subgraph if nothing requested
 
   const response = await fetch(
     `${getAPIBaseUrl()}/api/cctp/${type}?${urlParams}`,

--- a/packages/arb-token-bridge-ui/src/util/cctp/fetchCCTP.ts
+++ b/packages/arb-token-bridge-ui/src/util/cctp/fetchCCTP.ts
@@ -44,6 +44,8 @@ async function fetchCCTP({
     })
   )
 
+  if (!pageSize) return { pending: [], completed: [] } // don't query subgraph if nothing requested
+
   const response = await fetch(
     `${getAPIBaseUrl()}/api/cctp/${type}?${urlParams}`,
     {

--- a/packages/arb-token-bridge-ui/src/util/deposits/fetchDepositsFromSubgraph.ts
+++ b/packages/arb-token-bridge-ui/src/util/deposits/fetchDepositsFromSubgraph.ts
@@ -72,7 +72,7 @@ export const fetchDepositsFromSubgraph = async ({
     })
   )
 
-  if (!pageSize) return [] // don't query subgraph if nothing requested
+  if (pageSize === 0) return [] // don't query subgraph if nothing requested
 
   const response = await fetch(`${getAPIBaseUrl()}/api/deposits?${urlParams}`, {
     method: 'GET',

--- a/packages/arb-token-bridge-ui/src/util/deposits/fetchDepositsFromSubgraph.ts
+++ b/packages/arb-token-bridge-ui/src/util/deposits/fetchDepositsFromSubgraph.ts
@@ -72,6 +72,8 @@ export const fetchDepositsFromSubgraph = async ({
     })
   )
 
+  if (!pageSize) return [] // don't query subgraph if nothing requested
+
   const response = await fetch(`${getAPIBaseUrl()}/api/deposits?${urlParams}`, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' }

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/fetchWithdrawalsFromSubgraph.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/fetchWithdrawalsFromSubgraph.ts
@@ -70,6 +70,8 @@ export async function fetchWithdrawalsFromSubgraph({
     })
   )
 
+  if (!pageSize) return [] // don't query subgraph if nothing requested
+
   const response = await fetch(
     `${getAPIBaseUrl()}/api/withdrawals?${urlParams}`,
     {

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/fetchWithdrawalsFromSubgraph.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/fetchWithdrawalsFromSubgraph.ts
@@ -70,7 +70,7 @@ export async function fetchWithdrawalsFromSubgraph({
     })
   )
 
-  if (!pageSize) return [] // don't query subgraph if nothing requested
+  if (pageSize === 0) return [] // don't query subgraph if nothing requested
 
   const response = await fetch(
     `${getAPIBaseUrl()}/api/withdrawals?${urlParams}`,


### PR DESCRIPTION
We currently get 4x 500 errors on each user session start. This PR fixes that by validating the `pageSize` and having an early return, to avoid subgraph error.