### PR TITLE
feat: show WETH details in the transfer panel

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/NativeCurrencyPrice.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/NativeCurrencyPrice.tsx
@@ -1,4 +1,7 @@
-import { NativeCurrency } from '../../hooks/useNativeCurrency'
+import {
+  NativeCurrency,
+  useNativeCurrency
+} from '../../hooks/useNativeCurrency'
 import { useNetworks } from '../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
 import { useAppState } from '../../state'
@@ -13,6 +16,25 @@ export function useIsBridgingEth(childChainNativeCurrency: NativeCurrency) {
   const isBridgingEth =
     selectedToken === null && !childChainNativeCurrency.isCustom
   return isBridgingEth
+}
+
+export function useIsBridgingEthToCustomGasTokenChain() {
+  const {
+    app: { selectedToken, isSelectedTokenEther }
+  } = useAppState()
+  const [networks] = useNetworks()
+  const { childChain, childChainProvider, isDepositMode } =
+    useNetworksRelationship(networks)
+  const nativeCurrency = useNativeCurrency({ provider: childChainProvider })
+  const { isOrbitChain } = isNetwork(childChain.id)
+
+  return (
+    isDepositMode &&
+    isOrbitChain &&
+    selectedToken === null &&
+    nativeCurrency.isCustom &&
+    isSelectedTokenEther
+  )
 }
 
 export function NativeCurrencyPrice({


### PR DESCRIPTION
ETH transfers to custom gas token chains PR no. 2
Previous PR here: https://github.com/OffchainLabs/arbitrum-token-bridge/pull/1764.

This is a prerequisite for https://linear.app/offchain-labs/issue/FS-139/enable-wrapping-eth-and-depositing-into-a-custom-gas-token-network.

<img width="674" alt="image" src="https://github.com/user-attachments/assets/d207f075-42b4-48f3-86fc-73ce0e0ac4db">

### Testing
You should be able to see WETH balances and the note box as indicated on the screenshot above.
- WETH balance in the network box.
- WETH symbol with explorer URL in the summary box.
- Note box explaining users will receive WETH instead of ETH.