### PR TITLE
ci: hardcode graph network enabled flag

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
   NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
   NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
-  THE_GRAPH_NETWORK_ENABLED: ${{ secrets.THE_GRAPH_NETWORK_ENABLED }}
+  THE_GRAPH_NETWORK_ENABLED: "true"
   THE_GRAPH_NETWORK_API_KEY: ${{ secrets.THE_GRAPH_NETWORK_API_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IS_HOTFIX: ${{ contains(github.event.pull_request.title, 'hotfix') }}
@@ -211,7 +211,7 @@ jobs:
           envkey_NEXT_PUBLIC_LOCAL_ARBITRUM_RPC_URL: http://sequencer:8547
           envkey_TEST_FILE: ${{ matrix.tests.file }}
           envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
-          envkey_THE_GRAPH_NETWORK_ENABLED: ${{ secrets.THE_GRAPH_NETWORK_ENABLED }}
+          envkey_THE_GRAPH_NETWORK_ENABLED: "true"
           envkey_THE_GRAPH_NETWORK_API_KEY: ${{ secrets.THE_GRAPH_NETWORK_API_KEY }}
           directory: ./packages/arb-token-bridge-ui/
           file_name: .e2e.env
@@ -222,7 +222,7 @@ jobs:
           envkey_NEXT_PUBLIC_IS_E2E_TEST: true
           envkey_NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
           envkey_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
-          envkey_THE_GRAPH_NETWORK_ENABLED: ${{ secrets.THE_GRAPH_NETWORK_ENABLED }}
+          envkey_THE_GRAPH_NETWORK_ENABLED: "true"
           envkey_THE_GRAPH_NETWORK_API_KEY: ${{ secrets.THE_GRAPH_NETWORK_API_KEY }}
           directory: ./packages/arb-token-bridge-ui/
           file_name: .env


### PR DESCRIPTION
GA is masking secrets so setting booleans from secrets messes up env vars.