### PR TITLE
ci: use ubuntu-8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -166,7 +166,7 @@ jobs:
 
   test-e2e:
     name: "Test E2E"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-8
     needs: [install, check-files, check-is-hotfix, load-e2e-files]
     if: needs.check-files.outputs.run_tests == 'true' && needs.check-is-hotfix.outputs.is_hotfix == 'false'
     strategy:


### PR DESCRIPTION
`ubuntu-latest` is the same as `ubuntu-4`
(Ubuntu Latest (22.04) · 4-cores · 16 GB RAM · 150 GB SSD)

and the only different one we have available is `ubuntu-8`
(Ubuntu Latest (22.04) · 8-cores · 32 GB RAM · 300 GB SSD)