### PR TITLE
fix: dont fetch withdrawals for teleport pairs

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -334,6 +334,16 @@ const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
               isConnectedToParentChain
             })
             try {
+              if (
+                isTeleport({
+                  sourceChainId: chainPair.parentChainId,
+                  destinationChainId: chainPair.childChainId
+                })
+              ) {
+                // Teleport fetcher will go here.
+                return []
+              }
+
               return await fetcherFn({
                 sender: includeSentTxs ? address : undefined,
                 receiver: includeReceivedTxs ? address : undefined,


### PR DESCRIPTION
With teleport now we have chain pairs L1<>L3. We have to early return for this case because otherwise the code will progress to fetching withdrawals. It would fetch withdrawals for L3 and set the parent chain as L1.