### PR TITLE
ci: use node.js v18

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,10 @@
+name: Set up Node.js
+description: Set up Node.js
+
+runs:
+  using: composite
+  steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,6 +5,6 @@ runs:
   using: composite
   steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       is_hotfix: ${{ steps.check-is-hotfix.outputs.is_hotfix }}
-    
-    steps:        
-      - name: Make IS_HOTFIX env var global 
+
+    steps:
+      - name: Make IS_HOTFIX env var global
         id: check-is-hotfix
         run: |
           echo "is_hotfix=${{ env.IS_HOTFIX }}" >> $GITHUB_OUTPUT
@@ -79,6 +79,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
+
       - name: Install node_modules
         uses: OffchainLabs/actions/node-modules/install@main
 
@@ -89,6 +92,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
 
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main
@@ -108,6 +114,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
+
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main
 
@@ -125,6 +134,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
+
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main
 
@@ -138,6 +150,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
 
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main
@@ -178,6 +193,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
 
       - name: Chown workspace
         run: chown -R $(whoami) .
@@ -257,7 +275,7 @@ jobs:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64
-      
+
       - name: Create screenshots directory
         if: steps.e2e-run.outputs.status == 'failed'
         run: mkdir -p packages/arb-token-bridge-ui/tests/e2e/cypress/screenshots
@@ -291,7 +309,7 @@ jobs:
           path: packages/arb-token-bridge-ui/tests/e2e/cypress/videos
           compression-level: 0
           retention-days: 3
-            
+
       - name: Throw error if tests failed
         if: steps.e2e-run.outputs.status == 'failed'
         run: exit 1


### PR DESCRIPTION
### Summary

I opted not to go for v4 of actions because they default to Node.js v20.