### PR TITLE
revert: remove hardcoded retryable gas limit

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbTokenBridge.ts
@@ -438,8 +438,9 @@ export const useArbTokenBridge = (
         destinationAddress,
         amount,
         retryableGasOverrides: {
-          // temp hardcoded value for v2.2.4
-          gasLimit: { base: BigNumber.from(300_000) }
+          // the gas limit may vary by about 20k due to SSTORE (zero vs nonzero)
+          // the 30% gas limit increase should cover the difference
+          gasLimit: { percentIncrease: BigNumber.from(30) }
         }
       })
 

--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -103,8 +103,9 @@ export async function depositTokenEstimateGas(
     l2Provider,
     from: address,
     retryableGasOverrides: {
-      // temp hardcoded value for v2.2.4
-      gasLimit: { base: BigNumber.from(300_000) }
+      // the gas limit may vary by about 20k due to SSTORE (zero vs nonzero)
+      // the 30% gas limit increase should cover the difference
+      gasLimit: { percentIncrease: BigNumber.from(30) }
     }
   })
 


### PR DESCRIPTION
Reverts OffchainLabs/arbitrum-token-bridge#1540
as infura is now on `nitro/v2.3.0-3e14543/linux-amd64/go1.20.14`

you can use `cast client --rpc-url=` to check
https://book.getfoundry.sh/reference/cast/cast-client