### PR TITLE
chore: remove unused script

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -61,7 +61,6 @@
     "lint": "tsc && eslint 'src/**/*.{js,ts,tsx}'",
     "lint:fix": "tsc && eslint 'src/**/*.{js,ts,tsx}' --quiet --fix",
     "prettier:format": "prettier --config-precedence file-override --write \"src/**/*.{tsx,ts,scss,md,json}\"",
-    "getUnusedComponents": "ts-prune | grep ' default$'",
     "generateDenylist": "ts-node --project ./scripts/tsconfig.json ./scripts/generateDenylist.ts",
     "e2e:open": "env-cmd -f .e2e.env yarn synpress open --configFile synpress.config.ts",
     "e2e:run": "env-cmd -f .e2e.env yarn synpress run --configFile synpress.config.ts",


### PR DESCRIPTION
we don't use it anymore
it was a legacy script from 3 years ago according to git blame
https://github.com/OffchainLabs/arbitrum-token-bridge/blame/ec136b3bf1900dda74c417de1b6abd1c7c528302/packages/arb-token-bridge-ui/package.json