### PR TITLE
fix: update orbit-retryables monitoring branch

### DIFF
--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: OffchainLabs/arbitrum-token-bridge
-        ref: 'feat-enable-orbit-retryable-monitoring' # the branch where our alerting code is present
 
     - name: Restore node_modules
       uses: OffchainLabs/actions/node-modules/restore@main


### PR DESCRIPTION
We need `Monitor Orbit Retryables` action to checkout the main branch instead of the branch which got deleted after the merge.