### PR TITLE
chore: update `@arbitrum/sdk`

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.11",
-    "@arbitrum/sdk": "3.4.1-teleporter.1",
+    "@arbitrum/sdk": "3.4.1-teleporter.2",
     "@ethersproject/providers": "^5.7.0",
     "@headlessui/react": "^1.7.8",
     "@headlessui/tailwindcss": "^0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@arbitrum/sdk@3.4.1-teleporter.1":
-  version "3.4.1-teleporter.1"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.4.1-teleporter.1.tgz#5d3f29a7f7d29aee9b6b7084fcced0f8d9c6a2ba"
-  integrity sha512-AmoiUiQ1WSliPZCxIBNnP6B1caj2jgVshPc+7Nprk+DCllejm/jSl96RzXAMIEd5Vw3XOc70fMQ4BfB2R+Qmwg==
+"@arbitrum/sdk@3.4.1-teleporter.2":
+  version "3.4.1-teleporter.2"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.4.1-teleporter.2.tgz#dd7b7ac41c335a38efc472dc28e91171fd704ad0"
+  integrity sha512-mOEaKWs1DsqeWiYdrfPSAbAs43z+9n0gkq3uKDzM44Kw8l6GP9eTeYG4ntVC5GthWfuWyc8k6uvhbqT9jSRn2w==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"


### PR DESCRIPTION
Updates `@arbitrum/sdk` to the latest teleporter tag `3.4.1-teleporter.2` that has some fixes.