### PR TITLE
refactor: create `Address` type alias

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
@@ -14,6 +14,7 @@ import {
 } from './helpers'
 import { MergedTransaction } from '../../state/app/state'
 import { TabButton } from '../common/Tab'
+import { Address } from '../../util/AddressUtils'
 
 const roundedTabClasses =
   'roundedTab ui-not-selected:arb-hover relative flex flex-row flex-nowrap items-center gap-0.5 md:gap-2 rounded-tl-lg rounded-tr-lg px-2 md:px-4 py-2 text-base ui-selected:bg-white ui-not-selected:text-white justify-center md:justify-start grow md:grow-0'
@@ -21,7 +22,7 @@ const roundedTabClasses =
 export const TransactionHistory = ({
   props
 }: {
-  props: UseTransactionHistoryResult & { address: `0x${string}` | undefined }
+  props: UseTransactionHistoryResult & { address: Address | undefined }
 }) => {
   const {
     transactions,

--- a/packages/arb-token-bridge-ui/src/hooks/CCTP/useUpdateUSDCBalances.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/CCTP/useUpdateUSDCBalances.ts
@@ -4,6 +4,7 @@ import { isTokenSepoliaUSDC, isTokenMainnetUSDC } from '../../util/TokenUtils'
 import { useBalance } from '../useBalance'
 import { useNetworks } from '../useNetworks'
 import { useNetworksRelationship } from '../useNetworksRelationship'
+import { Address } from '../../util/AddressUtils'
 
 function getL1AddressFromAddress(address: string) {
   switch (address) {
@@ -44,7 +45,7 @@ export function useUpdateUSDCBalances({
   })
 
   const updateUSDCBalances = useCallback(
-    (address: `0x${string}` | string) => {
+    (address: Address | string) => {
       const l1Address = getL1AddressFromAddress(address)
 
       updateErc20L1Balance([l1Address.toLowerCase()])

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountIsBlocked.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountIsBlocked.ts
@@ -5,8 +5,9 @@ import useSWRImmutable from 'swr/immutable'
 import { ApiResponseSuccess } from '../pages/api/screenings'
 import { trackEvent } from '../util/AnalyticsUtils'
 import { isNetwork } from '../util/networks'
+import { Address } from '../util/AddressUtils'
 
-async function isBlocked(address: `0x${string}`): Promise<boolean> {
+async function isBlocked(address: Address): Promise<boolean> {
   if (
     process.env.NODE_ENV !== 'production' ||
     process.env.NEXT_PUBLIC_IS_E2E_TEST
@@ -27,7 +28,7 @@ async function isBlocked(address: `0x${string}`): Promise<boolean> {
   return ((await response.json()) as ApiResponseSuccess).blocked
 }
 
-async function fetcher(address: `0x${string}`): Promise<boolean> {
+async function fetcher(address: Address): Promise<boolean> {
   const accountIsBlocked = await isBlocked(address)
 
   if (accountIsBlocked) {

--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -51,6 +51,7 @@ import {
   shouldIncludeSentTxs
 } from '../util/SubgraphUtils'
 import { getOrbitChains } from '../util/orbitChainsList'
+import { Address } from '../util/AddressUtils'
 
 export type UseTransactionHistoryResult = {
   transactions: MergedTransaction[]
@@ -216,9 +217,7 @@ function getTxIdFromTransaction(tx: Transfer) {
 /**
  * Fetches transaction history only for deposits and withdrawals, without their statuses.
  */
-const useTransactionHistoryWithoutStatuses = (
-  address: `0x${string}` | undefined
-) => {
+const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
   const { chain } = useNetwork()
   const [isTestnetMode] = useIsTestnetMode()
   const { isSmartContractWallet, isLoading: isLoadingAccountType } =
@@ -429,7 +428,7 @@ const useTransactionHistoryWithoutStatuses = (
  * This is done in small batches to safely meet RPC limits.
  */
 export const useTransactionHistory = (
-  address: `0x${string}` | undefined,
+  address: Address | undefined,
   // TODO: look for a solution to this. It's used for now so that useEffect that handles pagination runs only a single instance.
   { runFetcher = false } = {}
 ): UseTransactionHistoryResult => {

--- a/packages/arb-token-bridge-ui/src/pages/api/cctp/[type].ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/cctp/[type].ts
@@ -1,6 +1,7 @@
 import { ApolloClient, gql, HttpLink, InMemoryCache } from '@apollo/client'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { ChainId } from '../../../util/networks'
+import { Address } from '../../../util/AddressUtils'
 
 const subgraphUrl = process.env.NEXT_PUBLIC_CCTP_SUBGRAPH_BASE_URL
 if (!subgraphUrl) {
@@ -20,7 +21,7 @@ export function getSubgraphClient(subgraph: string) {
 // Extending the standard NextJs request with CCTP params
 export type NextApiRequestWithCCTPParams = NextApiRequest & {
   query: {
-    walletAddress: `0x${string}`
+    walletAddress: Address
     l1ChainId: string
     pageNumber?: string
     pageSize?: string
@@ -35,26 +36,26 @@ export enum ChainDomain {
 export type MessageReceived = {
   blockNumber: string
   blockTimestamp: string
-  caller: `0x${string}`
+  caller: Address
   id: string
   messageBody: string
   nonce: string
-  sender: `0x${string}`
+  sender: Address
   sourceDomain: `${ChainDomain}`
-  transactionHash: `0x${string}`
+  transactionHash: Address
 }
 
 export type MessageSent = {
-  attestationHash: `0x${string}`
+  attestationHash: Address
   blockNumber: string
   blockTimestamp: string
   id: string
   message: string
   nonce: string
-  sender: `0x${string}`
-  recipient: `0x${string}`
+  sender: Address
+  recipient: Address
   sourceDomain: `${ChainDomain}`
-  transactionHash: `0x${string}`
+  transactionHash: Address
   amount: string
 }
 

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -12,6 +12,7 @@ import {
 } from '../../hooks/useTransactions'
 import { ConnectionState } from '../../util'
 import { CCTPSupportedChainId } from '../cctpState'
+import { Address } from '../../util/AddressUtils'
 
 export enum WhiteListState {
   VERIFYING,
@@ -64,9 +65,9 @@ export interface MergedTransaction {
   parentChainId: number
   cctpData?: {
     sourceChainId?: CCTPSupportedChainId
-    attestationHash?: `0x${string}` | null
+    attestationHash?: Address | null
     messageBytes?: string | null
-    receiveMessageTransactionHash?: `0x${string}` | null
+    receiveMessageTransactionHash?: Address | null
     receiveMessageTimestamp?: number | null
   }
 }

--- a/packages/arb-token-bridge-ui/src/state/cctpState.ts
+++ b/packages/arb-token-bridge-ui/src/state/cctpState.ts
@@ -28,6 +28,7 @@ import { trackEvent } from '../util/AnalyticsUtils'
 import { useAccountType } from '../hooks/useAccountType'
 import { AssetType } from '../hooks/arbTokenBridge.types'
 import { useTransactionHistory } from '../hooks/useTransactionHistory'
+import { Address } from '../util/AddressUtils'
 
 // see https://developers.circle.com/stablecoin/docs/cctp-technical-reference#block-confirmations-for-attestations
 // Blocks need to be awaited on the L1 whether it's a deposit or a withdrawal
@@ -382,7 +383,7 @@ export function useCctpState() {
 type useCctpFetchingParams = {
   l1ChainId: ChainId
   l2ChainId: ChainId
-  walletAddress: `0x${string}` | undefined
+  walletAddress: Address | undefined
   pageSize: number
   pageNumber: number
   type: 'deposits' | 'withdrawals' | 'all'
@@ -523,7 +524,7 @@ export function useClaimCctp(tx: MergedTransaction) {
       const attestation = await waitForAttestation(tx.cctpData.attestationHash)
       const receiveTx = await receiveMessage({
         attestation,
-        messageBytes: tx.cctpData.messageBytes as `0x${string}`,
+        messageBytes: tx.cctpData.messageBytes as Address,
         signer
       })
       const receiveReceiptTx = await receiveTx.wait()
@@ -542,7 +543,7 @@ export function useClaimCctp(tx: MergedTransaction) {
           receiveMessageTimestamp: resolvedAt,
           receiveMessageTransactionHash:
             receiveReceiptTx.status === 1
-              ? (receiveReceiptTx.transactionHash as `0x${string}`)
+              ? (receiveReceiptTx.transactionHash as Address)
               : null
         }
       })

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/BridgeTransferStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/BridgeTransferStarter.ts
@@ -1,6 +1,7 @@
 import { Provider } from '@ethersproject/providers'
 import { BigNumber, ContractTransaction, Signer } from 'ethers'
 import { MergedTransaction } from '../state/app/state'
+import { Address } from '../util/AddressUtils'
 
 type Asset = 'erc20' | 'eth'
 type TxType = 'deposit' | 'withdrawal'
@@ -11,8 +12,8 @@ export type BridgeTransferStatus = `${Chain}_tx_${TxStatus}`
 export type TransferType = `${Asset}_${TxType}` | 'cctp'
 
 export type MergedTransactionCctp = MergedTransaction & {
-  messageBytes: `0x${string}` | null
-  attestationHash: `0x${string}` | null
+  messageBytes: Address | null
+  attestationHash: Address | null
 }
 
 export type BridgeTransfer = {

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/CctpTransferStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/CctpTransferStarter.ts
@@ -15,6 +15,7 @@ import { fetchPerMessageBurnLimit, getCctpContracts } from './cctp'
 import { getChainIdFromProvider, getAddressFromSigner } from './utils'
 import { fetchErc20Allowance } from '../util/TokenUtils'
 import { TokenMessengerAbi } from '../util/cctp/TokenMessengerAbi'
+import { Address } from '../util/AddressUtils'
 
 export class CctpTransferStarter extends BridgeTransferStarter {
   public transferType: TransferType
@@ -104,9 +105,7 @@ export class CctpTransferStarter extends BridgeTransferStarter {
     // burn token on the selected chain to be transferred from cctp contracts to the other chain
 
     // CCTP uses 32 bytes addresses, while EVEM uses 20 bytes addresses
-    const mintRecipient = utils.hexlify(
-      utils.zeroPad(recipient, 32)
-    ) as `0x${string}`
+    const mintRecipient = utils.hexlify(utils.zeroPad(recipient, 32)) as Address
 
     const {
       usdcContractAddress,

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/cctp.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/cctp.ts
@@ -7,16 +7,17 @@ import { MessageTransmitterAbi } from '../util/cctp/MessageTransmitterAbi'
 import { CCTPSupportedChainId } from '../state/cctpState'
 import { ChainId } from '../util/networks'
 import { CommonAddress } from '../util/CommonAddressUtils'
+import { Address } from '../util/AddressUtils'
 
 // see https://developers.circle.com/stablecoin/docs/cctp-protocol-contract
 type Contracts = {
-  tokenMessengerContractAddress: `0x${string}`
+  tokenMessengerContractAddress: Address
   targetChainDomain: ChainDomain
   targetChainId: CCTPSupportedChainId
-  usdcContractAddress: `0x${string}`
-  messageTransmitterContractAddress: `0x${string}`
+  usdcContractAddress: Address
+  messageTransmitterContractAddress: Address
   attestationApiUrl: string
-  tokenMinterContractAddress: `0x${string}`
+  tokenMinterContractAddress: Address
 }
 
 const contracts: Record<CCTPSupportedChainId, Contracts> = {
@@ -68,7 +69,7 @@ const contracts: Record<CCTPSupportedChainId, Contracts> = {
 
 export type AttestationResponse =
   | {
-      attestation: `0x${string}`
+      attestation: Address
       status: 'complete'
     }
   | {
@@ -115,7 +116,7 @@ export const getCctpUtils = ({ sourceChainId }: { sourceChainId?: number }) => {
     messageTransmitterContractAddress
   } = getCctpContracts({ sourceChainId })
 
-  const fetchAttestation = async (attestationHash: `0x${string}`) => {
+  const fetchAttestation = async (attestationHash: Address) => {
     const response = await fetch(
       `${attestationApiUrl}/attestations/${attestationHash}`,
       { method: 'GET', headers: { accept: 'application/json' } }
@@ -125,7 +126,7 @@ export const getCctpUtils = ({ sourceChainId }: { sourceChainId?: number }) => {
     return attestationResponse
   }
 
-  const waitForAttestation = async (attestationHash: `0x${string}`) => {
+  const waitForAttestation = async (attestationHash: Address) => {
     while (true) {
       const attestation = await fetchAttestation(attestationHash)
       if (attestation.status === 'complete') {
@@ -141,8 +142,8 @@ export const getCctpUtils = ({ sourceChainId }: { sourceChainId?: number }) => {
     attestation,
     signer
   }: {
-    messageBytes: `0x${string}`
-    attestation: `0x${string}`
+    messageBytes: Address
+    attestation: Address
     signer: Signer
   }) => {
     const config = await prepareWriteContract({

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -2,6 +2,8 @@ import { Provider } from '@ethersproject/providers'
 
 import { getAPIBaseUrl } from '.'
 
+export type Address = `0x${string}`
+
 export async function addressIsSmartContract(
   address: string,
   provider: Provider

--- a/packages/arb-token-bridge-ui/src/util/WithdrawalUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawalUtils.ts
@@ -4,6 +4,7 @@ import { BigNumber } from 'ethers'
 import * as Sentry from '@sentry/react'
 
 import { GasEstimates } from '../hooks/arbTokenBridge.types'
+import { Address } from './AddressUtils'
 
 export async function withdrawInitTxEstimateGas({
   amount,
@@ -12,7 +13,7 @@ export async function withdrawInitTxEstimateGas({
   erc20L1Address
 }: {
   amount: BigNumber
-  address: `0x${string}`
+  address: Address
   l2Provider: Provider
   erc20L1Address?: string
 }): Promise<GasEstimates> {

--- a/packages/arb-token-bridge-ui/src/util/cctp/getAttestationHashAndMessageFromReceipt.ts
+++ b/packages/arb-token-bridge-ui/src/util/cctp/getAttestationHashAndMessageFromReceipt.ts
@@ -1,5 +1,6 @@
 import { TransactionReceipt } from '@ethersproject/providers'
 import { utils } from 'ethers'
+import { Address } from '../AddressUtils'
 
 export function getAttestationHashAndMessageFromReceipt(
   txReceipt: TransactionReceipt
@@ -16,10 +17,10 @@ export function getAttestationHashAndMessageFromReceipt(
   const messageBytes = utils.defaultAbiCoder.decode(
     ['bytes'],
     log.data
-  )[0] as `0x${string}`
+  )[0] as Address
 
   return {
     messageBytes,
-    attestationHash: utils.keccak256(messageBytes) as `0x${string}`
+    attestationHash: utils.keccak256(messageBytes) as Address
   }
 }


### PR DESCRIPTION
We use it everywhere and I use it a lot in the new tx history. Would be nice to merge it separately to reduce overall diff