### PR TITLE
feat: fetch latest subgraph block number on the server

### DIFF
--- a/packages/arb-token-bridge-ui/src/pages/api/chains/[chainId]/block-number.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/chains/[chainId]/block-number.ts
@@ -7,31 +7,31 @@ import {
   getL2SubgraphClient
 } from '../../../../util/SubgraphUtils'
 
-function getSubgraphClient(chain: string) {
-  switch (chain) {
-    case 'ethereum':
+function getSubgraphClient(chainId: number) {
+  switch (chainId) {
+    case ChainId.Ethereum:
       // it's the same whether we do arb1 or nova
       return getL1SubgraphClient(ChainId.ArbitrumOne)
 
-    case 'sepolia':
+    case ChainId.Sepolia:
       return getL1SubgraphClient(ChainId.ArbitrumSepolia)
 
-    case 'arbitrum-one':
+    case ChainId.ArbitrumOne:
       return getL2SubgraphClient(ChainId.ArbitrumOne)
 
-    case 'arbitrum-sepolia':
+    case ChainId.ArbitrumSepolia:
       return getL2SubgraphClient(ChainId.ArbitrumSepolia)
 
     default:
-      throw new Error(`[getSubgraphClient] unsupported chain: ${chain}`)
+      throw new Error(`[getSubgraphClient] unsupported chain id: ${chainId}`)
   }
 }
 
 export default async function handler(
-  req: NextApiRequest & { query: { chain: string } },
+  req: NextApiRequest & { query: { chainId: string } },
   res: NextApiResponse<{ data: number } | { message: string }>
 ) {
-  const { chain } = req.query
+  const { chainId } = req.query
 
   // validate method
   if (req.method !== 'GET') {
@@ -48,7 +48,7 @@ export default async function handler(
           }
         }
       }
-    } = await getSubgraphClient(chain).query({
+    } = await getSubgraphClient(Number(chainId)).query({
       query: gql`
         {
           _meta {

--- a/packages/arb-token-bridge-ui/src/pages/api/chains/[chain]/block-number.ts
+++ b/packages/arb-token-bridge-ui/src/pages/api/chains/[chain]/block-number.ts
@@ -1,0 +1,67 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { gql } from '@apollo/client'
+
+import { ChainId } from '../../../../util/networks'
+import {
+  getL1SubgraphClient,
+  getL2SubgraphClient
+} from '../../../../util/SubgraphUtils'
+
+function getSubgraphClient(chain: string) {
+  switch (chain) {
+    case 'ethereum':
+      // it's the same whether we do arb1 or nova
+      return getL1SubgraphClient(ChainId.ArbitrumOne)
+
+    case 'sepolia':
+      return getL1SubgraphClient(ChainId.ArbitrumSepolia)
+
+    case 'arbitrum-one':
+      return getL2SubgraphClient(ChainId.ArbitrumOne)
+
+    case 'arbitrum-sepolia':
+      return getL2SubgraphClient(ChainId.ArbitrumSepolia)
+
+    default:
+      throw new Error(`[getSubgraphClient] unsupported chain: ${chain}`)
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest & { query: { chain: string } },
+  res: NextApiResponse<{ data: number } | { message: string }>
+) {
+  const { chain } = req.query
+
+  // validate method
+  if (req.method !== 'GET') {
+    res.status(400).json({ message: `invalid method: ${req.method}` })
+    return
+  }
+
+  try {
+    const result: {
+      data: {
+        _meta: {
+          block: {
+            number: number
+          }
+        }
+      }
+    } = await getSubgraphClient(chain).query({
+      query: gql`
+        {
+          _meta {
+            block {
+              number
+            }
+          }
+        }
+      `
+    })
+
+    res.status(200).json({ data: result.data._meta.block.number })
+  } catch (error) {
+    res.status(200).json({ data: 0 })
+  }
+}

--- a/packages/arb-token-bridge-ui/src/util/SubgraphUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/SubgraphUtils.ts
@@ -1,6 +1,8 @@
 import fetch from 'cross-fetch'
-import { ApolloClient, HttpLink, InMemoryCache, gql } from '@apollo/client'
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
+
 import { ChainId } from './networks'
+import { getAPIBaseUrl } from '.'
 
 const L1SubgraphClient = {
   ArbitrumOne: new ApolloClient({
@@ -84,41 +86,18 @@ type FetchBlockNumberFromSubgraphQueryResult = {
   }
 }
 
-export const fetchBlockNumberFromSubgraph = async (
-  chainType: 'L1' | 'L2',
-  l2ChainId: number
+export const fetchLatestSubgraphBlockNumber = async (
+  chainId: number
 ): Promise<number> => {
-  const subgraphClient =
-    chainType === 'L2'
-      ? getL2SubgraphClient(l2ChainId)
-      : getL1SubgraphClient(l2ChainId)
+  const response = await fetch(
+    `${getAPIBaseUrl()}/api/chains/${chainId}/block-number`,
+    {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' }
+    }
+  )
 
-  const queryResult: FetchBlockNumberFromSubgraphQueryResult =
-    await subgraphClient.query({
-      query: gql`
-        {
-          _meta {
-            block {
-              number
-            }
-          }
-        }
-      `
-    })
-
-  return queryResult.data._meta.block.number
-}
-
-export const tryFetchLatestSubgraphBlockNumber = async (
-  chainType: 'L1' | 'L2',
-  l2ChainID: number
-): Promise<number> => {
-  try {
-    return await fetchBlockNumberFromSubgraph(chainType, l2ChainID)
-  } catch (error) {
-    // In case the subgraph is not supported or down, fall back to fetching everything through event logs
-    return 0
-  }
+  return ((await response.json()) as { data: number }).data
 }
 
 export const shouldIncludeSentTxs = ({

--- a/packages/arb-token-bridge-ui/src/util/SubgraphUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/SubgraphUtils.ts
@@ -75,17 +75,6 @@ export function getL2SubgraphClient(l2ChainId: number) {
   }
 }
 
-// TODO: Codegen types
-type FetchBlockNumberFromSubgraphQueryResult = {
-  data: {
-    _meta: {
-      block: {
-        number: number
-      }
-    }
-  }
-}
-
 export const fetchLatestSubgraphBlockNumber = async (
   chainId: number
 ): Promise<number> => {

--- a/packages/arb-token-bridge-ui/src/util/deposits/fetchDeposits.ts
+++ b/packages/arb-token-bridge-ui/src/util/deposits/fetchDeposits.ts
@@ -1,10 +1,10 @@
 import { Provider } from '@ethersproject/providers'
 import { utils } from 'ethers'
+
 import {
   fetchDepositsFromSubgraph,
   FetchDepositsFromSubgraphResult
 } from './fetchDepositsFromSubgraph'
-import { tryFetchLatestSubgraphBlockNumber } from '../SubgraphUtils'
 import { AssetType } from '../../hooks/arbTokenBridge.types'
 import { Transaction } from '../../hooks/useTransactions'
 import { defaultErc20Decimals } from '../../defaults'
@@ -47,23 +47,6 @@ export const fetchDeposits = async ({
 
   if (!fromBlock) {
     fromBlock = 0
-  }
-
-  if (!toBlock) {
-    // if toBlock hasn't been provided by the user
-
-    // fetch the latest L1 block number thorough subgraph first
-    let latestL1BlockNumber = await tryFetchLatestSubgraphBlockNumber(
-      'L1',
-      l2ChainId
-    )
-
-    // if the previous call returns 0, then fetch the latest block on-chain
-    if (!latestL1BlockNumber) {
-      latestL1BlockNumber = await l1Provider.getBlockNumber()
-    }
-
-    toBlock = latestL1BlockNumber
   }
 
   let depositsFromSubgraph: FetchDepositsFromSubgraphResult[] = []

--- a/packages/arb-token-bridge-ui/src/util/deposits/fetchDepositsFromSubgraph.ts
+++ b/packages/arb-token-bridge-ui/src/util/deposits/fetchDepositsFromSubgraph.ts
@@ -49,13 +49,13 @@ export const fetchDepositsFromSubgraph = async ({
   sender?: string
   receiver?: string
   fromBlock: number
-  toBlock: number
+  toBlock?: number
   l2ChainId: number
   pageSize?: number
   pageNumber?: number
   searchString?: string
 }): Promise<FetchDepositsFromSubgraphResult[]> => {
-  if (fromBlock >= toBlock) {
+  if (toBlock && fromBlock >= toBlock) {
     // if fromBlock > toBlock or both are equal / 0
     return []
   }

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/fetchWithdrawals.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/fetchWithdrawals.ts
@@ -6,7 +6,7 @@ import {
   FetchWithdrawalsFromSubgraphResult,
   fetchWithdrawalsFromSubgraph
 } from './fetchWithdrawalsFromSubgraph'
-import { tryFetchLatestSubgraphBlockNumber } from '../SubgraphUtils'
+import { fetchLatestSubgraphBlockNumber } from '../SubgraphUtils'
 import { fetchTokenWithdrawalsFromEventLogs } from './fetchTokenWithdrawalsFromEventLogs'
 import { fetchL2Gateways } from '../fetchL2Gateways'
 import { Withdrawal } from '../../hooks/useTransactionHistory'
@@ -53,8 +53,7 @@ export async function fetchWithdrawals({
     // if toBlock hasn't been provided by the user
 
     // fetch the latest L2 block number thorough subgraph
-    const latestSubgraphBlockNumber = await tryFetchLatestSubgraphBlockNumber(
-      'L2',
+    const latestSubgraphBlockNumber = await fetchLatestSubgraphBlockNumber(
       l2ChainID
     )
     toBlock = latestSubgraphBlockNumber


### PR DESCRIPTION
### Summary

We want to move all subgraph-related code and network requests to the server (see https://github.com/OffchainLabs/arbitrum-token-bridge/pull/1614) to not leak any API keys and to reduce the client bundle size. 

This PR sets stuff up for https://github.com/OffchainLabs/arbitrum-token-bridge/pull/1614 by adding a new API route `/api/chains/[chainId]/block-number` which returns the latest subgraph-indexed block number for that chain. If there is no subgraph for the chain, it will return 0. The API route follows a REST pattern, and I think we should move the transaction history routes to a similar one soon.

Previously, we were fetching this data from the client directly to the subgraph, but now we fetch it through the API route, so the request is done on the server.

### Steps to test

Everything should work exactly the same.
