### PR TITLE
ci: pin nitro testnode action to specific commit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       is_hotfix: ${{ steps.check-is-hotfix.outputs.is_hotfix }}
-    
-    steps:        
-      - name: Make IS_HOTFIX env var global 
+
+    steps:
+      - name: Make IS_HOTFIX env var global
         id: check-is-hotfix
         run: |
           echo "is_hotfix=${{ env.IS_HOTFIX }}" >> $GITHUB_OUTPUT
@@ -235,7 +235,7 @@ jobs:
           file_name: medium-res.env
 
       - name: Set up the local node
-        uses: OffchainLabs/actions/run-nitro-test-node@main
+        uses: OffchainLabs/actions/run-nitro-test-node@e3b7f5bdfc62cad21026c1d1f424f3fbadc046e0
 
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main
@@ -255,7 +255,7 @@ jobs:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64
-      
+
       - name: Create screenshots directory
         if: steps.e2e-run.outputs.status == 'failed'
         run: mkdir -p packages/arb-token-bridge-ui/tests/e2e/cypress/screenshots
@@ -289,7 +289,7 @@ jobs:
           path: packages/arb-token-bridge-ui/tests/e2e/cypress/videos
           compression-level: 0
           retention-days: 3
-            
+
       - name: Throw error if tests failed
         if: steps.e2e-run.outputs.status == 'failed'
         run: exit 1


### PR DESCRIPTION
Pins to a previous version. Later we can make it work with https://github.com/OffchainLabs/actions/commit/4e90f8e84a69f1cd1a4e8fa0d23d0ffcfe4699d7.