### PR TITLE
fix: smart-contract wallet detection fix

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -12,8 +12,7 @@ type Result = {
 
 export function useAccountType(): Result {
   const { address } = useAccount()
-  const [networks] = useNetworks()
-  const { sourceChainProvider } = networks
+  const [{ sourceChainProvider }] = useNetworks()
 
   const { data: isSmartContractWallet = false, isLoading } = useSWRImmutable(
     address ? [address, sourceChainProvider, 'useAccountType'] : null,

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -1,7 +1,8 @@
-import { useAccount, useProvider } from 'wagmi'
-import useSWR from 'swr'
+import { useAccount } from 'wagmi'
+import useSWRImmutable from 'swr/immutable'
 
 import { addressIsSmartContract } from '../util/AddressUtils'
+import { useNetworks } from './useNetworks'
 
 type Result = {
   isEOA: boolean
@@ -11,17 +12,12 @@ type Result = {
 
 export function useAccountType(): Result {
   const { address } = useAccount()
-  const provider = useProvider()
+  const [networks] = useNetworks()
+  const { sourceChainProvider } = networks
 
-  const { data: isSmartContractWallet = false, isLoading } = useSWR(
-    address ? [address, provider, 'useAccountType'] : null,
-    ([_address, _provider]) => addressIsSmartContract(_address, _provider),
-    {
-      revalidateIfStale: false,
-      shouldRetryOnError: true,
-      errorRetryCount: 3,
-      errorRetryInterval: 3_000
-    }
+  const { data: isSmartContractWallet = false, isLoading } = useSWRImmutable(
+    address ? [address, sourceChainProvider, 'useAccountType'] : null,
+    ([_address, _provider]) => addressIsSmartContract(_address, _provider)
   )
 
   // By default, assume it's an EOA

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -1,5 +1,5 @@
 import { useAccount, useProvider } from 'wagmi'
-import useSWRImmutable from 'swr/immutable'
+import { useEffect, useState } from 'react'
 
 import { addressIsSmartContract } from '../util/AddressUtils'
 
@@ -12,11 +12,20 @@ type Result = {
 export function useAccountType(): Result {
   const { address } = useAccount()
   const provider = useProvider()
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSmartContractWallet, setIsSmartContractWallet] = useState(false)
 
-  const { data: isSmartContractWallet = false, isLoading } = useSWRImmutable(
-    address ? [address, provider, 'useAccountType'] : null,
-    ([_address, _provider]) => addressIsSmartContract(_address, _provider)
-  )
+  useEffect(() => {
+    setIsLoading(true)
+    async function getAccountType() {
+      if (address && provider) {
+        const isSmartContract = await addressIsSmartContract(address, provider)
+        setIsSmartContractWallet(isSmartContract)
+        setIsLoading(false)
+      }
+    }
+    getAccountType()
+  }, [address, provider])
 
   // By default, assume it's an EOA
   return {

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -1,7 +1,6 @@
 import { Provider } from '@ethersproject/providers'
 
 import { getAPIBaseUrl } from '.'
-import { getProviderForChainId } from '../hooks/useNetworks'
 
 export type Address = `0x${string}`
 
@@ -9,17 +8,7 @@ export async function addressIsSmartContract(
   address: string,
   provider: Provider
 ) {
-  try {
-    console.log(
-      'xxxx calling addressIsSmartContract',
-      address,
-      provider,
-      (await provider.getCode(address)).length > 2
-    )
-    return (await provider.getCode(address)).length > 2
-  } catch (_) {
-    return false
-  }
+  return (await provider.getCode(address)).length > 2
 }
 
 export async function addressIsDenylisted(address: string) {

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -8,13 +8,11 @@ export async function addressIsSmartContract(
   address: string,
   provider: Provider
 ) {
-  console.log(
-    'XXXX',
-    address,
-    provider,
-    (await provider.getCode(address)).length > 2
-  )
-  return (await provider.getCode(address)).length > 2
+  try {
+    return (await provider.getCode(address)).length > 2
+  } catch (_) {
+    return false
+  }
 }
 
 export async function addressIsDenylisted(address: string) {

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -8,6 +8,12 @@ export async function addressIsSmartContract(
   address: string,
   provider: Provider
 ) {
+  console.log(
+    'XXXX',
+    address,
+    provider,
+    (await provider.getCode(address)).length > 2
+  )
   return (await provider.getCode(address)).length > 2
 }
 

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -1,6 +1,7 @@
 import { Provider } from '@ethersproject/providers'
 
 import { getAPIBaseUrl } from '.'
+import { getProviderForChainId } from '../hooks/useNetworks'
 
 export type Address = `0x${string}`
 
@@ -9,6 +10,12 @@ export async function addressIsSmartContract(
   provider: Provider
 ) {
   try {
+    console.log(
+      'xxxx calling addressIsSmartContract',
+      address,
+      provider,
+      (await provider.getCode(address)).length > 2
+    )
     return (await provider.getCode(address)).length > 2
   } catch (_) {
     return false


### PR DESCRIPTION
There was an issue where Safe wallet connection was not being detected as Smart Contract Wallet in Bridge UI.

Cause: 
When we use `const provider = useProvider()`  it sends both, the source chain and destination chain providers to the `addressIsSmartContract`  function. 
Now the catch is, when we log in to safe, we only log in through one of the providers (ie. either Ethereum or Arbitrum One, depending on the nature of SCW we created), so the other provider, when passed into the hook, results in the `addressIsSmartContract` value as false, and overrides the original true value from the correct provider.

Instead, now we pass just the source-chain-provider and it works consistently for testnets and mainnets.