### PR TITLE
feat: add GHO to withdraw-only list

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
@@ -6,9 +6,10 @@ import { Dialog } from '../common/Dialog'
 import { sanitizeTokenSymbol } from '../../util/TokenUtils'
 import { useNetworks } from '../../hooks/useNetworks'
 import { ExternalLink } from '../common/ExternalLink'
-import { getNetworkName } from '../../util/networks'
+import { ChainId, getNetworkName } from '../../util/networks'
 import { getL2ConfigForTeleport } from '../../token-bridge-sdk/teleport'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
+import { withdrawOnlyTokens } from '../../util/WithdrawOnlyUtils'
 
 type TransferDisabledDialogStore = {
   isOpen: boolean
@@ -67,6 +68,13 @@ export function TransferDisabledDialog() {
     ? getNetworkName(l2ChainIdForTeleport)
     : null
 
+  const isGHO =
+    networks.destinationChain.id === ChainId.ArbitrumOne &&
+    selectedToken?.address.toLowerCase() ===
+      withdrawOnlyTokens[ChainId.ArbitrumOne]
+        ?.find(_token => _token.symbol === 'GHO')
+        ?.l1Address.toLowerCase()
+
   return (
     <Dialog
       closeable
@@ -120,6 +128,18 @@ export function TransferDisabledDialog() {
               custom bridge solution that is incompatible with the canonical
               Arbitrum bridge.
             </p>
+            {isGHO && (
+              <p>
+                Please use the{' '}
+                <ExternalLink
+                  className="underline hover:opacity-70"
+                  href="https://app.transporter.io/?from=mainnet&tab=token&to=arbitrum&token=GHO"
+                >
+                  CCIP bridge for GHO
+                </ExternalLink>{' '}
+                instead.
+              </p>
+            )}
             <p>
               For more information please contact{' '}
               <span className="font-medium">{unsupportedToken}</span>

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -14,7 +14,7 @@ export type WithdrawOnlyToken = {
   l2Address: string
 }
 
-const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
+export const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
   [ChainId.ArbitrumOne]: [
     {
       symbol: 'MIM',
@@ -171,6 +171,12 @@ const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
       l2CustomAddr: '0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2',
       l1Address: '0x9D39A5DE30e57443BfF2A8307A4256c8797A3497',
       l2Address: '0x292CbA96fce24f6802dBdA021ED2B05481a3eEdF'
+    },
+    {
+      symbol: 'GHO',
+      l2CustomAddr: '',
+      l1Address: '0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f',
+      l2Address: '0xfeb8670b834d9157864126f5dbd24b25d06882ad'
     }
   ],
   [ChainId.ArbitrumNova]: []


### PR DESCRIPTION
When user tries to select GHO to deposit from Ethereum to Arbitrum One, the withdraw-only dialog pops up and suggests the CCIP bridge link. https://app.transporter.io/?from=mainnet&tab=token&to=arbitrum&token=GHO

<img width="1067" alt="image" src="https://github.com/OffchainLabs/arbitrum-token-bridge/assets/13184582/f9478af9-4c22-485c-ac50-ed2d9ff2db46">

Closes FS-648