### PR TITLE
fix: e2e testing patch

### DIFF
--- a/packages/arb-token-bridge-ui/tests/e2e/specfiles.json
+++ b/packages/arb-token-bridge-ui/tests/e2e/specfiles.json
@@ -48,5 +48,10 @@
     "name": "Switch network",
     "file": "tests/e2e/specs/**/switchNetworks.cy.{js,jsx,ts,tsx}",
     "recordVideo": "false"
+  },
+  {
+    "name": "URL Query params",
+    "file": "tests/e2e/specs/**/urlQueryParam.cy.{js,jsx,ts,tsx}",
+    "recordVideo": "false"
   }
 ]

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/importToken.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/importToken.cy.ts
@@ -3,7 +3,8 @@ import {
   invalidTokenAddress,
   ERC20TokenName,
   ERC20TokenSymbol,
-  importTokenThroughUI
+  importTokenThroughUI,
+  visitAfterSomeDelay
 } from '../../support/common'
 
 const ERC20TokenAddressL1: string = Cypress.env('ERC20_TOKEN_ADDRESS_L1')
@@ -251,8 +252,7 @@ describe('Import token', () => {
           }
         })
 
-        cy.wait(15_000)
-        cy.visit('/', {
+        visitAfterSomeDelay('/', {
           qs: {
             token: invalidTokenAddress
           }

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/importToken.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/importToken.cy.ts
@@ -251,6 +251,13 @@ describe('Import token', () => {
           }
         })
 
+        cy.wait(15_000)
+        cy.visit('/', {
+          qs: {
+            token: invalidTokenAddress
+          }
+        })
+
         // Modal is displayed
         cy.get('h2').contains(/invalid token address/i)
         cy.findByText(new RegExp(ERC20TokenAddressL1, 'i')).should('not.exist')

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/urlQueryParam.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/urlQueryParam.cy.ts
@@ -3,7 +3,7 @@
  */
 
 import { formatAmount } from '../../../src/util/NumberUtils'
-import { getInitialETHBalance } from '../../support/common'
+import { getInitialETHBalance, visitAfterSomeDelay } from '../../support/common'
 
 describe('User enters site with query params on URL', () => {
   let l1ETHbal: number
@@ -23,7 +23,7 @@ describe('User enters site with query params on URL', () => {
     context(
       '?amount=max should set transfer panel amount to maximum amount possible based on balance',
       () => {
-        cy.visit('/', {
+        visitAfterSomeDelay('/', {
           qs: {
             amount: 'max',
             sourceChain: 'custom-localhost',
@@ -64,7 +64,7 @@ describe('User enters site with query params on URL', () => {
     context(
       '?amount=MAX should set transfer panel amount to maximum amount possible based on balance',
       () => {
-        cy.visit('/', {
+        visitAfterSomeDelay('/', {
           qs: {
             amount: 'MAX',
             sourceChain: 'custom-localhost',
@@ -105,7 +105,7 @@ describe('User enters site with query params on URL', () => {
     context(
       '?amount=MaX should set transfer panel amount to maximum amount possible based on balance',
       () => {
-        cy.visit('/', {
+        visitAfterSomeDelay('/', {
           qs: {
             amount: 'MaX',
             sourceChain: 'custom-localhost',
@@ -145,7 +145,7 @@ describe('User enters site with query params on URL', () => {
       }
     )
     context('?amount=56 should set transfer panel amount to 56', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: '56',
           sourceChain: 'custom-localhost',
@@ -156,7 +156,7 @@ describe('User enters site with query params on URL', () => {
       cy.findByPlaceholderText(/Enter amount/i).should('have.value', '56')
     })
     context('?amount=1.6678 should set transfer panel amount to 1.6678', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: '1.6678',
           sourceChain: 'custom-localhost',
@@ -167,7 +167,7 @@ describe('User enters site with query params on URL', () => {
       cy.findByPlaceholderText(/Enter amount/i).should('have.value', '1.6678')
     })
     context('?amount=6 should set transfer panel amount to 6', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: '6',
           sourceChain: 'custom-localhost',
@@ -178,7 +178,7 @@ describe('User enters site with query params on URL', () => {
       cy.findByPlaceholderText(/Enter amount/i).should('have.value', '6')
     })
     context('?amount=0.123 should set transfer panel amount to 0.123', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: '0.123',
           sourceChain: 'custom-localhost',
@@ -190,7 +190,7 @@ describe('User enters site with query params on URL', () => {
       cy.findByPlaceholderText(/Enter amount/i).should('have.value', '0.123')
     })
     context('?amount=-0.123 should set transfer panel amount to 0.123', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: '-0.123',
           sourceChain: 'custom-localhost',
@@ -201,7 +201,7 @@ describe('User enters site with query params on URL', () => {
       cy.findByPlaceholderText(/Enter amount/i).should('have.value', '0.123')
     })
     it('?amount=asdfs should not set transfer panel amount', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: 'asdfs',
           sourceChain: 'custom-localhost',
@@ -212,7 +212,7 @@ describe('User enters site with query params on URL', () => {
       cy.findByPlaceholderText(/Enter amount/i).should('be.empty')
     })
     context('?amount=0 should set transfer panel amount to 0', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: '0',
           sourceChain: 'custom-localhost',
@@ -223,7 +223,7 @@ describe('User enters site with query params on URL', () => {
       cy.findByPlaceholderText(/Enter amount/i).should('have.value', '0')
     })
     context('?amount=0.0001 should set transfer panel amount to 0.0001', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: '0.0001',
           sourceChain: 'custom-localhost',
@@ -234,7 +234,7 @@ describe('User enters site with query params on URL', () => {
       cy.findByPlaceholderText(/Enter amount/i).should('have.value', '0.0001')
     })
     context('?amount=123,3,43 should not set transfer panel amount', () => {
-      cy.visit('/', {
+      visitAfterSomeDelay('/', {
         qs: {
           amount: '123,3,43',
           sourceChain: 'custom-localhost',
@@ -247,7 +247,7 @@ describe('User enters site with query params on URL', () => {
     context(
       '?amount=0, 123.222, 0.3 should not set transfer panel amount',
       () => {
-        cy.visit('/', {
+        visitAfterSomeDelay('/', {
           qs: {
             amount: '0, 123.222, 0.3',
             sourceChain: 'custom-localhost',

--- a/packages/arb-token-bridge-ui/tests/support/common.ts
+++ b/packages/arb-token-bridge-ui/tests/support/common.ts
@@ -155,3 +155,11 @@ export const startWebApp = (url = '/', qs: { [s: string]: string } = {}) => {
     }
   })
 }
+
+export const visitAfterSomeDelay = (
+  url: string,
+  options?: Partial<Cypress.VisitOptions>
+) => {
+  cy.wait(15_000) // let all the race conditions settle, let UI load well first
+  cy.visit(url, options)
+}


### PR DESCRIPTION
It was observed by the team that we were running into a race condition while testing with query params in E2E. This PR just adds a delay for the Bridge UI to settle, and then visits the required URL for testing.