### PR TITLE
fix: show USDC names correctly on orbit chain pairs

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/EstimatedGas.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/EstimatedGas.tsx
@@ -12,7 +12,7 @@ import { Loader } from '../common/atoms/Loader'
 import { useNetworks } from '../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
 import { NativeCurrencyPrice } from './NativeCurrencyPrice'
-import { isTokenUSDC } from '../../util/TokenUtils'
+import { isTokenNativeUSDC } from '../../util/TokenUtils'
 
 function getGasFeeTooltip(chainId: ChainId) {
   const { isEthereumMainnetOrTestnet } = isNetwork(chainId)
@@ -78,8 +78,6 @@ export function EstimatedGas({
 
   const isWithdrawalParentChain = !isDepositMode && isParentChain
 
-  const isCCTP = selectedToken && isTokenUSDC(selectedToken.address)
-
   const estimatedGasFee = useMemo(() => {
     if (!isDepositMode && !isParentChain) {
       return estimatedL1GasFees + estimatedL2GasFees
@@ -99,7 +97,7 @@ export function EstimatedGas({
     return <GasFeeForClaimTxMessage networkName={parentChainName} />
   }
 
-  if (isCCTP && !isSourceChain) {
+  if (isTokenNativeUSDC(selectedToken?.address) && !isSourceChain) {
     return (
       <GasFeeForClaimTxMessage networkName={networks.destinationChain.name} />
     )

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -24,8 +24,7 @@ export function TokenButton(): JSX.Element {
     }
   } = useAppState()
   const [networks] = useNetworks()
-  const { childChain, childChainProvider, parentChain, isDepositMode } =
-    useNetworksRelationship(networks)
+  const { childChainProvider } = useNetworksRelationship(networks)
 
   const nativeCurrency = useNativeCurrency({ provider: childChainProvider })
 
@@ -51,7 +50,6 @@ export function TokenButton(): JSX.Element {
     selectedToken?.address,
     arbTokenBridgeLoaded
   ])
-  const chainId = isDepositMode ? parentChain.id : childChain.id
 
   const tokenSymbol = useMemo(() => {
     if (!selectedToken) {
@@ -60,9 +58,9 @@ export function TokenButton(): JSX.Element {
 
     return sanitizeTokenSymbol(selectedToken.symbol, {
       erc20L1Address: selectedToken.address,
-      chainId
+      chainId: networks.sourceChain.id
     })
-  }, [selectedToken, chainId, nativeCurrency.symbol])
+  }, [selectedToken, networks.sourceChain.id, nativeCurrency.symbol])
 
   return (
     <>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenDepositCheckDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenDepositCheckDialog.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react'
 
 import { Dialog, UseDialogProps } from '../common/Dialog'
 import { DOCS_DOMAIN } from '../../constants'
+import { useNetworks } from '../../hooks/useNetworks'
+import { getNetworkName } from '../../util/networks'
 
 export type TokenDepositCheckDialogType = 'user-added-token' | 'new-token'
 
@@ -13,12 +15,16 @@ export type TokenDepositCheckDialogProps = UseDialogProps & {
 export function TokenDepositCheckDialog(props: TokenDepositCheckDialogProps) {
   const { type, symbol } = props
 
+  const [networks] = useNetworks()
+
+  const networkName = getNetworkName(networks.destinationChain.id)
+
   const textContent = useMemo(() => {
     switch (type) {
       case 'user-added-token':
         return (
           <>
-            You are about to deposit {symbol} to Arbitrum 🎉 <br />
+            You are about to deposit {symbol} to {networkName} 🎉 <br />
             <br />
             <span className="text-red-600">Do not bridge</span> if your token
             does something non-standard like generates passive interest or is a
@@ -55,7 +61,7 @@ export function TokenDepositCheckDialog(props: TokenDepositCheckDialogProps) {
       case 'new-token':
         return (
           <>
-            You are the first to bridge {symbol} to Arbitrum 🎉 <br />
+            You are the first to bridge {symbol} to {networkName} 🎉 <br />
             <br />
             <b>Important facts</b>
             <ol>
@@ -97,17 +103,17 @@ export function TokenDepositCheckDialog(props: TokenDepositCheckDialogProps) {
           </>
         )
     }
-  }, [type, symbol])
+  }, [type, symbol, networkName])
 
   const title = useMemo(() => {
     switch (type) {
       case 'user-added-token':
-        return `Depositing ${symbol} to Arbitrum`
+        return `Depositing ${symbol} to ${networkName}`
 
       case 'new-token':
         return 'New Token Detected'
     }
-  }, [type, symbol])
+  }, [type, symbol, networkName])
 
   return (
     <Dialog {...props} title={title}>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -30,7 +30,7 @@ import {
 } from './TransferPanelMainUtils'
 import { useBalance } from '../../hooks/useBalance'
 import { useGasPrice } from '../../hooks/useGasPrice'
-import { ERC20BridgeToken, TokenType } from '../../hooks/arbTokenBridge.types'
+import { ERC20BridgeToken } from '../../hooks/arbTokenBridge.types'
 import { useAccountType } from '../../hooks/useAccountType'
 import { depositEthEstimateGas } from '../../util/EthDepositUtils'
 import { withdrawInitTxEstimateGas } from '../../util/WithdrawalUtils'
@@ -67,6 +67,7 @@ import {
   useTransferDisabledDialogStore
 } from './TransferDisabledDialog'
 import { getBridgeUiConfigForChain } from '../../util/bridgeUiConfig'
+import { useUpdateUSDCTokenData } from './TransferPanelMain/hooks'
 
 enum NetworkType {
   l1 = 'l1',
@@ -314,15 +315,27 @@ export function TransferPanelMain({
     useAccountType()
   const { isArbitrumOne, isArbitrumSepolia } = isNetwork(childChain.id)
 
+  const isSepoliaArbSepoliaPair =
+    (networks.sourceChain.id === ChainId.Sepolia &&
+      networks.destinationChain.id === ChainId.ArbitrumSepolia) ||
+    (networks.sourceChain.id === ChainId.ArbitrumSepolia &&
+      networks.destinationChain.id === ChainId.Sepolia)
+
+  const isEthereumArbitrumOnePair =
+    (networks.sourceChain.id === ChainId.Ethereum &&
+      networks.destinationChain.id === ChainId.ArbitrumOne) ||
+    (networks.sourceChain.id === ChainId.ArbitrumOne &&
+      networks.destinationChain.id === ChainId.Ethereum)
+
   const nativeCurrency = useNativeCurrency({ provider: childChainProvider })
 
   const l1GasPrice = useGasPrice({ provider: parentChainProvider })
   const l2GasPrice = useGasPrice({ provider: childChainProvider })
 
-  const { app } = useAppState()
+  const {
+    app: { selectedToken }
+  } = useAppState()
   const { address: walletAddress } = useAccount()
-  const { arbTokenBridge, selectedToken } = app
-  const { token } = arbTokenBridge
 
   const { destinationAddress, setDestinationAddress } =
     useDestinationAddressStore()
@@ -436,6 +449,7 @@ export function TransferPanelMain({
 
     if (
       isTokenArbitrumOneNativeUSDC(selectedToken.address) &&
+      isEthereumArbitrumOnePair &&
       erc20L1Balances &&
       erc20L2Balances
     ) {
@@ -446,6 +460,7 @@ export function TransferPanelMain({
     }
     if (
       isTokenArbitrumSepoliaNativeUSDC(selectedToken.address) &&
+      isSepoliaArbSepoliaPair &&
       erc20L1Balances &&
       erc20L2Balances
     ) {
@@ -456,7 +471,13 @@ export function TransferPanelMain({
     }
 
     return result
-  }, [erc20L1Balances, erc20L2Balances, selectedToken])
+  }, [
+    erc20L1Balances,
+    erc20L2Balances,
+    isEthereumArbitrumOnePair,
+    isSepoliaArbSepoliaPair,
+    selectedToken
+  ])
 
   const [loadingMaxAmount, setLoadingMaxAmount] = useState(false)
   const { openDialog: openTransferDisabledDialog } =
@@ -685,45 +706,7 @@ export function TransferPanelMain({
     })
   }, [networks.destinationChain.id, networks.sourceChain.id, setNetworks])
 
-  useEffect(() => {
-    const isArbOneUSDC = isTokenArbitrumOneNativeUSDC(selectedToken?.address)
-    const isArbSepoliaUSDC = isTokenArbitrumSepoliaNativeUSDC(
-      selectedToken?.address
-    )
-    // If user select native USDC on L2, when switching to deposit mode,
-    // we need to default to set the corresponding USDC on L1
-    if (!isDepositMode) {
-      return
-    }
-
-    // When switching network, token might be undefined
-    if (!token) {
-      return
-    }
-
-    const commonUSDC = {
-      name: 'USD Coin',
-      type: TokenType.ERC20,
-      symbol: 'USDC',
-      decimals: 6,
-      listIds: new Set<number>()
-    }
-    if (isArbOneUSDC) {
-      token.updateTokenData(CommonAddress.Ethereum.USDC)
-      actions.app.setSelectedToken({
-        ...commonUSDC,
-        address: CommonAddress.Ethereum.USDC,
-        l2Address: CommonAddress.ArbitrumOne['USDC.e']
-      })
-    } else if (isArbSepoliaUSDC) {
-      token.updateTokenData(CommonAddress.Sepolia.USDC)
-      actions.app.setSelectedToken({
-        ...commonUSDC,
-        address: CommonAddress.Sepolia.USDC,
-        l2Address: CommonAddress.ArbitrumSepolia['USDC.e']
-      })
-    }
-  }, [actions.app, isDepositMode, selectedToken, token])
+  useUpdateUSDCTokenData()
 
   type NetworkListboxesProps = {
     from: Pick<NetworkListboxProps, 'onChange'>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -314,18 +314,26 @@ export function TransferPanelMain({
   const { isSmartContractWallet, isLoading: isLoadingAccountType } =
     useAccountType()
   const { isArbitrumOne, isArbitrumSepolia } = isNetwork(childChain.id)
+  const {
+    isArbitrumOne: isSourceChainArbitrumOne,
+    isEthereumMainnet: isSourceChainEthereum,
+    isSepolia: isSourceChainSepolia,
+    isArbitrumSepolia: isSourceChainArbitrumSepolia
+  } = isNetwork(networks.sourceChain.id)
+  const {
+    isArbitrumOne: isDestinationChainArbitrumOne,
+    isEthereumMainnet: isDestinationChainEthereum,
+    isSepolia: isDestinationChainSepolia,
+    isArbitrumSepolia: isDestinationChainArbitrumSepolia
+  } = isNetwork(networks.destinationChain.id)
 
   const isSepoliaArbSepoliaPair =
-    (networks.sourceChain.id === ChainId.Sepolia &&
-      networks.destinationChain.id === ChainId.ArbitrumSepolia) ||
-    (networks.sourceChain.id === ChainId.ArbitrumSepolia &&
-      networks.destinationChain.id === ChainId.Sepolia)
+    (isSourceChainSepolia && isDestinationChainArbitrumSepolia) ||
+    (isSourceChainArbitrumSepolia && isDestinationChainSepolia)
 
   const isEthereumArbitrumOnePair =
-    (networks.sourceChain.id === ChainId.Ethereum &&
-      networks.destinationChain.id === ChainId.ArbitrumOne) ||
-    (networks.sourceChain.id === ChainId.ArbitrumOne &&
-      networks.destinationChain.id === ChainId.Ethereum)
+    (isSourceChainEthereum && isDestinationChainArbitrumOne) ||
+    (isSourceChainArbitrumOne && isDestinationChainEthereum)
 
   const nativeCurrency = useNativeCurrency({ provider: childChainProvider })
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/hooks.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/hooks.ts
@@ -9,7 +9,7 @@ import { useNetworks } from '../../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../../hooks/useNetworksRelationship'
 import { TokenType } from '../../../hooks/arbTokenBridge.types'
 import { CommonAddress } from '../../../util/CommonAddressUtils'
-import { ChainId } from '../../../util/networks'
+import { isNetwork } from '../../../util/networks'
 
 const commonUSDC = {
   name: 'USD Coin',
@@ -29,6 +29,10 @@ export function useUpdateUSDCTokenData() {
   } = useAppState()
   const [networks] = useNetworks()
   const { isDepositMode } = useNetworksRelationship(networks)
+  const {
+    isArbitrumOne: isDestinationChainArbitrumOne,
+    isArbitrumSepolia: isDestinationChainArbitrumSepolia
+  } = isNetwork(networks.destinationChain.id)
 
   useEffect(() => {
     const isArbOneUSDC = isTokenArbitrumOneNativeUSDC(selectedToken?.address)
@@ -42,7 +46,7 @@ export function useUpdateUSDCTokenData() {
       return
     }
 
-    if (isArbOneUSDC && networks.destinationChain.id === ChainId.ArbitrumOne) {
+    if (isArbOneUSDC && isDestinationChainArbitrumOne) {
       token.updateTokenData(CommonAddress.Ethereum.USDC)
       actions.app.setSelectedToken({
         ...commonUSDC,
@@ -51,10 +55,7 @@ export function useUpdateUSDCTokenData() {
       })
     }
 
-    if (
-      isArbSepoliaUSDC &&
-      networks.destinationChain.id === ChainId.ArbitrumSepolia
-    ) {
+    if (isArbSepoliaUSDC && isDestinationChainArbitrumSepolia) {
       token.updateTokenData(CommonAddress.Sepolia.USDC)
       actions.app.setSelectedToken({
         ...commonUSDC,
@@ -65,7 +66,8 @@ export function useUpdateUSDCTokenData() {
   }, [
     actions.app,
     isDepositMode,
-    networks.destinationChain.id,
+    isDestinationChainArbitrumOne,
+    isDestinationChainArbitrumSepolia,
     selectedToken,
     token
   ])

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/hooks.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/hooks.ts
@@ -1,0 +1,71 @@
+import { useEffect } from 'react'
+
+import {
+  isTokenArbitrumOneNativeUSDC,
+  isTokenArbitrumSepoliaNativeUSDC
+} from '../../../util/TokenUtils'
+import { useActions, useAppState } from '../../../state'
+import { useNetworks } from '../../../hooks/useNetworks'
+import { useNetworksRelationship } from '../../../hooks/useNetworksRelationship'
+import { TokenType } from '../../../hooks/arbTokenBridge.types'
+import { CommonAddress } from '../../../util/CommonAddressUtils'
+import { ChainId } from '../../../util/networks'
+
+export function useUpdateUSDCTokenData() {
+  const actions = useActions()
+  const {
+    app: { arbTokenBridge, selectedToken }
+  } = useAppState()
+  const { token } = arbTokenBridge
+  const [networks] = useNetworks()
+  const { isDepositMode } = useNetworksRelationship(networks)
+
+  useEffect(() => {
+    const isArbOneUSDC = isTokenArbitrumOneNativeUSDC(selectedToken?.address)
+    const isArbSepoliaUSDC = isTokenArbitrumSepoliaNativeUSDC(
+      selectedToken?.address
+    )
+    // If user select native USDC on L2, when switching to deposit mode,
+    // we need to default to set the corresponding USDC on L1
+    if (!isDepositMode) {
+      return
+    }
+
+    // When switching network, token might be undefined
+    if (!token) {
+      return
+    }
+
+    const commonUSDC = {
+      name: 'USD Coin',
+      type: TokenType.ERC20,
+      symbol: 'USDC',
+      decimals: 6,
+      listIds: new Set<number>()
+    }
+    if (isArbOneUSDC && networks.destinationChain.id === ChainId.ArbitrumOne) {
+      token.updateTokenData(CommonAddress.Ethereum.USDC)
+      actions.app.setSelectedToken({
+        ...commonUSDC,
+        address: CommonAddress.Ethereum.USDC,
+        l2Address: CommonAddress.ArbitrumOne['USDC.e']
+      })
+    } else if (
+      isArbSepoliaUSDC &&
+      networks.destinationChain.id === ChainId.ArbitrumSepolia
+    ) {
+      token.updateTokenData(CommonAddress.Sepolia.USDC)
+      actions.app.setSelectedToken({
+        ...commonUSDC,
+        address: CommonAddress.Sepolia.USDC,
+        l2Address: CommonAddress.ArbitrumSepolia['USDC.e']
+      })
+    }
+  }, [
+    actions.app,
+    isDepositMode,
+    networks.destinationChain.id,
+    selectedToken,
+    token
+  ])
+}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/hooks.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/hooks.ts
@@ -11,12 +11,22 @@ import { TokenType } from '../../../hooks/arbTokenBridge.types'
 import { CommonAddress } from '../../../util/CommonAddressUtils'
 import { ChainId } from '../../../util/networks'
 
+const commonUSDC = {
+  name: 'USD Coin',
+  type: TokenType.ERC20,
+  symbol: 'USDC',
+  decimals: 6,
+  listIds: new Set<number>()
+}
+
 export function useUpdateUSDCTokenData() {
   const actions = useActions()
   const {
-    app: { arbTokenBridge, selectedToken }
+    app: {
+      arbTokenBridge: { token },
+      selectedToken
+    }
   } = useAppState()
-  const { token } = arbTokenBridge
   const [networks] = useNetworks()
   const { isDepositMode } = useNetworksRelationship(networks)
 
@@ -25,24 +35,13 @@ export function useUpdateUSDCTokenData() {
     const isArbSepoliaUSDC = isTokenArbitrumSepoliaNativeUSDC(
       selectedToken?.address
     )
+
     // If user select native USDC on L2, when switching to deposit mode,
     // we need to default to set the corresponding USDC on L1
     if (!isDepositMode) {
       return
     }
 
-    // When switching network, token might be undefined
-    if (!token) {
-      return
-    }
-
-    const commonUSDC = {
-      name: 'USD Coin',
-      type: TokenType.ERC20,
-      symbol: 'USDC',
-      decimals: 6,
-      listIds: new Set<number>()
-    }
     if (isArbOneUSDC && networks.destinationChain.id === ChainId.ArbitrumOne) {
       token.updateTokenData(CommonAddress.Ethereum.USDC)
       actions.app.setSelectedToken({
@@ -50,7 +49,9 @@ export function useUpdateUSDCTokenData() {
         address: CommonAddress.Ethereum.USDC,
         l2Address: CommonAddress.ArbitrumOne['USDC.e']
       })
-    } else if (
+    }
+
+    if (
       isArbSepoliaUSDC &&
       networks.destinationChain.id === ChainId.ArbitrumSepolia
     ) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -3,9 +3,9 @@ import { twMerge } from 'tailwind-merge'
 
 import { formatAmount } from '../../util/NumberUtils'
 import {
-  ChainId,
   getBaseChainIdByChainId,
-  getNetworkName
+  getNetworkName,
+  isNetwork
 } from '../../util/networks'
 import { useNativeCurrency } from '../../hooks/useNativeCurrency'
 import { useGasSummary } from '../../hooks/TransferPanel/useGasSummary'
@@ -69,11 +69,15 @@ export function TransferPanelSummary({ token }: TransferPanelSummaryProps) {
 
   const [{ amount }] = useArbQueryParams()
 
+  const {
+    isArbitrumOne: isDestinationChainArbitrumOne,
+    isArbitrumSepolia: isDestinationChainArbitrumSepolia
+  } = isNetwork(networks.destinationChain.id)
+
   const isDepositingUSDCtoArbOneOrArbSepolia =
     isTokenUSDC(token?.address) &&
     isDepositMode &&
-    (networks.destinationChain.id === ChainId.ArbitrumOne ||
-      networks.destinationChain.id === ChainId.ArbitrumSepolia)
+    (isDestinationChainArbitrumOne || isDestinationChainArbitrumSepolia)
 
   const baseChainId = getBaseChainIdByChainId({
     chainId: childChain.id

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -69,6 +69,12 @@ export function TransferPanelSummary({ token }: TransferPanelSummaryProps) {
 
   const [{ amount }] = useArbQueryParams()
 
+  const isDepositingUSDCtoArbOneOrArbSepolia =
+    isTokenUSDC(token?.address) &&
+    isDepositMode &&
+    (networks.destinationChain.id === ChainId.ArbitrumOne ||
+      networks.destinationChain.id === ChainId.ArbitrumSepolia)
+
   const baseChainId = getBaseChainIdByChainId({
     chainId: childChain.id
   })
@@ -145,11 +151,7 @@ export function TransferPanelSummary({ token }: TransferPanelSummaryProps) {
             token={token}
             isParentChain={!isDepositMode}
           />{' '}
-          {isTokenUSDC(token?.address) &&
-            isDepositMode &&
-            networks.destinationChain.id === ChainId.ArbitrumOne && (
-              <>or USDC</>
-            )}
+          {isDepositingUSDCtoArbOneOrArbSepolia && <>or USDC</>}
           <NativeCurrencyPrice amount={Number(amount)} showBrackets />
         </span>
       </div>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -17,7 +17,7 @@ import { getTxConfirmationDate } from '../common/WithdrawalCountdown'
 import { useNetworks } from '../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
 import { NativeCurrencyPrice } from './NativeCurrencyPrice'
-import { isTokenUSDC } from '../../util/TokenUtils'
+import { isTokenNativeUSDC } from '../../util/TokenUtils'
 
 export type TransferPanelSummaryToken = { symbol: string; address: string }
 
@@ -75,7 +75,7 @@ export function TransferPanelSummary({ token }: TransferPanelSummaryProps) {
   } = isNetwork(networks.destinationChain.id)
 
   const isDepositingUSDCtoArbOneOrArbSepolia =
-    isTokenUSDC(token?.address) &&
+    isTokenNativeUSDC(token?.address) &&
     isDepositMode &&
     (isDestinationChainArbitrumOne || isDestinationChainArbitrumSepolia)
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -2,7 +2,11 @@ import React, { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import { formatAmount } from '../../util/NumberUtils'
-import { getBaseChainIdByChainId, getNetworkName } from '../../util/networks'
+import {
+  ChainId,
+  getBaseChainIdByChainId,
+  getNetworkName
+} from '../../util/networks'
 import { useNativeCurrency } from '../../hooks/useNativeCurrency'
 import { useGasSummary } from '../../hooks/TransferPanel/useGasSummary'
 import { useArbQueryParams } from '../../hooks/useArbQueryParams'
@@ -141,7 +145,11 @@ export function TransferPanelSummary({ token }: TransferPanelSummaryProps) {
             token={token}
             isParentChain={!isDepositMode}
           />{' '}
-          {isTokenUSDC(token?.address) && isDepositMode && <>or USDC</>}
+          {isTokenUSDC(token?.address) &&
+            isDepositMode &&
+            networks.destinationChain.id === ChainId.ArbitrumOne && (
+              <>or USDC</>
+            )}
           <NativeCurrencyPrice amount={Number(amount)} showBrackets />
         </span>
       </div>

--- a/packages/arb-token-bridge-ui/src/components/common/TokenSymbolWithExplorerLink.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/TokenSymbolWithExplorerLink.tsx
@@ -6,7 +6,7 @@ import {
   NativeCurrencyErc20,
   useNativeCurrency
 } from '../../hooks/useNativeCurrency'
-import { isTokenUSDC, sanitizeTokenSymbol } from '../../util/TokenUtils'
+import { isTokenNativeUSDC, sanitizeTokenSymbol } from '../../util/TokenUtils'
 import { ExternalLink } from './ExternalLink'
 import { useNetworks } from '../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
@@ -75,7 +75,7 @@ export function TokenSymbolWithExplorerLink({
   if (
     token === null ||
     !isERC20BridgeToken(token) ||
-    isTokenUSDC(token.address)
+    isTokenNativeUSDC(token.address)
   ) {
     return <span>{symbol}</span>
   }

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -281,6 +281,10 @@ export const isTokenArbitrumOneUSDCe = (tokenAddress: string | undefined) =>
 export const isTokenSepoliaUSDC = (tokenAddress: string | undefined) =>
   tokenAddress?.toLowerCase() === CommonAddress.Sepolia.USDC.toLowerCase()
 
+export const isTokenArbitrumSepoliaUSDCe = (tokenAddress: string | undefined) =>
+  tokenAddress?.toLowerCase() ===
+  CommonAddress.ArbitrumSepolia['USDC.e'].toLowerCase()
+
 export const isTokenArbitrumOneNativeUSDC = (
   tokenAddress: string | undefined
 ) =>
@@ -315,7 +319,8 @@ export function sanitizeTokenSymbol(
   if (
     isTokenMainnetUSDC(options.erc20L1Address) ||
     isTokenArbitrumOneUSDCe(options.erc20L1Address) ||
-    isTokenSepoliaUSDC(options.erc20L1Address)
+    isTokenSepoliaUSDC(options.erc20L1Address) ||
+    isTokenArbitrumSepoliaUSDCe(options.erc20L1Address)
   ) {
     // It should be `USDC` on all chains except Arbitrum One/Arbitrum Sepolia
     if (isArbitrumOne || isArbitrumSepolia) return 'USDC.e'

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -274,6 +274,10 @@ type SanitizeTokenOptions = {
 export const isTokenMainnetUSDC = (tokenAddress: string | undefined) =>
   tokenAddress?.toLowerCase() === CommonAddress.Ethereum.USDC.toLowerCase()
 
+export const isTokenArbitrumOneUSDCe = (tokenAddress: string | undefined) =>
+  tokenAddress?.toLowerCase() ===
+  CommonAddress.ArbitrumOne['USDC.e'].toLowerCase()
+
 export const isTokenSepoliaUSDC = (tokenAddress: string | undefined) =>
   tokenAddress?.toLowerCase() === CommonAddress.Sepolia.USDC.toLowerCase()
 
@@ -310,6 +314,7 @@ export function sanitizeTokenSymbol(
 
   if (
     isTokenMainnetUSDC(options.erc20L1Address) ||
+    isTokenArbitrumOneUSDCe(options.erc20L1Address) ||
     isTokenSepoliaUSDC(options.erc20L1Address)
   ) {
     // It should be `USDC` on all chains except Arbitrum One/Arbitrum Sepolia
@@ -333,6 +338,7 @@ export function sanitizeTokenName(
 
   if (
     isTokenMainnetUSDC(options.erc20L1Address) ||
+    isTokenArbitrumOneUSDCe(options.erc20L1Address) ||
     isTokenSepoliaUSDC(options.erc20L1Address)
   ) {
     // It should be `USD Coin` on all chains except Arbitrum One/Arbitrum Sepolia

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -344,7 +344,8 @@ export function sanitizeTokenName(
   if (
     isTokenMainnetUSDC(options.erc20L1Address) ||
     isTokenArbitrumOneUSDCe(options.erc20L1Address) ||
-    isTokenSepoliaUSDC(options.erc20L1Address)
+    isTokenSepoliaUSDC(options.erc20L1Address) ||
+    isTokenArbitrumSepoliaUSDCe(options.erc20L1Address)
   ) {
     // It should be `USD Coin` on all chains except Arbitrum One/Arbitrum Sepolia
     if (isArbitrumOne || isArbitrumSepolia) return 'Bridged USDC'

--- a/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenUtils.ts
@@ -296,7 +296,7 @@ export const isTokenArbitrumSepoliaNativeUSDC = (
   tokenAddress?.toLowerCase() ===
   CommonAddress.ArbitrumSepolia.USDC.toLowerCase()
 
-export const isTokenUSDC = (tokenAddress: string | undefined) => {
+export const isTokenNativeUSDC = (tokenAddress: string | undefined) => {
   return (
     isTokenMainnetUSDC(tokenAddress) ||
     isTokenSepoliaUSDC(tokenAddress) ||


### PR DESCRIPTION
currently on prod, when user has selected Arb One Native USDC when trying to deposit to an Orbit chain, the balances do not load and the token name is wrong
<img width="685" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/20a4648f-a7f6-45c1-95c5-f9587f5faa94">

This PR fixes it
<img width="663" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/32b86803-cb55-4d78-8e2a-0dae7bc83414">
