### PR TITLE
fix: bump hardcoded retryable gas limit for deposits

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -80,7 +80,8 @@ async function fetchTokenFallbackGasEstimates({
     // https://arbiscan.io/tx/0xb341745b6f4a34ee539c628dcf177fc98b658e494c7f8d21da872e69d5173596
     // https://arbiscan.io/tx/0x731d31834bc01d33a1de33b5562b29c1ae6f75d20f6da83a5d74c3c91bd2dab9
     // https://arbiscan.io/tx/0x6b13bfe9f22640ac25f77a677a3c36e748913d5e07766b3d6394de09a1398020
-    estimatedChildChainGas: BigNumber.from(150_000),
+    // https://arbiscan.io/tx/0x8f52daffdd97af8130d667a74a89234cd9ce838d23214d61818bd9743a2f64f8 // 275_000
+    estimatedChildChainGas: BigNumber.from(300_000),
     estimatedChildChainSubmissionCost
   }
 }


### PR DESCRIPTION
We observed [this tx](https://arbiscan.io/tx/0x8f52daffdd97af8130d667a74a89234cd9ce838d23214d61818bd9743a2f64f8) to be taking more gas than what we estimate on UI. 
Updating the fallback gas limit for token deposits to accommodate for this case as well.