### PR TITLE
fix: detect SCW correctly

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/AdvancedSettings.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/AdvancedSettings.tsx
@@ -84,11 +84,11 @@ export async function getDestinationAddressError({
 async function getDestinationAddressWarning({
   destinationAddress,
   isEOA,
-  destinationProvider
+  destinationChainId
 }: {
   destinationAddress: string | undefined
   isEOA: boolean
-  destinationProvider: Provider
+  destinationChainId: number
 }) {
   if (!destinationAddress) {
     return null
@@ -100,7 +100,7 @@ async function getDestinationAddressWarning({
 
   const destinationIsSmartContract = await addressIsSmartContract(
     destinationAddress,
-    destinationProvider
+    destinationChainId
   )
 
   // checks if trying to send to a contract address, only checks EOA
@@ -163,9 +163,7 @@ export const AdvancedSettings = () => {
       const result = await getDestinationAddressWarning({
         destinationAddress,
         isEOA,
-        destinationProvider: isDepositMode
-          ? childChainProvider
-          : parentChainProvider
+        destinationChainId: isDepositMode ? childChain.id : parentChain.id
       })
       if (isSubscribed) {
         setWarning(result)
@@ -181,7 +179,9 @@ export const AdvancedSettings = () => {
     isDepositMode,
     isEOA,
     childChainProvider,
-    parentChainProvider
+    parentChainProvider,
+    childChain.id,
+    parentChain.id
   ])
 
   const collapsible = useMemo(() => {

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/Erc20WithdrawalStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/Erc20WithdrawalStarter.ts
@@ -189,9 +189,11 @@ export class Erc20WithdrawalStarter extends BridgeTransferStarter {
 
     const address = await getAddressFromSigner(signer)
 
+    const sourceChainId = await getChainIdFromProvider(this.sourceChainProvider)
+
     const isSmartContractWallet = await addressIsSmartContract(
       address,
-      this.sourceChainProvider
+      sourceChainId
     )
 
     if (isSmartContractWallet && !destinationAddress) {

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/teleport.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/teleport.ts
@@ -6,7 +6,7 @@ import { L1GatewayRouter__factory } from '@arbitrum/sdk/dist/lib/abi/factories/L
 import { IInbox__factory } from '@arbitrum/sdk/dist/lib/abi/factories/IInbox__factory'
 import { IBridge__factory } from '@arbitrum/sdk/dist/lib/abi/factories/IBridge__factory'
 import { IRollupCore__factory } from '@arbitrum/sdk/dist/lib/abi/factories/IRollupCore__factory'
-import { getProviderForChainId } from './utils'
+import { getChainIdFromProvider, getProviderForChainId } from './utils'
 import { TELEPORT_ALLOWLIST } from '../util/networks'
 import { addressIsSmartContract } from '../util/AddressUtils'
 
@@ -65,7 +65,9 @@ async function tryGetInboxFromRouter(
   address: string,
   provider: Provider
 ): Promise<string | undefined> {
-  if (!(await addressIsSmartContract(address, provider))) {
+  const chainId = await getChainIdFromProvider(provider)
+
+  if (!(await addressIsSmartContract(address, chainId))) {
     throw new Error(
       '[tryGetInboxFromRouter]: address passed is not a smart contract'
     )

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -1,5 +1,5 @@
 import { getAPIBaseUrl } from '.'
-import { getProviderForChainId } from '@/token-bridge-sdk/utils'
+import { getProviderForChainId } from '../token-bridge-sdk/utils'
 
 export type Address = `0x${string}`
 

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -1,17 +1,14 @@
-import { Provider } from '@ethersproject/providers'
-
 import { getAPIBaseUrl } from '.'
+import { getProviderForChainId } from '@/token-bridge-sdk/utils'
 
 export type Address = `0x${string}`
 
-export async function addressIsSmartContract(
-  address: string,
-  provider: Provider
-) {
+export async function addressIsSmartContract(address: string, chainId: number) {
+  const provider = getProviderForChainId(chainId)
   try {
     return (await provider.getCode(address)).length > 2
-  } catch (_) {
-    return false
+  } catch (error) {
+    throw Error('Cannot determine if address is a smart contract')
   }
 }
 

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -7,8 +7,8 @@ export async function addressIsSmartContract(address: string, chainId: number) {
   const provider = getProviderForChainId(chainId)
   try {
     return (await provider.getCode(address)).length > 2
-  } catch (error) {
-    throw Error('Cannot determine if address is a smart contract')
+  } catch (_) {
+    return false
   }
 }
 

--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -11,7 +11,7 @@ import {
 } from './TokenUtils'
 import { DepositGasEstimates } from '../hooks/arbTokenBridge.types'
 import { addressIsSmartContract } from './AddressUtils'
-import { getChainIdFromProvider } from '@/token-bridge-sdk/utils'
+import { getChainIdFromProvider } from '../token-bridge-sdk/utils'
 
 async function fetchTokenFallbackGasEstimates({
   inboxAddress,

--- a/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts
@@ -11,6 +11,7 @@ import {
 } from './TokenUtils'
 import { DepositGasEstimates } from '../hooks/arbTokenBridge.types'
 import { addressIsSmartContract } from './AddressUtils'
+import { getChainIdFromProvider } from '@/token-bridge-sdk/utils'
 
 async function fetchTokenFallbackGasEstimates({
   inboxAddress,
@@ -56,9 +57,11 @@ async function fetchTokenFallbackGasEstimates({
     l2Provider: childChainProvider
   })
 
+  const childChainId = await getChainIdFromProvider(childChainProvider)
+
   const isFirstTimeTokenBridging = !(await addressIsSmartContract(
     childChainTokenAddress,
-    childChainProvider
+    childChainId
   ))
   if (isFirstTimeTokenBridging) {
     return {


### PR DESCRIPTION
We should use the wallet's chain instead of the source chain for detecting if the wallet is a Smart Contract Wallet.