### PR TITLE
fix: amount overflow error (hotfix)

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -71,7 +71,7 @@ import { getBridgeUiConfigForChain } from '../../util/bridgeUiConfig'
 import { useNetworks } from '../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
 import { CctpTransferStarter } from '@/token-bridge-sdk/CctpTransferStarter'
-import { countDecimals } from '../../util/NumberUtils'
+import { truncateExtraDecimals } from '../../util/NumberUtils'
 
 const isAllowedL2 = async ({
   l1TokenAddress,
@@ -179,10 +179,7 @@ export function TransferPanel() {
         ? selectedToken.decimals
         : nativeCurrency.decimals
 
-      const correctDecimalsAmount =
-        countDecimals(newAmount) > decimals
-          ? Number(newAmount).toFixed(decimals)
-          : newAmount
+      const correctDecimalsAmount = truncateExtraDecimals(newAmount, decimals)
 
       setQueryParams({ amount: correctDecimalsAmount })
     },

--- a/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useGasSummary.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useGasSummary.ts
@@ -60,12 +60,9 @@ export function useGasSummary(): UseGasSummaryResult {
 
     const decimals = token ? token.decimals : nativeCurrency.decimals
 
-    try {
-      // if amount has more decimals than token's decimals, it will throw an error
-      return utils.parseUnits(amountSafe, decimals)
-    } catch (error) {
-      return constants.Zero
-    }
+    const correctDecimalsAmount = Number(amountSafe).toFixed(decimals)
+
+    return utils.parseUnits(correctDecimalsAmount, decimals)
   }, [debouncedAmount, token, nativeCurrency])
 
   const parentChainGasPrice = useGasPrice({ provider: parentChainProvider })

--- a/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useGasSummary.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useGasSummary.ts
@@ -60,7 +60,12 @@ export function useGasSummary(): UseGasSummaryResult {
 
     const decimals = token ? token.decimals : nativeCurrency.decimals
 
-    return utils.parseUnits(amountSafe, decimals)
+    try {
+      // if amount has more decimals than token's decimals, it will throw an error
+      return utils.parseUnits(amountSafe, decimals)
+    } catch (error) {
+      return constants.Zero
+    }
   }, [debouncedAmount, token, nativeCurrency])
 
   const parentChainGasPrice = useGasPrice({ provider: parentChainProvider })

--- a/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useGasSummary.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useGasSummary.ts
@@ -16,6 +16,7 @@ import { useNativeCurrency } from '../useNativeCurrency'
 import { useGasEstimates } from './useGasEstimates'
 import { useTokenToBeBridgedBalance } from '../useTokenToBeBridgedBalance'
 import { DepositGasEstimates } from '../arbTokenBridge.types'
+import { truncateExtraDecimals } from '../../util/NumberUtils'
 
 const INITIAL_GAS_SUMMARY_RESULT: UseGasSummaryResult = {
   status: 'loading',
@@ -60,7 +61,7 @@ export function useGasSummary(): UseGasSummaryResult {
 
     const decimals = token ? token.decimals : nativeCurrency.decimals
 
-    const correctDecimalsAmount = Number(amountSafe).toFixed(decimals)
+    const correctDecimalsAmount = truncateExtraDecimals(amountSafe, decimals)
 
     return utils.parseUnits(correctDecimalsAmount, decimals)
   }, [debouncedAmount, token, nativeCurrency])

--- a/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
@@ -116,16 +116,12 @@ export const formatAmount = <T extends number | BigNumber | undefined>(
   )
 }
 
-export const countDecimals = (num: number | string) => {
-  if (Math.floor(Number(num)) === Number(num)) {
-    return 0
-  }
-
-  const decimalPart = String(num).split('.')[1]
+export const truncateExtraDecimals = (amount: string, decimals: number) => {
+  const decimalPart = amount.split('.')[1]
 
   if (typeof decimalPart === 'undefined') {
-    return 0
+    return amount
   }
 
-  return decimalPart.length
+  return `${amount.split('.')[0]}.${decimalPart.slice(0, decimals)}`
 }

--- a/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
@@ -115,3 +115,17 @@ export const formatAmount = <T extends number | BigNumber | undefined>(
     }) + suffix
   )
 }
+
+export const countDecimals = (num: number | string) => {
+  if (Math.floor(Number(num)) === Number(num)) {
+    return 0
+  }
+
+  const decimalPart = String(num).split('.')[1]
+
+  if (typeof decimalPart === 'undefined') {
+    return 0
+  }
+
+  return decimalPart.length
+}


### PR DESCRIPTION
Currently on production, if the number of decimals of `amount` is more than the number of decimals of the token, the app will crash. This PR fixes it.

<img width="624" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/cf554390-d9bd-4bcd-a632-885ebb88b58f">
