### PR TITLE
refactor: add `sourceChainId` and `destinationChainId` to tx

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRowAction.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRowAction.tsx
@@ -97,7 +97,7 @@ export function TransactionsTableRowAction({
         content={
           <span>
             {`Please switch to ${getNetworkName(
-              tx.isWithdrawal ? tx.parentChainId : tx.childChainId
+              tx.destinationChainId
             )} to claim your ${tx.isWithdrawal ? 'withdrawal' : 'deposit'}.`}
           </span>
         }
@@ -110,9 +110,7 @@ export function TransactionsTableRowAction({
           onClick={async () => {
             try {
               if (!currentChainIsValid) {
-                return switchNetwork?.(
-                  tx.isWithdrawal ? tx.parentChainId : tx.childChainId
-                )
+                return switchNetwork?.(tx.destinationChainId)
               }
 
               if (tx.isCctp) {

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/helpers.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/helpers.ts
@@ -100,14 +100,6 @@ export function isTxFailed(tx: MergedTransaction) {
   return tx.status === WithdrawalStatus.FAILURE
 }
 
-export function getSourceChainId(tx: MergedTransaction) {
-  return isDeposit(tx) ? tx.parentChainId : tx.childChainId
-}
-
-export function getDestChainId(tx: MergedTransaction) {
-  return isDeposit(tx) ? tx.childChainId : tx.parentChainId
-}
-
 export function getProvider(chainId: ChainId) {
   const rpcUrl =
     rpcURLs[chainId] ?? getWagmiChain(chainId).rpcUrls.default.http[0]

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -666,7 +666,9 @@ export function TransferPanel() {
           receiveMessageTimestamp: null
         },
         parentChainId: parentChain.id,
-        childChainId: childChain.id
+        childChainId: childChain.id,
+        sourceChainId: isDepositMode ? parentChain.id : childChain.id,
+        destinationChainId: isDepositMode ? childChain.id : parentChain.id
       }
 
       addPendingTransaction(newTransfer)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -667,8 +667,8 @@ export function TransferPanel() {
         },
         parentChainId: parentChain.id,
         childChainId: childChain.id,
-        sourceChainId: isDepositMode ? parentChain.id : childChain.id,
-        destinationChainId: isDepositMode ? childChain.id : parentChain.id
+        sourceChainId: networks.sourceChain.id,
+        destinationChainId: networks.destinationChain.id
       }
 
       addPendingTransaction(newTransfer)

--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -216,7 +216,9 @@ export const useArbTokenBridge = (
       tokenAddress: null,
       depositStatus: DepositStatus.L1_PENDING,
       parentChainId: Number(l1NetworkID),
-      childChainId: Number(l2NetworkID)
+      childChainId: Number(l2NetworkID),
+      sourceChainId: Number(l1NetworkID),
+      destinationChainId: Number(l2NetworkID)
     })
 
     addDepositToCache({
@@ -299,7 +301,9 @@ export const useArbTokenBridge = (
         blockNum: null,
         tokenAddress: null,
         parentChainId: Number(l1NetworkID),
-        childChainId: Number(l2NetworkID)
+        childChainId: Number(l2NetworkID),
+        sourceChainId: Number(l2NetworkID),
+        destinationChainId: Number(l1NetworkID)
       })
 
       const receipt = await tx.wait()
@@ -471,7 +475,9 @@ export const useArbTokenBridge = (
         blockNum: null,
         tokenAddress: erc20L1Address,
         parentChainId: Number(l1NetworkID),
-        childChainId: Number(l2NetworkID)
+        childChainId: Number(l2NetworkID),
+        sourceChainId: Number(l1NetworkID),
+        destinationChainId: Number(l2NetworkID)
       })
 
       addDepositToCache({
@@ -590,7 +596,9 @@ export const useArbTokenBridge = (
         blockNum: null,
         tokenAddress: erc20L1Address,
         parentChainId: Number(l1NetworkID),
-        childChainId: Number(l2NetworkID)
+        childChainId: Number(l2NetworkID),
+        sourceChainId: Number(l2NetworkID),
+        destinationChainId: Number(l1NetworkID)
       })
 
       const receipt = await tx.wait()

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -62,6 +62,8 @@ export interface MergedTransaction {
   depositStatus?: DepositStatus
   childChainId: number
   parentChainId: number
+  sourceChainId: number
+  destinationChainId: number
   cctpData?: {
     sourceChainId?: CCTPSupportedChainId
     attestationHash?: `0x${string}` | null

--- a/packages/arb-token-bridge-ui/src/state/app/utils.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/utils.ts
@@ -94,8 +94,10 @@ export const transformDeposit = (tx: Transaction): MergedTransaction => {
     l1ToL2MsgData: tx.l1ToL2MsgData,
     l2ToL1MsgData: tx.l2ToL1MsgData,
     depositStatus: getDepositStatus(tx),
+    parentChainId: Number(tx.l1NetworkID),
     childChainId: Number(tx.l2NetworkID),
-    parentChainId: Number(tx.l1NetworkID)
+    sourceChainId: Number(tx.l1NetworkID),
+    destinationChainId: Number(tx.l2NetworkID)
   }
 }
 
@@ -126,8 +128,10 @@ export const transformWithdrawal = (
     blockNum: tx.ethBlockNum.toNumber(),
     tokenAddress: tx.tokenAddress || null,
     nodeBlockDeadline: tx.nodeBlockDeadline,
+    parentChainId: tx.parentChainId,
     childChainId: tx.childChainId,
-    parentChainId: tx.parentChainId
+    sourceChainId: tx.childChainId,
+    destinationChainId: tx.parentChainId
   }
 }
 

--- a/packages/arb-token-bridge-ui/src/state/cctpState.ts
+++ b/packages/arb-token-bridge-ui/src/state/cctpState.ts
@@ -137,6 +137,8 @@ function parseTransferToMergedTransaction(
     isCctp: true,
     parentChainId: isDeposit ? sourceChainId : destinationChainId,
     childChainId: isDeposit ? destinationChainId : sourceChainId,
+    sourceChainId,
+    destinationChainId,
     cctpData: {
       sourceChainId,
       attestationHash: messageSent.attestationHash,


### PR DESCRIPTION
Adds `sourceChainId` and `destinationChainId` to `MergedTransaction` so we don't have to do either:
- `tx.isWithdrawal ? tx.parentChainId : tx.childChainId` or,
- cctp: `isEthereumSourceChain : tx.parentChainId : tx.childChainId`

We can just call `tx.sourceChainId/destinationChainId` directly. 

Also reduces diff in the tx history reskin.