### PR TITLE
refactor: bump @arbitrum/sdk

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.11",
-    "@arbitrum/sdk": "^3.2.0-beta.1-custom-fee-token.0",
+    "@arbitrum/sdk": "^3.2.0-beta.1-custom-fee-token.1",
     "@ethersproject/providers": "^5.7.0",
     "@headlessui/react": "^1.7.8",
     "@headlessui/tailwindcss": "^0.1.2",

--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.11",
-    "@arbitrum/sdk": "^3.2.0-beta.1-custom-fee-token.1",
+    "@arbitrum/sdk": "^3.2.0-beta.2-custom-fee-token.0",
     "@ethersproject/providers": "^5.7.0",
     "@headlessui/react": "^1.7.8",
     "@headlessui/tailwindcss": "^0.1.2",

--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.11",
-    "@arbitrum/sdk": "^3.2.0-beta.2-custom-fee-token.0",
+    "@arbitrum/sdk": "^3.2.0-custom-fee-token.0",
     "@ethersproject/providers": "^5.7.0",
     "@headlessui/react": "^1.7.8",
     "@headlessui/tailwindcss": "^0.1.2",

--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.11",
-    "@arbitrum/sdk": "^3.1.13-orbit-custom-fee-token.1",
+    "@arbitrum/sdk": "^3.2.0-beta.1-custom-fee-token.0",
     "@ethersproject/providers": "^5.7.0",
     "@headlessui/react": "^1.7.8",
     "@headlessui/tailwindcss": "^0.1.2",

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
@@ -215,7 +215,11 @@ export const TransactionHistoryTable = ({
             There are no recent {isPendingTab ? 'pending' : 'settled'}{' '}
             transactions.
           </span>
-          <button onClick={resume} className="arb-hover text-sm">
+          <button
+            onClick={resume}
+            className="arb-hover text-sm"
+            aria-label="Load more"
+          >
             <div className="flex space-x-1 rounded border border-black px-2 py-1">
               <span>Load more</span>
               <ArrowDownOnSquareIcon width={16} />
@@ -258,7 +262,11 @@ export const TransactionHistoryTable = ({
             </div>
 
             {!completed && (
-              <button onClick={resume} className="arb-hover text-sm">
+              <button
+                onClick={resume}
+                className="arb-hover text-sm"
+                aria-label="Load more"
+              >
                 <div className="flex space-x-1 rounded border border-black px-2 py-1">
                   <span>Load more</span>
                   <ArrowDownOnSquareIcon width={16} />

--- a/packages/arb-token-bridge-ui/src/components/common/AddCustomChain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/AddCustomChain.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 import { isAddress } from 'ethers/lib/utils.js'
 import { Popover } from '@headlessui/react'
-import { addCustomNetwork } from '@arbitrum/sdk'
+import {
+  addCustomNetwork,
+  constants as arbitrumSdkConstants
+} from '@arbitrum/sdk'
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { EllipsisHorizontalIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { constants } from 'ethers'
@@ -190,10 +193,12 @@ async function mapOrbitConfigToOrbitChain(
     isCustom: true,
     name: data.chainInfo.chainName,
     partnerChainID: data.chainInfo.parentChainId,
+    partnerChainIDs: [],
     retryableLifetimeSeconds: 604800,
     nitroGenesisBlock: 0,
     nitroGenesisL1Block: 0,
     depositTimeout: 900000,
+    blockTime: arbitrumSdkConstants.ARB_MINIMUM_BLOCK_TIME_IN_SECONDS,
     nativeToken: data.chainInfo.nativeToken,
     isArbitrum: true,
     tokenBridge: {

--- a/packages/arb-token-bridge-ui/src/components/common/AddCustomChain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/AddCustomChain.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { isAddress } from 'ethers/lib/utils.js'
 import { Popover } from '@headlessui/react'
-import { addCustomChain } from '@arbitrum/sdk'
+import { addCustomNetwork } from '@arbitrum/sdk'
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { EllipsisHorizontalIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { constants } from 'ethers'
@@ -264,7 +264,7 @@ export const AddCustomChain = () => {
       const nativeToken = await fetchNativeToken(data)
       // Orbit config has been validated and will be added to the custom list after page refreshes
       // let's still try to add it here to handle eventual errors
-      addCustomChain({ customChain })
+      addCustomNetwork({ customL2Network: customChain })
       saveCustomChainToLocalStorage({ ...customChain, ...nativeToken })
       saveOrbitConfigToLocalStorage(data)
       // reload to apply changes

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/helpers.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/helpers.ts
@@ -1,3 +1,5 @@
+import { constants } from '@arbitrum/sdk'
+
 import { ChainWithRpcUrl } from '../../util/networks'
 
 export function createMockOrbitChain({
@@ -25,6 +27,7 @@ export function createMockOrbitChain({
     name: `Mocked Orbit Chain ${chainId}`,
     slug: `mocked-orbit-chain-${chainId}`,
     partnerChainID: parentChainId,
+    partnerChainIDs: [],
     retryableLifetimeSeconds: 604800,
     tokenBridge: {
       l1CustomGateway: '',
@@ -44,6 +47,7 @@ export function createMockOrbitChain({
     },
     nitroGenesisBlock: 0,
     nitroGenesisL1Block: 0,
-    depositTimeout: 1800000
+    depositTimeout: 1800000,
+    blockTime: constants.ARB_MINIMUM_BLOCK_TIME_IN_SECONDS
   }
 }

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useArbQueryParams.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useArbQueryParams.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { addCustomChain } from '@arbitrum/sdk'
+import { addCustomNetwork } from '@arbitrum/sdk'
 import { ChainId, customChainLocalStorageKey } from '../../util/networks'
 import { AmountQueryParam, ChainParam } from '../useArbQueryParams'
 import { createMockOrbitChain } from './helpers'
@@ -224,7 +224,7 @@ describe('ChainParam custom encoder and decoder', () => {
         chainId: 222222,
         parentChainId: 1
       })
-      addCustomChain({ customChain })
+      addCustomNetwork({ customL2Network: customChain })
       expect(ChainParam.decode('222222')).toEqual(222222)
     })
   })

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useNetworks.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useNetworks.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { addCustomChain } from '@arbitrum/sdk'
+import { addCustomNetwork } from '@arbitrum/sdk'
 import { ChainId, customChainLocalStorageKey } from '../../util/networks'
 import { sanitizeQueryParams } from '../useNetworks'
 import { createMockOrbitChain } from './helpers'
@@ -40,10 +40,10 @@ describe('sanitizeQueryParams', () => {
         return null
       }
     )
-    addCustomChain({ customChain: mockedOrbitChain_1 })
-    addCustomChain({ customChain: mockedOrbitChain_2 })
-    addCustomChain({ customChain: mockedOrbitChain_3 })
-    addCustomChain({ customChain: mockedOrbitChain_4 })
+    addCustomNetwork({ customL2Network: mockedOrbitChain_1 })
+    addCustomNetwork({ customL2Network: mockedOrbitChain_2 })
+    addCustomNetwork({ customL2Network: mockedOrbitChain_3 })
+    addCustomNetwork({ customL2Network: mockedOrbitChain_4 })
   })
 
   afterAll(() => {

--- a/packages/arb-token-bridge-ui/src/hooks/useNativeCurrency.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useNativeCurrency.ts
@@ -1,5 +1,5 @@
 import { Provider, StaticJsonRpcProvider } from '@ethersproject/providers'
-import { EthBridger, getChain, L2Network } from '@arbitrum/sdk'
+import { EthBridger, L2Network, getL2Network } from '@arbitrum/sdk'
 import useSWRImmutable from 'swr/immutable'
 
 import { ETHER_TOKEN_LOGO, ether } from '../constants'
@@ -60,7 +60,7 @@ export async function fetchNativeCurrency({
   let chain: L2Network
 
   try {
-    chain = await getChain(provider)
+    chain = await getL2Network(provider)
   } catch (error) {
     // This will only throw for L1s, so we can safely assume that the native currency is ETH
     return nativeCurrencyEther

--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -438,7 +438,7 @@ export const useTransactionHistory = (
     useAccountType()
   const { connector } = useAccount()
   // max number of transactions mapped in parallel
-  const MAX_BATCH_SIZE = 10
+  const MAX_BATCH_SIZE = 3
   // Pause fetching after specified number of days. User can resume fetching to get another batch.
   const PAUSE_SIZE_DAYS = 30
 

--- a/packages/arb-token-bridge-ui/src/pages/index.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import dynamic from 'next/dynamic'
-import { addCustomChain, addCustomNetwork } from '@arbitrum/sdk'
+import { addCustomNetwork } from '@arbitrum/sdk'
 
 import { AppConnectionFallbackContainer } from '../components/App/AppConnectionFallbackContainer'
 import { Loader } from '../components/common/atoms/Loader'
@@ -26,15 +26,8 @@ export default function Index() {
     ;[...getOrbitChains(), ...getCustomChainsFromLocalStorage()].forEach(
       chain => {
         try {
-          addCustomChain({ customChain: chain })
-          mapCustomChainToNetworkData(chain)
-        } catch (_) {
-          // already added
-        }
-
-        try {
-          // adding to L2 networks too to be fully compatible with the sdk
           addCustomNetwork({ customL2Network: chain })
+          mapCustomChainToNetworkData(chain)
         } catch (_) {
           // already added
         }

--- a/packages/arb-token-bridge-ui/src/util/EthDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/EthDepositUtils.ts
@@ -1,4 +1,4 @@
-import { EthBridger, getChain } from '@arbitrum/sdk'
+import { EthBridger, getL2Network } from '@arbitrum/sdk'
 import { Provider } from '@ethersproject/providers'
 import { BigNumber, constants } from 'ethers'
 
@@ -20,7 +20,7 @@ async function customFeeTokenAllowanceIsInsufficient(
   params: DepositEthEstimateGasParams
 ) {
   const { amount, address, l1Provider, l2Provider } = params
-  const l2Network = await getChain(l2Provider)
+  const l2Network = await getL2Network(l2Provider)
 
   if (typeof l2Network.nativeToken === 'undefined') {
     throw new Error(

--- a/packages/arb-token-bridge-ui/src/util/__tests__/networks.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/__tests__/networks.test.ts
@@ -1,5 +1,4 @@
-import { constants } from '@arbitrum/sdk'
-import { addCustomNetwork } from '@arbitrum/sdk/dist/lib/dataEntities/networks'
+import { constants, addCustomNetwork } from '@arbitrum/sdk'
 
 import { ChainId, getBaseChainIdByChainId } from '../networks'
 import { orbitTestnets } from '../orbitChainsList'

--- a/packages/arb-token-bridge-ui/src/util/__tests__/networks.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/__tests__/networks.test.ts
@@ -1,4 +1,5 @@
-import { addCustomChain } from '@arbitrum/sdk/dist/lib/dataEntities/networks'
+import { constants } from '@arbitrum/sdk'
+import { addCustomNetwork } from '@arbitrum/sdk/dist/lib/dataEntities/networks'
 
 import { ChainId, getBaseChainIdByChainId } from '../networks'
 import { orbitTestnets } from '../orbitChainsList'
@@ -13,8 +14,8 @@ beforeAll(() => {
   }
 
   // add local
-  addCustomChain({
-    customParentChain: {
+  addCustomNetwork({
+    customL1Network: {
       blockTime: 10,
       chainID: 1337,
       explorerUrl: '',
@@ -23,7 +24,7 @@ beforeAll(() => {
       partnerChainIDs: [412346],
       isArbitrum: false
     },
-    customChain: {
+    customL2Network: {
       chainID: 412346,
       partnerChainIDs: [
         // Orbit chains will go here
@@ -45,6 +46,7 @@ beforeAll(() => {
       nitroGenesisBlock: 0,
       nitroGenesisL1Block: 0,
       depositTimeout: 900000,
+      blockTime: constants.ARB_MINIMUM_BLOCK_TIME_IN_SECONDS,
       tokenBridge: {
         l1CustomGateway: '0x75E0E92A79880Bd81A69F72983D03c75e2B33dC8',
         l1ERC20Gateway: '0x4Af567288e68caD4aA93A272fe6139Ca53859C70',
@@ -64,8 +66,8 @@ beforeAll(() => {
     }
   })
 
-  addCustomChain({
-    customChain: xaiTestnet
+  addCustomNetwork({
+    customL2Network: xaiTestnet
   })
 })
 

--- a/packages/arb-token-bridge-ui/src/util/fetchL2Gateways.ts
+++ b/packages/arb-token-bridge-ui/src/util/fetchL2Gateways.ts
@@ -20,7 +20,6 @@ export async function fetchL2Gateways(l2Provider: Provider) {
   const { l2ERC20Gateway, l2CustomGateway, l2WethGateway } =
     l2Network.tokenBridge
   const gatewaysToUse = [l2ERC20Gateway, l2CustomGateway, l2WethGateway]
-
   const l2ArbReverseGateway = l2ArbReverseGatewayAddresses[l2Network.chainID]
   const l2DaiGateway = l2DaiGatewayAddresses[l2Network.chainID]
   const l2wstETHGateway = l2wstETHGatewayAddresses[l2Network.chainID]

--- a/packages/arb-token-bridge-ui/src/util/fetchL2Gateways.ts
+++ b/packages/arb-token-bridge-ui/src/util/fetchL2Gateways.ts
@@ -13,18 +13,13 @@ import {
  *
  * @param l2Provider Provider for the L2 network
  */
-export async function fetchL2Gateways(l2Provider: Provider): Promise<string[]> {
+export async function fetchL2Gateways(l2Provider: Provider) {
   const l2Network = await getL2Network(l2Provider)
 
   /* configure gateway addresses for fetching withdrawals */
   const { l2ERC20Gateway, l2CustomGateway, l2WethGateway } =
     l2Network.tokenBridge
-
-  const gatewaysToUse = [l2ERC20Gateway, l2CustomGateway]
-
-  if (l2WethGateway) {
-    gatewaysToUse.push(l2WethGateway)
-  }
+  const gatewaysToUse = [l2ERC20Gateway, l2CustomGateway, l2WethGateway]
 
   const l2ArbReverseGateway = l2ArbReverseGatewayAddresses[l2Network.chainID]
   const l2DaiGateway = l2DaiGatewayAddresses[l2Network.chainID]

--- a/packages/arb-token-bridge-ui/src/util/fetchL2Gateways.ts
+++ b/packages/arb-token-bridge-ui/src/util/fetchL2Gateways.ts
@@ -13,13 +13,19 @@ import {
  *
  * @param l2Provider Provider for the L2 network
  */
-export async function fetchL2Gateways(l2Provider: Provider) {
+export async function fetchL2Gateways(l2Provider: Provider): Promise<string[]> {
   const l2Network = await getL2Network(l2Provider)
 
   /* configure gateway addresses for fetching withdrawals */
   const { l2ERC20Gateway, l2CustomGateway, l2WethGateway } =
     l2Network.tokenBridge
-  const gatewaysToUse = [l2ERC20Gateway, l2CustomGateway, l2WethGateway]
+
+  const gatewaysToUse = [l2ERC20Gateway, l2CustomGateway]
+
+  if (l2WethGateway) {
+    gatewaysToUse.push(l2WethGateway)
+  }
+
   const l2ArbReverseGateway = l2ArbReverseGatewayAddresses[l2Network.chainID]
   const l2DaiGateway = l2DaiGatewayAddresses[l2Network.chainID]
   const l2wstETHGateway = l2wstETHGatewayAddresses[l2Network.chainID]

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -4,16 +4,12 @@ import {
   addCustomNetwork,
   constants
 } from '@arbitrum/sdk'
-import {
-  networks as arbitrumSdkChains,
-  l2Networks as arbitrumSdkArbitrumChains
-} from '@arbitrum/sdk/dist/lib/dataEntities/networks'
+import { networks as arbitrumSdkChains } from '@arbitrum/sdk/dist/lib/dataEntities/networks'
 
 import { loadEnvironmentVariableWithFallback } from './index'
 import { getBridgeUiConfigForChain } from './bridgeUiConfig'
 import { orbitMainnets, orbitTestnets } from './orbitChainsList'
 
-// TODO: when the main branch of SDK supports Orbit chains, we should be able to fetch it from a single object instead
 export const getChains = () => {
   const chains = Object.values(arbitrumSdkChains)
   return chains.filter(chain => chain.chainID !== 1338)
@@ -208,8 +204,8 @@ export const getBlockTime = (chainId: ChainId) => {
 }
 
 export const getConfirmPeriodBlocks = (chainId: ChainId) => {
-  const network = arbitrumSdkArbitrumChains[chainId]
-  if (!network) {
+  const network = arbitrumSdkChains[chainId]
+  if (!network || !isArbitrumChain(network)) {
     throw new Error(
       `Couldn't get confirm period blocks. Unexpected chain ID: ${chainId}`
     )

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -60,7 +60,7 @@ export function getBaseChainIdByChainId({
     return chainId
   }
 
-  let currentParentChain: L1Network | L2Network = getParentChain(chain)
+  let currentParentChain = getParentChain(chain)
   // keep following the parent chains until we find the L1 chain
   while (!isL1Chain(currentParentChain)) {
     currentParentChain = getParentChain(currentParentChain)

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -1,11 +1,12 @@
-import { L1Network, L2Network, addCustomNetwork } from '@arbitrum/sdk'
 import {
-  Chain,
-  ParentChain,
-  l2Networks,
-  chains as arbitrumSdkChains,
-  parentChains as arbitrumSdkParentChains,
-  addCustomChain
+  L1Network,
+  L2Network,
+  addCustomNetwork,
+  constants
+} from '@arbitrum/sdk'
+import {
+  networks as arbitrumSdkChains,
+  l2Networks as arbitrumSdkArbitrumChains
 } from '@arbitrum/sdk/dist/lib/dataEntities/networks'
 
 import { loadEnvironmentVariableWithFallback } from './index'
@@ -14,10 +15,7 @@ import { orbitMainnets, orbitTestnets } from './orbitChainsList'
 
 // TODO: when the main branch of SDK supports Orbit chains, we should be able to fetch it from a single object instead
 export const getChains = () => {
-  const chains = Object.values({
-    ...arbitrumSdkChains,
-    ...arbitrumSdkParentChains
-  })
+  const chains = Object.values(arbitrumSdkChains)
   return chains.filter(chain => chain.chainID !== 1338)
 }
 
@@ -33,7 +31,7 @@ const MAINNET_INFURA_RPC_URL = `https://mainnet.infura.io/v3/${INFURA_KEY}`
 const GOERLI_INFURA_RPC_URL = `https://goerli.infura.io/v3/${INFURA_KEY}`
 const SEPOLIA_INFURA_RPC_URL = `https://sepolia.infura.io/v3/${INFURA_KEY}`
 
-export type ChainWithRpcUrl = Chain & {
+export type ChainWithRpcUrl = L2Network & {
   rpcUrl: string
   slug?: string
 }
@@ -45,11 +43,11 @@ export function getBaseChainIdByChainId({
 }): number {
   const chain = arbitrumSdkChains[chainId]
 
-  if (!chain || !chain.partnerChainID) {
+  if (!chain || isL1Chain(chain)) {
     return chainId
   }
 
-  const parentChain = arbitrumSdkParentChains[chain.partnerChainID]
+  const parentChain = arbitrumSdkChains[chain.partnerChainID]
 
   if (!parentChain) {
     return chainId
@@ -195,15 +193,15 @@ export const getExplorerUrl = (chainId: ChainId) => {
 }
 
 export const getBlockTime = (chainId: ChainId) => {
-  const network = arbitrumSdkParentChains[chainId]
+  const network = arbitrumSdkChains[chainId]
   if (!network) {
     throw new Error(`Couldn't get block time. Unexpected chain ID: ${chainId}`)
   }
-  return (network as L1Network).blockTime ?? 12
+  return network.blockTime
 }
 
 export const getConfirmPeriodBlocks = (chainId: ChainId) => {
-  const network = l2Networks[chainId] || arbitrumSdkChains[chainId]
+  const network = arbitrumSdkArbitrumChains[chainId]
   if (!network) {
     throw new Error(
       `Couldn't get confirm period blocks. Unexpected chain ID: ${chainId}`
@@ -241,7 +239,7 @@ const defaultL1Network: L1Network = {
   isArbitrum: false
 }
 
-const defaultL2Network: ParentChain = {
+const defaultL2Network: L2Network = {
   chainID: 412346,
   partnerChainIDs: [
     // Orbit chains will go here
@@ -263,6 +261,7 @@ const defaultL2Network: ParentChain = {
   nitroGenesisBlock: 0,
   nitroGenesisL1Block: 0,
   depositTimeout: 900000,
+  blockTime: constants.ARB_MINIMUM_BLOCK_TIME_IN_SECONDS,
   tokenBridge: {
     l1CustomGateway: '0x75E0E92A79880Bd81A69F72983D03c75e2B33dC8',
     l1ERC20Gateway: '0x4Af567288e68caD4aA93A272fe6139Ca53859C70',
@@ -312,11 +311,6 @@ export function registerLocalNetwork(
     addCustomNetwork({ customL1Network: l1Network, customL2Network: l2Network })
   } catch (error: any) {
     console.error(`Failed to register local network: ${error.message}`)
-  }
-  try {
-    addCustomChain({ customParentChain: l1Network, customChain: l2Network })
-  } catch (error: any) {
-    //
   }
 }
 
@@ -427,8 +421,12 @@ export function mapCustomChainToNetworkData(chain: ChainWithRpcUrl) {
   explorerUrls[chain.chainID] = chain.explorerUrl
 }
 
-function isChildChain(chain: L2Network | ParentChain): chain is L2Network {
-  return typeof (chain as L2Network).partnerChainID !== 'undefined'
+function isL1Chain(chain: L1Network | L2Network): chain is L1Network {
+  return !chain.isArbitrum
+}
+
+function isArbitrumChain(chain: L1Network | L2Network): chain is L2Network {
+  return chain.isArbitrum
 }
 
 export function getDestinationChainIds(chainId: ChainId): ChainId[] {
@@ -439,7 +437,7 @@ export function getDestinationChainIds(chainId: ChainId): ChainId[] {
     return []
   }
 
-  const parentChainId = isChildChain(arbitrumSdkChain)
+  const parentChainId = isArbitrumChain(arbitrumSdkChain)
     ? arbitrumSdkChain.partnerChainID
     : undefined
 

--- a/packages/arb-token-bridge-ui/src/util/orbitChainsList.ts
+++ b/packages/arb-token-bridge-ui/src/util/orbitChainsList.ts
@@ -1,3 +1,4 @@
+import { constants } from '@arbitrum/sdk'
 import { NativeCurrencyBase } from '../hooks/useNativeCurrency'
 import { ChainWithRpcUrl } from './networks'
 
@@ -36,6 +37,7 @@ export const orbitMainnets: {
     name: 'Xai',
     slug: 'xai',
     partnerChainID: 42161,
+    partnerChainIDs: [],
     retryableLifetimeSeconds: 604800,
     tokenBridge: {
       l1CustomGateway: '0xb15A0826d65bE4c2fDd961b72636168ee70Af030',
@@ -56,6 +58,7 @@ export const orbitMainnets: {
     nitroGenesisBlock: 0,
     nitroGenesisL1Block: 0,
     depositTimeout: 1800000,
+    blockTime: constants.ARB_MINIMUM_BLOCK_TIME_IN_SECONDS,
     bridgeUiConfig: {
       color: {
         primary: '#F30019',
@@ -90,6 +93,7 @@ export const orbitMainnets: {
     name: 'RARI Mainnet',
     slug: 'rari-mainnet',
     partnerChainID: 42161,
+    partnerChainIDs: [],
     retryableLifetimeSeconds: 604800,
     tokenBridge: {
       l1CustomGateway: '0x8bE956aB42274056ef4471BEb211b33e258b7324',
@@ -110,6 +114,7 @@ export const orbitMainnets: {
     nitroGenesisBlock: 0,
     nitroGenesisL1Block: 0,
     depositTimeout: 1800000,
+    blockTime: constants.ARB_MINIMUM_BLOCK_TIME_IN_SECONDS,
     bridgeUiConfig: {
       color: {
         primary: '#B16EFF',
@@ -141,6 +146,7 @@ export const orbitTestnets: { [key in number]: OrbitChainConfig } = {
     name: 'Xai Orbit Testnet',
     slug: 'xai-testnet',
     partnerChainID: 421613,
+    partnerChainIDs: [],
     retryableLifetimeSeconds: 604800,
     tokenBridge: {
       l1CustomGateway: '0xdBbDc3EE848C05792CC93EA140c59731f920c3F2',
@@ -161,6 +167,7 @@ export const orbitTestnets: { [key in number]: OrbitChainConfig } = {
     nitroGenesisBlock: 0,
     nitroGenesisL1Block: 0,
     depositTimeout: 1800000,
+    blockTime: constants.ARB_MINIMUM_BLOCK_TIME_IN_SECONDS,
     bridgeUiConfig: {
       color: {
         primary: '#F30019',

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/txHistory.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/txHistory.cy.ts
@@ -20,6 +20,20 @@ describe('Transaction History', () => {
         .and('equal', 'selected')
     })
 
+    // We load 3 transactions in a batch, and only we load more only if these transactions happen last month
+    // Out 3 most recent transactions are settled transactions.
+    // That means 'Load more' button click is required to fetch our pending transaction.
+    cy.waitUntil(
+      () => cy.findByRole('button', { name: 'Load more' }).should('be.visible'),
+      {
+        errorMsg: 'Did not find Load more button.',
+        timeout: 30_000,
+        interval: 500
+      }
+    ).then(btn => {
+      cy.wrap(btn).click()
+    })
+
     // wait for transactions to fetch
     cy.waitUntil(
       () =>

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/txHistory.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/txHistory.cy.ts
@@ -20,8 +20,8 @@ describe('Transaction History', () => {
         .and('equal', 'selected')
     })
 
-    // We load 3 transactions in a batch, and only we load more only if these transactions happen last month
-    // Out 3 most recent transactions are settled transactions.
+    // We load 3 transactions in a batch, and only we load more only if these transactions happened last month
+    // Our 3 most recent transactions are settled transactions.
     // That means 'Load more' button click is required to fetch our pending transaction.
     cy.waitUntil(
       () => cy.findByRole('button', { name: 'Load more' }).should('be.visible'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@arbitrum/sdk@^3.1.13-orbit-custom-fee-token.1":
-  version "3.1.13-orbit-custom-fee-token.1"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.1.13-orbit-custom-fee-token.1.tgz#c10e26c71447eb8c9d0cb1c6efe26c57841b18b7"
-  integrity sha512-DkKk92Ga1lAsn0FZ+6/HAMcPHdmdAvCalZYfWhyHxTQXYdAWDA9Pz0gRi1KaOBPV2eQn7t64Cluz9Z3LU+7Bog==
+"@arbitrum/sdk@^3.2.0-beta.1-custom-fee-token.0":
+  version "3.2.0-beta.1-custom-fee-token.0"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.2.0-beta.1-custom-fee-token.0.tgz#181df887b1af3958c425b2a6f4132c1bba88b2ee"
+  integrity sha512-ydIRN9EEz/A9UOUYY/iImBSLn+AH4lXsH4idZeNTw8IYItJS2yRov9NWqLeHjGl2YrwN0GnSK6ta0JFDay+N6w==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"
@@ -1283,6 +1283,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@ledgerhq/connect-kit-loader@^1.0.1":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.8.tgz#6cc32191660dd9d6e8f89047af09b0f201e30190"
+  integrity sha512-mDJsOucVW8m3Lk2fdQst+P74SgiKebvq1iBk4sXLbADQOwhL9bWGaArvO+tW7jPJZwEfSPWBdHcHoYi11XAwZw==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@arbitrum/sdk@^3.2.0-beta.1-custom-fee-token.1":
-  version "3.2.0-beta.1-custom-fee-token.1"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.2.0-beta.1-custom-fee-token.1.tgz#d90504bfd70e687676034c19d26e15b7fbf98038"
-  integrity sha512-RWLFlW+UpvFsYFPtWwIDZqH+a0sMZRmZxf7wv82q4U98j8ozIzzv/7dJoD9wjXfE8quZL1wz+vZ2oiT5r6hlxw==
+"@arbitrum/sdk@^3.2.0-beta.2-custom-fee-token.0":
+  version "3.2.0-beta.2-custom-fee-token.0"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.2.0-beta.2-custom-fee-token.0.tgz#fb6aa644c60187653931c7f49dc807111fbca9eb"
+  integrity sha512-+2GAmNNxRx7wCTK8VhTGOxCSXlohQx//uaVBiPtNlbX/G81BUlW/UQBI9KF8Iu6sirSpr3OqVD8hZ2v8eSxXMQ==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@arbitrum/sdk@^3.2.0-beta.2-custom-fee-token.0":
-  version "3.2.0-beta.2-custom-fee-token.0"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.2.0-beta.2-custom-fee-token.0.tgz#fb6aa644c60187653931c7f49dc807111fbca9eb"
-  integrity sha512-+2GAmNNxRx7wCTK8VhTGOxCSXlohQx//uaVBiPtNlbX/G81BUlW/UQBI9KF8Iu6sirSpr3OqVD8hZ2v8eSxXMQ==
+"@arbitrum/sdk@^3.2.0-custom-fee-token.0":
+  version "3.2.0-custom-fee-token.0"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.2.0-custom-fee-token.0.tgz#7cd90e0819e68785a6660f1eacb7027f61d8c19f"
+  integrity sha512-x76mRShzMn+VTt4NAl8BEcZL0/3RQCXZ5UnwpAtzPqU+HJV8wrBEP4SHDJwQgu+XWwBPaegiInG8FmgcM5ph0g==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"
@@ -1283,11 +1283,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
-
-"@ledgerhq/connect-kit-loader@^1.0.1":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.8.tgz#6cc32191660dd9d6e8f89047af09b0f201e30190"
-  integrity sha512-mDJsOucVW8m3Lk2fdQst+P74SgiKebvq1iBk4sXLbADQOwhL9bWGaArvO+tW7jPJZwEfSPWBdHcHoYi11XAwZw==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@arbitrum/sdk@^3.2.0-beta.1-custom-fee-token.0":
-  version "3.2.0-beta.1-custom-fee-token.0"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.2.0-beta.1-custom-fee-token.0.tgz#181df887b1af3958c425b2a6f4132c1bba88b2ee"
-  integrity sha512-ydIRN9EEz/A9UOUYY/iImBSLn+AH4lXsH4idZeNTw8IYItJS2yRov9NWqLeHjGl2YrwN0GnSK6ta0JFDay+N6w==
+"@arbitrum/sdk@^3.2.0-beta.1-custom-fee-token.1":
+  version "3.2.0-beta.1-custom-fee-token.1"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.2.0-beta.1-custom-fee-token.1.tgz#d90504bfd70e687676034c19d26e15b7fbf98038"
+  integrity sha512-RWLFlW+UpvFsYFPtWwIDZqH+a0sMZRmZxf7wv82q4U98j8ozIzzv/7dJoD9wjXfE8quZL1wz+vZ2oiT5r6hlxw==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"


### PR DESCRIPTION
### Summary

Bumps the version of `@arbitrum/sdk` to `3.2.0-custom-fee-token.0` which is the latest stable release with additional (unstable) custom gas token changes on top. The custom gas token changes should land in a stable release soon. 

### Steps to test

Everything should work exactly the same.
