### PR TITLE
feat: monitor orbit retryables

### DIFF
--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout Bridge
       uses: actions/checkout@v3
       with:
-        repository: https://github.com/OffchainLabs/arbitrum-token-bridge
+        repository: OffchainLabs/arbitrum-token-bridge
         ref: 'feat-enable-orbit-retryable-monitoring' # the branch where our alerting code is present
 
     - name: Restore node_modules

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
-  SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+  ORBIT_RETRYABLE_MONITORING_SLACK_TOKEN: ${{ secrets.ORBIT_RETRYABLE_MONITORING_SLACK_TOKEN }}
+  ORBIT_RETRYABLE_MONITORING_SLACK_CHANNEL: ${{ secrets.ORBIT_RETRYABLE_MONITORING_SLACK_CHANNEL }}
 
 jobs:
   run-alerting:
@@ -52,8 +52,8 @@ jobs:
       run: cd ./orbit-retryable-tracker && yarn findRetryables --enableAlerting
       env:
         NODE_ENV: "CI"
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+        ORBIT_RETRYABLE_MONITORING_SLACK_TOKEN: ${{ secrets.ORBIT_RETRYABLE_MONITORING_SLACK_TOKEN }}
+        ORBIT_RETRYABLE_MONITORING_SLACK_CHANNEL: ${{ secrets.ORBIT_RETRYABLE_MONITORING_SLACK_CHANNEL }}
 
 
     - name: Clean up

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -1,0 +1,59 @@
+name: Orbit Retryable Tracker
+
+on:
+  schedule:
+    # Run everyday at 12:00 PM UTC
+    - cron: '0 12 * * *'
+
+env:
+  NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
+
+jobs:
+  run-alerting:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Bridge repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: yarn install
+
+    - name: Generate chains JSON
+      run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor
+
+    - name: Checkout Orbit-Retryable-Tracker repository
+      uses: actions/checkout@v2
+      with:
+        repository: https://github.com/OffchainLabs/orbit-retryable-tracker/tree/enable-alerting
+        path: orbit-retryable-tracker
+
+    - name: Copy chains JSON to Retryable-Tracker
+      run: cp chains.jsonorbit-retryable-tracker/lib/config.json
+
+    - name: Set up Node.js
+      working-directory: orbit-retryable-tracker
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+    
+    - name: Install dependencies for Retryable-Tracker
+      working-directory: orbit-retryable-tracker
+      run: yarn install
+
+    - name: Run alerting command
+      working-directory: orbit-retryable-tracker
+      run: yarn findRetryables --continuous --enableAlerting
+      env:
+        NODE_ENV: "CI"
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+
+
+    - name: Clean up
+      run: rm chains.json

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -38,7 +38,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: pwd && ls && cp packages/arb-token-bridge-ui/scripts/orbit-chains.json orbit-retryable-tracker/lib/config.json
+      run: pwd && ls && cp .packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json orbit-retryable-tracker/lib/config.json
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -1,4 +1,4 @@
-name: Orbit Retryable Tracker
+name: Monitor Orbit Retryables
 
 on:
   schedule:

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -20,6 +20,7 @@ jobs:
       with:
         repository: OffchainLabs/arbitrum-token-bridge
         ref: 'feat-enable-orbit-retryable-monitoring' # the branch where our alerting code is present
+        path: bridge
 
     - name: Restore node_modules
       uses: OffchainLabs/actions/node-modules/restore@main
@@ -38,7 +39,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: cp orbit-chains.json orbit-retryable-tracker/lib/config.json
+      run: cp bridge/orbit-chains.json orbit-retryable-tracker/lib/config.json
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -3,7 +3,7 @@ name: Orbit Retryable Tracker
 on:
   schedule:
     # Run everyday at 12:00 PM UTC
-    - cron: '0 12 * * *'
+    - cron: '*/3 * * * *'
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
@@ -16,12 +16,13 @@ jobs:
 
     steps:
     - name: Checkout Bridge repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
+      with:
+        repository: https://github.com/OffchainLabs/arbitrum-token-bridge
+        ref: 'feat-enable-orbit-retryable-monitoring' # the branch where our alerting code is present
 
     - name: Set up Node.js
       uses: actions/setup-node@v3
-      with:
-        node-version: '18'
 
     - name: Install dependencies
       run: yarn install
@@ -30,7 +31,7 @@ jobs:
       run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor
 
     - name: Checkout Orbit-Retryable-Tracker repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         repository: https://github.com/OffchainLabs/orbit-retryable-tracker
         ref: 'enable-alerting' # the branch where our alerting code is present

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -39,9 +39,14 @@ jobs:
 
     - name: Copy chains JSON to Retryable-Tracker
       run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/config.json
-    
+   
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+      
     - name: Install dependencies for Retryable-Tracker
-      run: cd ./orbit-retryable-tracker && nvm use 18 && yarn install && ls
+      run: cd ./orbit-retryable-tracker && yarn install
 
     - name: Run alerting command
       run: cd ./orbit-retryable-tracker && yarn findRetryables --continuous --enableAlerting

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -41,7 +41,7 @@ jobs:
       run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/config.json
    
     - name: Setup Node for Retryable-Tracker
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v3
       with:
         node-version: 18
 

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -1,9 +1,11 @@
 name: Orbit Retryable Tracker
 
 on:
-  schedule:
-    # Run everyday at 12:00 PM UTC
-    - cron: '*/3 * * * *'
+  push:
+    branches:
+      - "feat-enable-orbit-retryable-monitoring"
+    paths:
+      - ".github/workflows/orbit-retryable-monitor.yaml"
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -41,9 +41,9 @@ jobs:
       run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/config.json
    
     - name: Setup Node for Retryable-Tracker
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: latest
 
     - name: Install dependencies for Retryable-Tracker
       run: cd ./orbit-retryable-tracker && yarn install

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -28,7 +28,7 @@ jobs:
       run: yarn install
 
     - name: Generate chains JSON
-      run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor --testnet
+      run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor
 
     - name: Checkout Orbit-Retryable-Tracker repository
       uses: actions/checkout@v3

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -38,7 +38,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: cp ./packages/arb-token-bridge-ui/public ./orbit-retryable-tracker/config.json
+      run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/config.json
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker
@@ -47,12 +47,10 @@ jobs:
     #     node-version: '18' # Specify the version of Node.js you need
     
     - name: Install dependencies for Retryable-Tracker
-      working-directory: orbit-retryable-tracker
-      run: yarn install
+      run: cd ./orbit-retryable-tracker && yarn install
 
     - name: Run alerting command
-      working-directory: orbit-retryable-tracker
-      run: yarn findRetryables --continuous --enableAlerting
+      run: cd ./orbit-retryable-tracker && yarn findRetryables --continuous --enableAlerting
       env:
         NODE_ENV: "CI"
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout Orbit-Retryable-Tracker repository
       uses: actions/checkout@v3
       with:
-        repository: https://github.com/OffchainLabs/orbit-retryable-tracker
+        repository: OffchainLabs/orbit-retryable-tracker
         ref: 'enable-alerting' # the branch where our alerting code is present
         path: orbit-retryable-tracker
 

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -20,7 +20,6 @@ jobs:
       with:
         repository: OffchainLabs/arbitrum-token-bridge
         ref: 'feat-enable-orbit-retryable-monitoring' # the branch where our alerting code is present
-        path: main
 
     - name: Restore node_modules
       uses: OffchainLabs/actions/node-modules/restore@main
@@ -29,7 +28,6 @@ jobs:
       run: yarn install
 
     - name: Generate chains JSON
-      working-directory: main
       run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor
 
     - name: Checkout Orbit-Retryable-Tracker repository
@@ -40,7 +38,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: cp main/orbit-chains.json orbit-retryable-tracker/lib/config.json
+      run: pwd && cp ./orbit-chains.json orbit-retryable-tracker/lib/config.json
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -29,6 +29,7 @@ jobs:
       run: yarn install
 
     - name: Generate chains JSON
+      working-directory: bridge-ui
       run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor
 
     - name: Checkout Orbit-Retryable-Tracker repository

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -40,11 +40,11 @@ jobs:
     - name: Copy chains JSON to Retryable-Tracker
       run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/config.json
    
-    - name: Setup Node
+    - name: Setup Node for Retryable-Tracker
       uses: actions/setup-node@v4
       with:
         node-version: 18
-      
+
     - name: Install dependencies for Retryable-Tracker
       run: cd ./orbit-retryable-tracker && yarn install
 

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -2,10 +2,8 @@ name: Orbit Retryable Tracker
 
 on:
   push:
-    branches:
-      - "feat-enable-orbit-retryable-monitoring"
     paths:
-      - ".github/workflows/orbit-retryable-monitor.yaml"
+      - ".github/workflows/orbit-retryable-monitor.yml"
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
@@ -17,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Bridge repository
+    - name: Checkout Bridge
       uses: actions/checkout@v3
       with:
         repository: https://github.com/OffchainLabs/arbitrum-token-bridge
         ref: 'feat-enable-orbit-retryable-monitoring' # the branch where our alerting code is present
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
+    - name: Restore node_modules
+      uses: OffchainLabs/actions/node-modules/restore@main
 
     - name: Install dependencies
       run: yarn install

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -49,7 +49,7 @@ jobs:
       run: cd ./orbit-retryable-tracker && yarn install
 
     - name: Run alerting command
-      run: cd ./orbit-retryable-tracker && yarn findRetryables --continuous --enableAlerting
+      run: cd ./orbit-retryable-tracker && yarn findRetryables --enableAlerting
       env:
         NODE_ENV: "CI"
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -38,7 +38,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: pwd && ls && cp .packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json orbit-retryable-tracker/lib/config.json
+      run: pwd && cd ./packages/arb-token-bridge-ui/public && ls
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -39,15 +39,9 @@ jobs:
 
     - name: Copy chains JSON to Retryable-Tracker
       run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/config.json
-
-    # - name: Set up Node.js
-    #   working-directory: orbit-retryable-tracker
-    #   uses: actions/setup-node@v3
-    #   with:
-    #     node-version: '18' # Specify the version of Node.js you need
     
     - name: Install dependencies for Retryable-Tracker
-      run: cd ./orbit-retryable-tracker && yarn install
+      run: cd ./orbit-retryable-tracker && yarn install && ls
 
     - name: Run alerting command
       run: cd ./orbit-retryable-tracker && yarn findRetryables --continuous --enableAlerting

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -38,7 +38,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: pwd && cp ./orbit-chains.json orbit-retryable-tracker/lib/config.json
+      run: pwd && ls && cp packages/arb-token-bridge-ui/scripts/orbit-chains.json orbit-retryable-tracker/lib/config.json
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker
@@ -60,4 +60,4 @@ jobs:
 
 
     - name: Clean up
-      run: rm orbit-chains.json
+      run: rm packages/arb-token-bridge-ui/scripts/orbit-chains.json

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -41,7 +41,7 @@ jobs:
       run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/config.json
     
     - name: Install dependencies for Retryable-Tracker
-      run: cd ./orbit-retryable-tracker && yarn install && ls
+      run: cd ./orbit-retryable-tracker && nvm use 18 && yarn install && ls
 
     - name: Run alerting command
       run: cd ./orbit-retryable-tracker && yarn findRetryables --continuous --enableAlerting

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -2,8 +2,8 @@ name: Monitor Orbit Retryables
 
 on:
   schedule:
-    # Run every 3 hours (while we test)
-    - cron: '0 */3 * * *'
+    # Run every 1 hours (while we test)
+    - cron: '0 */1 * * *'
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         repository: OffchainLabs/arbitrum-token-bridge
         ref: 'feat-enable-orbit-retryable-monitoring' # the branch where our alerting code is present
-        path: bridge
+        path: bridge-ui
 
     - name: Restore node_modules
       uses: OffchainLabs/actions/node-modules/restore@main
@@ -39,7 +39,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: cp bridge/orbit-chains.json orbit-retryable-tracker/lib/config.json
+      run: cp bridge-ui/orbit-chains.json orbit-retryable-tracker/lib/config.json
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         repository: OffchainLabs/arbitrum-token-bridge
         ref: 'feat-enable-orbit-retryable-monitoring' # the branch where our alerting code is present
-        path: bridge-ui
+        path: main
 
     - name: Restore node_modules
       uses: OffchainLabs/actions/node-modules/restore@main
@@ -29,7 +29,7 @@ jobs:
       run: yarn install
 
     - name: Generate chains JSON
-      working-directory: bridge-ui
+      working-directory: main
       run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor
 
     - name: Checkout Orbit-Retryable-Tracker repository
@@ -40,7 +40,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: cp bridge-ui/orbit-chains.json orbit-retryable-tracker/lib/config.json
+      run: cp main/orbit-chains.json orbit-retryable-tracker/lib/config.json
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -1,9 +1,9 @@
 name: Orbit Retryable Tracker
 
 on:
-  push:
-    paths:
-      - ".github/workflows/orbit-retryable-monitor.yml"
+  schedule:
+    # Run everyday at 12:00 PM UTC
+    - cron: '0 12 * * *'
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -2,8 +2,8 @@ name: Orbit Retryable Tracker
 
 on:
   schedule:
-    # Run everyday at 12:00 PM UTC
-    - cron: '0 12 * * *'
+    # Run every 3 hours (while we test)
+    - cron: '0 */3 * * *'
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -28,7 +28,7 @@ jobs:
       run: yarn install
 
     - name: Generate chains JSON
-      run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor
+      run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor --testnet
 
     - name: Checkout Orbit-Retryable-Tracker repository
       uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/config.json
+      run: cp ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json ./orbit-retryable-tracker/lib/config.json
    
     - name: Setup Node for Retryable-Tracker
       uses: actions/setup-node@v4
@@ -57,4 +57,4 @@ jobs:
 
 
     - name: Clean up
-      run: rm packages/arb-token-bridge-ui/scripts/orbit-chains.json
+      run: rm ./packages/arb-token-bridge-ui/public/__auto-generated-orbit-chains.json

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
+  SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
 
 jobs:
   run-alerting:
@@ -14,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout Bridge repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Node.js
       uses: actions/setup-node@v3
@@ -28,19 +30,20 @@ jobs:
       run: yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor
 
     - name: Checkout Orbit-Retryable-Tracker repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
-        repository: https://github.com/OffchainLabs/orbit-retryable-tracker/tree/enable-alerting
+        repository: https://github.com/OffchainLabs/orbit-retryable-tracker
+        ref: 'enable-alerting' # the branch where our alerting code is present
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: cp chains.jsonorbit-retryable-tracker/lib/config.json
+      run: cp orbit-chains.json orbit-retryable-tracker/lib/config.json
 
-    - name: Set up Node.js
-      working-directory: orbit-retryable-tracker
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18'
+    # - name: Set up Node.js
+    #   working-directory: orbit-retryable-tracker
+    #   uses: actions/setup-node@v3
+    #   with:
+    #     node-version: '18' # Specify the version of Node.js you need
     
     - name: Install dependencies for Retryable-Tracker
       working-directory: orbit-retryable-tracker
@@ -56,4 +59,4 @@ jobs:
 
 
     - name: Clean up
-      run: rm chains.json
+      run: rm orbit-chains.json

--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -38,7 +38,7 @@ jobs:
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker
-      run: pwd && cd ./packages/arb-token-bridge-ui/public && ls
+      run: cp ./packages/arb-token-bridge-ui/public ./orbit-retryable-tracker/config.json
 
     # - name: Set up Node.js
     #   working-directory: orbit-retryable-tracker

--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -62,6 +62,7 @@
     "lint:fix": "tsc && eslint 'src/**/*.{js,ts,tsx}' --quiet --fix",
     "prettier:format": "prettier --config-precedence file-override --write \"src/**/*.{tsx,ts,scss,md,json}\"",
     "generateDenylist": "ts-node --project ./scripts/tsconfig.json ./scripts/generateDenylist.ts",
+    "generateOrbitChainsToMonitor": "ts-node --project ./scripts/tsconfig.json ./scripts/generateOrbitChainsToMonitor.ts",
     "e2e:open": "env-cmd -f .e2e.env yarn synpress open --configFile synpress.config.ts",
     "e2e:run": "env-cmd -f .e2e.env yarn synpress run --configFile synpress.config.ts",
     "e2e:run:cctp": "E2E_CCTP=true yarn e2e:run",

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -53,4 +53,4 @@ async function generateOrbitChainsToMonitor() {
 }
 
 generateOrbitChainsToMonitor()
-//3
+//4

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -53,4 +53,4 @@ async function generateOrbitChainsToMonitor() {
 }
 
 generateOrbitChainsToMonitor()
-//2
+//3

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -42,16 +42,14 @@ async function generateOrbitChainsToMonitor() {
   }))
 
   // write to orbit-chains.json, we will use this json as an input to the retryable-monitoring script
-  fs.writeFileSync(
-    'orbit-chains.json',
-    JSON.stringify(
-      {
-        childChains: [orbitChainsToMonitor]
-      },
-      null,
-      2
-    )
+  const resultsJson = JSON.stringify(
+    {
+      childChains: [orbitChainsToMonitor]
+    },
+    null,
+    2
   )
+  fs.writeFileSync('./public/__auto-generated-orbit-chains.json', resultsJson)
 }
 
 generateOrbitChainsToMonitor()

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -28,7 +28,7 @@ const sanitizeRpcUrl = (url: string) => {
 }
 
 async function generateOrbitChainsToMonitor() {
-  const orbitChains = await getOrbitChains({ mainnet: true, testnet: true })
+  const orbitChains = await getOrbitChains({ mainnet: true, testnet: false })
 
   // make the orbit chain data compatible with the orbit-data required by the retryable-monitoring script
   const orbitChainsToMonitor: ChildNetwork[] = orbitChains.map(orbitChain => ({

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -53,4 +53,4 @@ async function generateOrbitChainsToMonitor() {
 }
 
 generateOrbitChainsToMonitor()
-//1
+//2

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -54,4 +54,4 @@ async function generateOrbitChainsToMonitor() {
 
 generateOrbitChainsToMonitor()
 
-//5
+//6

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -40,7 +40,16 @@ async function generateOrbitChainsToMonitor() {
     )
   }))
 
-  fs.writeFileSync('chains.json', JSON.stringify(orbitChainsToMonitor, null, 2))
+  fs.writeFileSync(
+    'orbit-chains.json',
+    JSON.stringify(
+      {
+        childChains: [orbitChainsToMonitor]
+      },
+      null,
+      2
+    )
+  )
 }
 
 generateOrbitChainsToMonitor()

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -53,4 +53,5 @@ async function generateOrbitChainsToMonitor() {
 }
 
 generateOrbitChainsToMonitor()
-//4
+
+//5

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -1,0 +1,46 @@
+import fs from 'fs'
+import { getOrbitChains } from '../src/util/orbitChainsList'
+import { L2Network } from '@arbitrum/sdk'
+import { getExplorerUrl, rpcURLs } from '../src/util/networks'
+
+interface ChildNetwork extends L2Network {
+  parentRpcUrl: string
+  orbitRpcUrl: string
+  parentExplorerUrl: string
+}
+
+const sanitizeExplorerUrl = (url: string) => {
+  // we want explorer urls to have a trailing slash
+  if (url.endsWith('/')) {
+    return url
+  } else {
+    return url + '/'
+  }
+}
+
+const sanitizeRpcUrl = (url: string) => {
+  // we want rpc urls to NOT have a trailing slash
+  if (url.endsWith('/')) {
+    return url.slice(0, -1)
+  } else {
+    return url
+  }
+}
+
+async function generateOrbitChainsToMonitor() {
+  const orbitChains = await getOrbitChains()
+
+  const orbitChainsToMonitor: ChildNetwork[] = orbitChains.map(orbitChain => ({
+    ...orbitChain,
+    explorerUrl: sanitizeExplorerUrl(orbitChain.explorerUrl),
+    orbitRpcUrl: sanitizeRpcUrl(orbitChain.rpcUrl),
+    parentRpcUrl: sanitizeRpcUrl(rpcURLs[orbitChain.partnerChainID]),
+    parentExplorerUrl: sanitizeExplorerUrl(
+      getExplorerUrl(orbitChain.partnerChainID)
+    )
+  }))
+
+  fs.writeFileSync('chains.json', JSON.stringify(orbitChainsToMonitor, null, 2))
+}
+
+generateOrbitChainsToMonitor()

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -1,23 +1,7 @@
 import fs from 'fs'
-import yargs from 'yargs'
 import { L2Network } from '@arbitrum/sdk'
 import { getOrbitChains } from '../src/util/orbitChainsList'
 import { getExplorerUrl, rpcURLs } from '../src/util/networks'
-
-// Type for options passed to findRetryables function
-type GenerateOrbitChainsOptions = {
-  mainnet: boolean
-  testnet: boolean
-}
-
-// Parsing command line arguments using yargs
-const options: GenerateOrbitChainsOptions = yargs(process.argv.slice(2))
-  .options({
-    mainnet: { type: 'boolean', default: true },
-    testnet: { type: 'boolean', default: false }
-  })
-  .strict()
-  .parseSync() as GenerateOrbitChainsOptions
 
 interface ChildNetwork extends L2Network {
   parentRpcUrl: string
@@ -43,14 +27,8 @@ const sanitizeRpcUrl = (url: string) => {
   }
 }
 
-async function generateOrbitChainsToMonitor({
-  mainnet,
-  testnet
-}: {
-  mainnet: boolean
-  testnet: boolean
-}) {
-  const orbitChains = await getOrbitChains({ mainnet, testnet })
+async function generateOrbitChainsToMonitor() {
+  const orbitChains = await getOrbitChains({ mainnet: true, testnet: true })
 
   // make the orbit chain data compatible with the orbit-data required by the retryable-monitoring script
   const orbitChainsToMonitor: ChildNetwork[] = orbitChains.map(orbitChain => ({
@@ -74,7 +52,4 @@ async function generateOrbitChainsToMonitor({
   fs.writeFileSync('./public/__auto-generated-orbit-chains.json', resultsJson)
 }
 
-generateOrbitChainsToMonitor({
-  mainnet: options.mainnet,
-  testnet: options.testnet
-})
+generateOrbitChainsToMonitor()

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -53,3 +53,4 @@ async function generateOrbitChainsToMonitor() {
 }
 
 generateOrbitChainsToMonitor()
+//1

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
-import { getOrbitChains } from '../src/util/orbitChainsList'
 import { L2Network } from '@arbitrum/sdk'
+import { getOrbitChains } from '../src/util/orbitChainsList'
 import { getExplorerUrl, rpcURLs } from '../src/util/networks'
 
 interface ChildNetwork extends L2Network {
@@ -30,6 +30,7 @@ const sanitizeRpcUrl = (url: string) => {
 async function generateOrbitChainsToMonitor() {
   const orbitChains = await getOrbitChains()
 
+  // make the orbit chain data compatible with the orbit-data required by the retryable-monitoring script
   const orbitChainsToMonitor: ChildNetwork[] = orbitChains.map(orbitChain => ({
     ...orbitChain,
     explorerUrl: sanitizeExplorerUrl(orbitChain.explorerUrl),
@@ -40,6 +41,7 @@ async function generateOrbitChainsToMonitor() {
     )
   }))
 
+  // write to orbit-chains.json, we will use this json as an input to the retryable-monitoring script
   fs.writeFileSync(
     'orbit-chains.json',
     JSON.stringify(


### PR DESCRIPTION
Scripts to monitor all the retryables for Orbit chains that have been added to the Bridge UI. They will run daily and will alert us in the testing channel. The steps are as follows: 
1. Using Github actions - Generate the `Orbit chains' json` that is compatible with the input for https://github.com/OffchainLabs/orbit-retryable-tracker script.
2. Move the generated `orbit-chains' json` to the config of `orbit-retryable-tracker` script, and run the `findRetryable` script in that repo.
3. Raise alerts about any unsuccessful retryables found in the chains.

Closes FS-525
