### PR TITLE
fix: tx history improvements in the preview

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -41,6 +41,7 @@ function TransactionHistorySidePanel() {
       isOpen={isTransactionHistoryPanelVisible}
       onClose={closeTransactionHistoryPanel}
       scrollable={false}
+      panelClassNameOverrides="pb-8"
     >
       <TransactionHistory props={{ ...transactionHistoryProps, address }} />
     </SidePanel>

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
@@ -18,7 +18,7 @@ import { TransactionsTableDetails } from './TransactionsTableDetails'
 import { Address } from '../../util/AddressUtils'
 
 const tabClasses =
-  'text-white px-3 mr-2 ui-selected:border-b-2 ui-selected:border-white ui-not-selected:text-white/80 arb-hover'
+  'text-white px-3 mr-2 border-b-2 ui-selected:border-white ui-not-selected:border-transparent ui-not-selected:text-white/80 arb-hover'
 
 type TxDetailsStore = {
   tx: MergedTransaction | null

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
@@ -73,7 +73,7 @@ const TableHeader = ({
 }: PropsWithChildren<{ className?: string }>) => (
   <div
     className={twMerge(
-      'h-full w-full py-4 text-left text-sm font-normal',
+      'h-full w-full pb-2 pt-4 text-left text-sm font-normal',
       className
     )}
   >
@@ -178,7 +178,7 @@ export const TransactionHistoryTable = (
         const aboveHeight = entries[0].contentRect.height
         const viewportHeight = window.innerHeight
         const newTableHeight = Math.max(
-          viewportHeight - aboveHeight - SIDE_PANEL_HEADER_HEIGHT,
+          viewportHeight - aboveHeight - SIDE_PANEL_HEADER_HEIGHT - 20,
           0
         )
         setTableHeight(newTableHeight)
@@ -248,7 +248,7 @@ export const TransactionHistoryTable = (
             rowCount={transactions.length}
             headerHeight={52}
             headerRowRenderer={props => (
-              <div className="mx-4 flex w-[928px] border-b border-white/30 text-white">
+              <div className="mx-4 flex w-[920px] border-b border-white/30 text-white">
                 {props.columns}
               </div>
             )}

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRow.tsx
@@ -167,7 +167,7 @@ export function TransactionsTableRow({
     <div
       data-testid={`${isClaimableTx ? 'claimable' : 'deposit'}-row-${tx.txId}`}
       className={twMerge(
-        'relative ml-4 mr-2 grid h-[60px] grid-cols-[140px_140px_140px_140px_100px_180px_140px] items-center justify-between border-b border-white/30 text-xs text-white',
+        'relative mx-4 grid h-[60px] grid-cols-[140px_140px_140px_140px_100px_170px_140px] items-center justify-between border-b border-white/30 text-xs text-white',
         className
       )}
     >

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRowAction.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRowAction.tsx
@@ -116,7 +116,7 @@ export function TransactionsTableRowAction({
       <Button
         variant="primary"
         onClick={handleRedeemRetryable}
-        className="w-14 rounded bg-red-400 p-2 text-xs"
+        className="w-14 rounded bg-red-400 p-2 text-xs text-black"
       >
         Retry
       </Button>

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRowAction.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRowAction.tsx
@@ -116,7 +116,7 @@ export function TransactionsTableRowAction({
       <Button
         variant="primary"
         onClick={handleRedeemRetryable}
-        className="w-16 rounded bg-red-400 p-2 text-xs"
+        className="w-14 rounded bg-red-400 p-2 text-xs"
       >
         Retry
       </Button>
@@ -153,7 +153,7 @@ export function TransactionsTableRowAction({
     ) : (
       <Button
         variant="primary"
-        className="w-12 rounded bg-green-400 p-2 text-xs text-black"
+        className="w-14 rounded bg-green-400 p-2 text-xs text-black"
         onClick={handleClaim}
       >
         Claim


### PR DESCRIPTION
- Right padding in each row, so that scrollbar doesn't overlap See Details button
- All action buttons same width and text color
- Bottom padding to the entire table
- Lower padding between table header and its bottom border
- Add transparent bottom border to unselected tabs so that they don't "jump" on selection