### PR TITLE
chore: use Coinbase API for ETH price

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useETHPrice.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useETHPrice.ts
@@ -12,10 +12,10 @@ export type UseETHPriceResult = {
 
 export function useETHPrice(): UseETHPriceResult {
   const { data, error, isValidating, mutate } = useSWR<number, Error>(
-    'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
-    url => axios.get(url).then(res => res.data.ethereum.usd),
+    'https://api.coinbase.com/v2/prices/ETH-USD/spot',
+    url => axios.get(url).then(res => Number(res.data.data.amount)),
     {
-      refreshInterval: 30_000,
+      refreshInterval: 60_000,
       shouldRetryOnError: true,
       errorRetryCount: 2,
       errorRetryInterval: 3_000

--- a/packages/arb-token-bridge-ui/src/hooks/useETHPrice.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useETHPrice.ts
@@ -13,7 +13,7 @@ export type UseETHPriceResult = {
 export function useETHPrice(): UseETHPriceResult {
   const { data, error, isValidating, mutate } = useSWR<number, Error>(
     'https://api.coinbase.com/v2/prices/ETH-USD/spot',
-    url => axios.get(url).then(res => Number(res.data.data.amount)),
+    url => axios.get(url).then(res => res.data.data.amount),
     {
       refreshInterval: 60_000,
       shouldRetryOnError: true,
@@ -24,7 +24,7 @@ export function useETHPrice(): UseETHPriceResult {
 
   const ethToUSD = useCallback(
     (etherValue: number) => {
-      const safeETHPrice = typeof data === 'number' ? data : 0
+      const safeETHPrice = data && !isNaN(data) ? Number(data) : 0
       return etherValue * safeETHPrice
     },
     [data]

--- a/packages/arb-token-bridge-ui/src/hooks/useETHPrice.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useETHPrice.ts
@@ -15,7 +15,7 @@ export function useETHPrice(): UseETHPriceResult {
     'https://api.coinbase.com/v2/prices/ETH-USD/spot',
     url => axios.get(url).then(res => res.data.data.amount),
     {
-      refreshInterval: 60_000,
+      refreshInterval: 300_000,
       shouldRetryOnError: true,
       errorRetryCount: 2,
       errorRetryInterval: 3_000


### PR DESCRIPTION
no API key, no auth

https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/api-prices#get-spot-price

https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/rate-limiting

rate limit is 10K calls/hour

This PR changes the refresh interval form every 30s to every 5 mins

Closes #1441