### PR TITLE
fix: increase withdrawals gas limit by 30%

### DIFF
--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/Erc20WithdrawalStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/Erc20WithdrawalStarter.ts
@@ -203,7 +203,7 @@ export class Erc20WithdrawalStarter extends BridgeTransferStarter {
       this.sourceChainProvider
     )
 
-    const { txRequest } = await erc20Bridger.getWithdrawalRequest({
+    const request = await erc20Bridger.getWithdrawalRequest({
       from: address,
       erc20l1Address: destinationChainErc20Address,
       destinationAddress: destinationAddress ?? address,
@@ -211,13 +211,11 @@ export class Erc20WithdrawalStarter extends BridgeTransferStarter {
     })
 
     const tx = await erc20Bridger.withdraw({
+      ...request,
       l2Signer: signer,
-      erc20l1Address: destinationChainErc20Address,
-      destinationAddress: destinationAddress ?? address,
-      amount,
       overrides: {
         gasLimit: percentIncrease(
-          await this.sourceChainProvider.estimateGas(txRequest),
+          await this.sourceChainProvider.estimateGas(request.txRequest),
           BigNumber.from(30)
         )
       }

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/Erc20WithdrawalStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/Erc20WithdrawalStarter.ts
@@ -216,7 +216,6 @@ export class Erc20WithdrawalStarter extends BridgeTransferStarter {
       destinationAddress: destinationAddress ?? address,
       amount,
       overrides: {
-        // same as in WithdrawalUtils.ts, needs to be cleaned up and moved to the SDK
         gasLimit: percentIncrease(
           await this.sourceChainProvider.estimateGas(txRequest),
           BigNumber.from(30)

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/Erc20WithdrawalStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/Erc20WithdrawalStarter.ts
@@ -203,9 +203,11 @@ export class Erc20WithdrawalStarter extends BridgeTransferStarter {
       this.sourceChainProvider
     )
 
-    const { estimatedChildChainGas } = await this.transferEstimateGas({
-      amount,
-      signer
+    const { txRequest } = await erc20Bridger.getWithdrawalRequest({
+      from: address,
+      erc20l1Address: destinationChainErc20Address,
+      destinationAddress: destinationAddress ?? address,
+      amount
     })
 
     const tx = await erc20Bridger.withdraw({
@@ -214,7 +216,11 @@ export class Erc20WithdrawalStarter extends BridgeTransferStarter {
       destinationAddress: destinationAddress ?? address,
       amount,
       overrides: {
-        gasLimit: percentIncrease(estimatedChildChainGas, BigNumber.from(20))
+        // same as in WithdrawalUtils.ts, needs to be cleaned up and moved to the SDK
+        gasLimit: percentIncrease(
+          await this.sourceChainProvider.estimateGas(txRequest),
+          BigNumber.from(30)
+        )
       }
     })
 

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/EthWithdrawalStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/EthWithdrawalStarter.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'ethers'
 import { EthBridger } from '@arbitrum/sdk'
 import {
   BridgeTransferStarter,
@@ -5,7 +6,7 @@ import {
   TransferProps,
   TransferType
 } from './BridgeTransferStarter'
-import { getAddressFromSigner } from './utils'
+import { getAddressFromSigner, percentIncrease } from './utils'
 import { withdrawInitTxEstimateGas } from '../util/WithdrawalUtils'
 
 export class EthWithdrawalStarter extends BridgeTransferStarter {
@@ -46,13 +47,23 @@ export class EthWithdrawalStarter extends BridgeTransferStarter {
 
   public async transfer({ amount, signer }: TransferProps) {
     const address = await getAddressFromSigner(signer)
-
     const ethBridger = await EthBridger.fromProvider(this.sourceChainProvider)
-    const tx = await ethBridger.withdraw({
+
+    const request = await ethBridger.getWithdrawalRequest({
       amount,
-      l2Signer: signer,
       destinationAddress: address,
       from: address
+    })
+
+    const tx = await ethBridger.withdraw({
+      ...request,
+      l2Signer: signer,
+      overrides: {
+        gasLimit: percentIncrease(
+          await this.sourceChainProvider.estimateGas(request.txRequest),
+          BigNumber.from(30)
+        )
+      }
     })
 
     return {


### PR DESCRIPTION
This was missed with the token bridge sdk, but was in previously.

Before:
  - ETH withdrawal gas limit: ~70k
  - WETH withdrawal gas limit: ~167k
  
After:
  - ETH withdrawal gas limit: ~90k
  - WETH withdrawal gas limit: ~217k