### PR TITLE
fix: adjust switch network button layout

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableClaimableRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableClaimableRow.tsx
@@ -351,7 +351,7 @@ export function TransactionsTableClaimableRow({
     <div
       data-testid={`withdrawal-row-${tx.txId}`}
       className={twMerge(
-        'relative grid h-full grid-cols-[150px_250px_140px_320px_110px] border-b border-dark text-sm text-dark',
+        'relative grid h-full grid-cols-[150px_250px_140px_300px_130px] border-b border-dark text-sm text-dark',
         className,
         bgClassName
       )}


### PR DESCRIPTION
The switch button is cut off:

<img width="995" alt="Screenshot 2024-02-28 at 12 23 22" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/47932951/677d5e0d-9870-43ee-959c-8160dc401892">
