### PR TITLE
feat: add Stylus testnet warning banner

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -28,6 +28,28 @@ export type TransferPanelSummaryProps = {
   token: ERC20BridgeToken | null
 }
 
+function StylusNetworkWarning() {
+  const [{ sourceChain, destinationChain }] = useNetworks()
+  const { isStylusTestnetV1orV2: isSourceChainStylusTestnet } = isNetwork(
+    sourceChain.id
+  )
+  const { isStylusTestnetV1orV2: isDestinationChainStylusTestnet } = isNetwork(
+    destinationChain.id
+  )
+
+  if (!isSourceChainStylusTestnet && !isDestinationChainStylusTestnet) {
+    return null
+  }
+
+  return (
+    <NoteBox variant="warning">
+      Stylus is now live on Arbitrum Sepolia. The Stylus v1 and v2 testnets will
+      be deprecated shortly. Please withdraw all testnet assets and resume
+      testing on Arbitrum Sepolia.
+    </NoteBox>
+  )
+}
+
 function StyledLoader() {
   return (
     <span className="flex">
@@ -250,6 +272,7 @@ export function TransferPanelSummary({ token }: TransferPanelSummaryProps) {
           )}
         </span>
       </div>
+      <StylusNetworkWarning />
     </TransferPanelSummaryContainer>
   )
 }

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -369,6 +369,8 @@ export function isNetwork(chainId: ChainId) {
     isStylusTestnetV2 ||
     isTestnetOrbitChain
 
+  const isStylusTestnetV1orV2 = isStylusTestnet || isStylusTestnetV2
+
   const isSupported =
     isArbitrumOne ||
     isArbitrumNova ||
@@ -395,6 +397,7 @@ export function isNetwork(chainId: ChainId) {
     // Orbit chains
     isOrbitChain,
     isTestnet,
+    isStylusTestnetV1orV2,
     // General
     isSupported,
     // Core Chain is a chain category for the UI


### PR DESCRIPTION
Banner shows when user's source/destination chain is either Stylus testnet v1 or v2

<img width="722" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/0f80d6fd-1434-492d-9a23-b57b8bdd43ec">


Closes FS-606