### PR TITLE
fix: correct the logic for e2e balance assertion

### DIFF
--- a/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
@@ -225,8 +225,8 @@ describe('Deposit ERC20 Token', () => {
         // the balance on the source chain should not be the same as before
         cy.findByLabelText('WETH balance amount on l1')
           .should('be.visible')
-          .its('text')
-          .should('not.eq', l1ERC20bal)
+          .invoke('text')
+          .should('eq', formatAmount(Number(l1ERC20bal) - ERC20AmountToSend))
       })
     })
 

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
@@ -27,12 +27,7 @@ describe('Withdraw ERC20 Token', () => {
         multiCallerAddress: getL2NetworkConfig().multiCall,
         address: Cypress.env('ADDRESS'),
         rpcURL: Cypress.env('ARB_RPC_URL')
-      }).then(
-        val =>
-          (l2ERC20bal = formatAmount(val, {
-            symbol: 'WETH'
-          }))
-      )
+      }).then(val => (l2ERC20bal = formatAmount(val)))
     })
 
     it('should show form fields correctly', () => {
@@ -228,8 +223,11 @@ describe('Withdraw ERC20 Token', () => {
               // the balance on the source chain should not be the same as before
               cy.findByLabelText('WETH balance amount on l2')
                 .should('be.visible')
-                .its('text')
-                .should('not.eq', l2ERC20bal)
+                .invoke('text')
+                .should(
+                  'eq',
+                  formatAmount(Number(l2ERC20bal) - ERC20AmountToSend)
+                )
             })
           })
       })


### PR DESCRIPTION
In previous tests we asserted that new balance after deposits/withdrawals should not match the original balance. But turns out it was being done because of flakiness, and we can assert the exact balance now.