### PR TITLE
feat: add Moon to L2 approval list

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/L2ApprovalUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/L2ApprovalUtils.ts
@@ -29,6 +29,11 @@ const L2ApproveTokens: { [chainId: number]: RequireL2ApproveToken[] } = {
       symbol: 'ARB',
       l1Address: '0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1',
       l2Address: '0xf823C3cD3CeBE0a1fA952ba88Dc9EEf8e0Bf46AD'
+    },
+    {
+      symbol: 'MOON',
+      l1Address: '0xb2490e357980cE57bF5745e181e537a64Eb367B1',
+      l2Address: '0x0057Ac2d777797d31CD3f8f13bF5e927571D6Ad0'
     }
   ],
   [ChainId.ArbitrumGoerli]: [


### PR DESCRIPTION
`MOON`
https://nova.arbiscan.io/token/0x0057ac2d777797d31cd3f8f13bf5e927571d6ad0
https://etherscan.io/token/0xb2490e357980ce57bf5745e181e537a64eb367b1

As `MOON` is an early token, it didn't implement the `IArbToken` interface and hence requires approval on Arb Nova for the gateway to spend it for bridging.