### PR TITLE
refactor: move `getProviderFromChainId` into `bridge-sdk`

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/AddCustomChain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/AddCustomChain.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../util/networks'
 import { Loader } from './atoms/Loader'
 import { Erc20Data, fetchErc20Data } from '../../util/TokenUtils'
-import { getProviderForChainId } from '../../hooks/useNetworks'
+import { getProviderForChainId } from '@/token-bridge-sdk/utils'
 import { Transition } from './Transition'
 import { Button } from './Button'
 

--- a/packages/arb-token-bridge-ui/src/hooks/useNetworks.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useNetworks.ts
@@ -4,11 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { mainnet, arbitrum } from '@wagmi/core/chains'
 
 import { useArbQueryParams } from './useArbQueryParams'
-import {
-  ChainId,
-  getCustomChainsFromLocalStorage,
-  rpcURLs
-} from '../util/networks'
+import { ChainId, getCustomChainsFromLocalStorage } from '../util/networks'
 import {
   sepolia,
   holesky,
@@ -23,29 +19,7 @@ import {
 import { getDestinationChainIds } from '../util/networks'
 import { getWagmiChain } from '../util/wagmi/getWagmiChain'
 import { getOrbitChains } from '../util/orbitChainsList'
-
-const getProviderForChainCache: {
-  [chainId: number]: StaticJsonRpcProvider
-} = {
-  // start with empty cache
-}
-
-function createProviderWithCache(chainId: ChainId) {
-  const rpcUrl = rpcURLs[chainId]
-  const provider = new StaticJsonRpcProvider(rpcUrl, chainId)
-  getProviderForChainCache[chainId] = provider
-  return provider
-}
-
-export function getProviderForChainId(chainId: ChainId): StaticJsonRpcProvider {
-  const cachedProvider = getProviderForChainCache[chainId]
-
-  if (typeof cachedProvider !== 'undefined') {
-    return cachedProvider
-  }
-
-  return createProviderWithCache(chainId)
-}
+import { getProviderForChainId } from '@/token-bridge-sdk/utils'
 
 export function isSupportedChainId(
   chainId: ChainId | undefined

--- a/packages/arb-token-bridge-ui/src/hooks/useRedeemRetryable.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useRedeemRetryable.ts
@@ -10,7 +10,7 @@ import { trackEvent } from '../util/AnalyticsUtils'
 import { getNetworkName } from '../util/networks'
 import { isUserRejectedError } from '../util/isUserRejectedError'
 import { errorToast } from '../components/common/atoms/Toast'
-import { getProviderForChainId } from './useNetworks'
+import { getProviderForChainId } from '@/token-bridge-sdk/utils'
 import { useTransactionHistory } from './useTransactionHistory'
 import { Address } from '../util/AddressUtils'
 

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/BridgeTransferStarterFactory.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/BridgeTransferStarterFactory.ts
@@ -6,8 +6,7 @@ import { EthDepositStarter } from './EthDepositStarter'
 import { Erc20DepositStarter } from './Erc20DepositStarter'
 import { EthWithdrawalStarter } from './EthWithdrawalStarter'
 import { Erc20WithdrawalStarter } from './Erc20WithdrawalStarter'
-import { getBridgeTransferProperties } from './utils'
-import { getProviderForChainId } from '../hooks/useNetworks'
+import { getBridgeTransferProperties, getProviderForChainId } from './utils'
 
 function getCacheKey(props: BridgeTransferStarterPropsWithChainIds): string {
   let cacheKey = `source:${props.sourceChainId}-destination:${props.destinationChainId}`

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/utils.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/utils.ts
@@ -1,7 +1,7 @@
 import { BigNumber, Signer } from 'ethers'
-import { Provider } from '@ethersproject/providers'
+import { Provider, StaticJsonRpcProvider } from '@ethersproject/providers'
 
-import { isNetwork } from '../util/networks'
+import { ChainId, isNetwork, rpcURLs } from '../util/networks'
 import { BridgeTransferStarterPropsWithChainIds } from './BridgeTransferStarter'
 
 export const getAddressFromSigner = async (signer: Signer) => {
@@ -57,4 +57,27 @@ export function percentIncrease(
   increase: BigNumber
 ): BigNumber {
   return num.add(num.mul(increase).div(100))
+}
+
+const getProviderForChainCache: {
+  [chainId: number]: StaticJsonRpcProvider
+} = {
+  // start with empty cache
+}
+
+function createProviderWithCache(chainId: ChainId) {
+  const rpcUrl = rpcURLs[chainId]
+  const provider = new StaticJsonRpcProvider(rpcUrl, chainId)
+  getProviderForChainCache[chainId] = provider
+  return provider
+}
+
+export function getProviderForChainId(chainId: ChainId): StaticJsonRpcProvider {
+  const cachedProvider = getProviderForChainCache[chainId]
+
+  if (typeof cachedProvider !== 'undefined') {
+    return cachedProvider
+  }
+
+  return createProviderWithCache(chainId)
 }


### PR DESCRIPTION
Teleport PR 1 of n.
---
We use `getProviderFromChainId` all over the code, in `token-bridge-sdk` and UI as well. It's better if this method is exported from `token-bridge-sdk`, rather than us trying to import this method from UI into SDK.

Closes FS-537