### PR TITLE
chore: update branch for orbit-retryable monitor

### DIFF
--- a/.github/workflows/orbit-retryable-monitor.yml
+++ b/.github/workflows/orbit-retryable-monitor.yml
@@ -34,7 +34,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: OffchainLabs/orbit-retryable-tracker
-        ref: 'enable-alerting' # the branch where our alerting code is present
         path: orbit-retryable-tracker
 
     - name: Copy chains JSON to Retryable-Tracker


### PR DESCRIPTION
To be merged after https://github.com/OffchainLabs/orbit-retryable-tracker/pull/7 is merged