### PR TITLE
fix: get correct token balance for orbit deposits

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useGasSummary.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useGasSummary.ts
@@ -20,7 +20,7 @@ import {
   calculateEstimatedL2GasFees,
   calculateEstimatedL1GasFees
 } from '../../components/TransferPanel/TransferPanelMainUtils'
-import { useBalance } from '../useBalance'
+import { useTokenToBeBridgedBalance } from '../useTokenToBeBridgedBalance'
 
 const INITIAL_GAS_ESTIMATION_RESULT: GasEstimationResult = {
   // Estimated Parent Chain gas, denominated in Wei, represented as a BigNumber
@@ -63,13 +63,6 @@ export function useGasSummary(): UseGasSummaryResult {
   const { childChainProvider, parentChainProvider, isDepositMode } =
     useNetworksRelationship(networks)
   const { address: walletAddress } = useAccount()
-  const {
-    eth: [ethBalance],
-    erc20: [erc20Balances]
-  } = useBalance({
-    provider: networks.sourceChainProvider,
-    walletAddress
-  })
 
   const [{ amount }] = useArbQueryParams()
   const nativeCurrency = useNativeCurrency({ provider: childChainProvider })
@@ -103,23 +96,7 @@ export function useGasSummary(): UseGasSummaryResult {
     []
   )
 
-  const balance: BigNumber | null = useMemo(() => {
-    if (!token) {
-      return ethBalance
-    }
-
-    if (isDepositMode) {
-      return erc20Balances?.[token.address.toLowerCase()] ?? constants.Zero
-    }
-
-    // token that has never been deposited so it doesn't have an l2Address
-    if (!token.l2Address) {
-      return constants.Zero
-    }
-
-    // token withdrawal
-    return erc20Balances?.[token.l2Address.toLowerCase()] ?? constants.Zero
-  }, [erc20Balances, ethBalance, isDepositMode, token])
+  const balance = useTokenToBeBridgedBalance()
 
   const estimateGas = useCallback(async () => {
     if (!walletAddress) {

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenToBeBridgedBalance.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenToBeBridgedBalance.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useAccount } from 'wagmi'
 import { constants } from 'ethers'
 
@@ -28,53 +27,40 @@ export function useTokenToBeBridgedBalance() {
     provider: childChainProvider
   })
 
-  return useMemo(() => {
-    // user selected source chain native currency or
-    // user bridging the destination chain's native currency
-    if (!selectedToken) {
-      // check if it involves custom orbit chain
-      if (childChainNativeCurrency.isCustom) {
-        if (isDepositMode) {
-          return (
-            erc20SourceChainBalances?.[
-              childChainNativeCurrency.address.toLowerCase()
-            ] ?? constants.Zero
-          )
-        }
-        return ethSourceChainBalance
-      }
-
-      return ethSourceChainBalance
-    }
-
-    if (!erc20SourceChainBalances) {
-      return constants.Zero
-    }
-
-    if (isDepositMode) {
+  // user selected source chain native currency or
+  // user bridging the destination chain's native currency
+  if (!selectedToken) {
+    // check if user is depositing destination chain's custom native currency to orbit chain
+    if (childChainNativeCurrency.isCustom && isDepositMode) {
       return (
-        erc20SourceChainBalances[selectedToken.address.toLowerCase()] ??
-        constants.Zero
+        erc20SourceChainBalances?.[
+          childChainNativeCurrency.address.toLowerCase()
+        ] ?? constants.Zero
       )
     }
+    return ethSourceChainBalance
+  }
 
-    const selectedTokenChildChainAddress =
-      selectedToken.l2Address?.toLowerCase()
+  if (!erc20SourceChainBalances) {
+    return constants.Zero
+  }
 
-    // token that has never been deposited so it doesn't have an l2Address
-    if (!selectedTokenChildChainAddress) {
-      return constants.Zero
-    }
-
-    // token withdrawal
+  if (isDepositMode) {
     return (
-      erc20SourceChainBalances[selectedTokenChildChainAddress] ?? constants.Zero
+      erc20SourceChainBalances[selectedToken.address.toLowerCase()] ??
+      constants.Zero
     )
-  }, [
-    childChainNativeCurrency,
-    selectedToken,
-    isDepositMode,
-    erc20SourceChainBalances,
-    ethSourceChainBalance
-  ])
+  }
+
+  const selectedTokenChildChainAddress = selectedToken.l2Address?.toLowerCase()
+
+  // token that has never been deposited so it doesn't have an l2Address
+  if (!selectedTokenChildChainAddress) {
+    return constants.Zero
+  }
+
+  // token withdrawal
+  return (
+    erc20SourceChainBalances[selectedTokenChildChainAddress] ?? constants.Zero
+  )
 }

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenToBeBridgedBalance.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenToBeBridgedBalance.ts
@@ -29,16 +29,21 @@ export function useTokenToBeBridgedBalance() {
   })
 
   return useMemo(() => {
-    // check if it involves custom orbit chain
-    if (childChainNativeCurrency.isCustom) {
-      return isDepositMode
-        ? erc20SourceChainBalances?.[
-            childChainNativeCurrency.address.toLowerCase()
-          ] ?? constants.Zero
-        : ethSourceChainBalance
-    }
-
+    // user selected source chain native currency or
+    // user bridging the destination chain's native currency
     if (!selectedToken) {
+      // check if it involves custom orbit chain
+      if (childChainNativeCurrency.isCustom) {
+        if (isDepositMode) {
+          return (
+            erc20SourceChainBalances?.[
+              childChainNativeCurrency.address.toLowerCase()
+            ] ?? constants.Zero
+          )
+        }
+        return ethSourceChainBalance
+      }
+
       return ethSourceChainBalance
     }
 
@@ -46,16 +51,15 @@ export function useTokenToBeBridgedBalance() {
       return constants.Zero
     }
 
-    const selectedTokenParentChainAddress = selectedToken.address.toLowerCase()
-    const selectedTokenChildChainAddress =
-      selectedToken.l2Address?.toLowerCase()
-
     if (isDepositMode) {
       return (
-        erc20SourceChainBalances[selectedTokenParentChainAddress] ??
+        erc20SourceChainBalances[selectedToken.address.toLowerCase()] ??
         constants.Zero
       )
     }
+
+    const selectedTokenChildChainAddress =
+      selectedToken.l2Address?.toLowerCase()
 
     // token that has never been deposited so it doesn't have an l2Address
     if (!selectedTokenChildChainAddress) {

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenToBeBridgedBalance.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenToBeBridgedBalance.ts
@@ -38,6 +38,9 @@ export function useTokenToBeBridgedBalance() {
         ] ?? constants.Zero
       )
     }
+
+    // `ethSourceChainBalance` is the ETH balance at source chain when ETH is selected for bridging,
+    // or the custom gas native currency balance when withdrawing the native currency
     return ethSourceChainBalance
   }
 
@@ -55,6 +58,7 @@ export function useTokenToBeBridgedBalance() {
   const selectedTokenChildChainAddress = selectedToken.l2Address?.toLowerCase()
 
   // token that has never been deposited so it doesn't have an l2Address
+  // this should not happen because user shouldn't be able to select it
   if (!selectedTokenChildChainAddress) {
     return constants.Zero
   }

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenToBeBridgedBalance.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenToBeBridgedBalance.ts
@@ -1,0 +1,76 @@
+import { useMemo } from 'react'
+import { useAccount } from 'wagmi'
+import { constants } from 'ethers'
+
+import { useNativeCurrency } from './useNativeCurrency'
+import { useBalance } from './useBalance'
+import { useNetworksRelationship } from './useNetworksRelationship'
+import { useNetworks } from './useNetworks'
+import { useAppState } from '../state'
+
+/**
+ * `TokenToBridge` means native currency or ERC20 token user wants to bridge
+ */
+export function useTokenToBeBridgedBalance() {
+  const { address: walletAddress } = useAccount()
+  const {
+    app: { selectedToken }
+  } = useAppState()
+  const [networks] = useNetworks()
+  const { childChainProvider, isDepositMode } =
+    useNetworksRelationship(networks)
+  const {
+    eth: [ethSourceChainBalance],
+    erc20: [erc20SourceChainBalances]
+  } = useBalance({ provider: networks.sourceChainProvider, walletAddress })
+
+  const childChainNativeCurrency = useNativeCurrency({
+    provider: childChainProvider
+  })
+
+  return useMemo(() => {
+    // check if it involves custom orbit chain
+    if (childChainNativeCurrency.isCustom) {
+      return isDepositMode
+        ? erc20SourceChainBalances?.[
+            childChainNativeCurrency.address.toLowerCase()
+          ] ?? constants.Zero
+        : ethSourceChainBalance
+    }
+
+    if (!selectedToken) {
+      return ethSourceChainBalance
+    }
+
+    if (!erc20SourceChainBalances) {
+      return constants.Zero
+    }
+
+    const selectedTokenParentChainAddress = selectedToken.address.toLowerCase()
+    const selectedTokenChildChainAddress =
+      selectedToken.l2Address?.toLowerCase()
+
+    if (isDepositMode) {
+      return (
+        erc20SourceChainBalances[selectedTokenParentChainAddress] ??
+        constants.Zero
+      )
+    }
+
+    // token that has never been deposited so it doesn't have an l2Address
+    if (!selectedTokenChildChainAddress) {
+      return constants.Zero
+    }
+
+    // token withdrawal
+    return (
+      erc20SourceChainBalances[selectedTokenChildChainAddress] ?? constants.Zero
+    )
+  }, [
+    childChainNativeCurrency,
+    selectedToken,
+    isDepositMode,
+    erc20SourceChainBalances,
+    ethSourceChainBalance
+  ])
+}


### PR DESCRIPTION
This bugfix is for
the gas estimation for native gas token deposits from an L2 to the custom gas Orbit chain
when the user's wallet has a higher native gas token amount than their ETH amount on L2

Latest commit on master branch:
https://arbitrum-token-bridge-aazi9ikl8-offchain-labs.vercel.app/?destinationChain=arbitrum-one&sourceChain=ethereum
<img width="760" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/a1482267-3089-4b96-b775-6d6bd93c1972">

This PR:
<img width="662" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/fe013265-ea1f-4384-805a-7f60cddea1ce">
