### PR TITLE
fix: fetch balances when wallet address is valid

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useBalance.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useBalance.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
-import { BigNumber } from 'ethers'
+import { BigNumber, utils } from 'ethers'
+import { useAccount } from 'wagmi'
 import { Provider } from '@ethersproject/abstract-provider'
 import useSWR, {
   useSWRConfig,
@@ -43,10 +44,16 @@ const merge: Middleware = (useSWRNext: SWRHook) => {
 
 const useBalance = ({ provider, walletAddress }: UseBalanceProps) => {
   const chainId = useChainId({ provider })
-  const walletAddressLowercased = useMemo(
-    () => walletAddress?.toLowerCase(),
-    [walletAddress]
-  )
+  const { address: connectedWalletAddress } = useAccount()
+
+  const walletAddressLowercased = useMemo(() => {
+    // use balances for the passed wallet address only if it's valid
+    if (utils.isAddress(String(walletAddress))) {
+      return walletAddress?.toLowerCase()
+    }
+    // otherwise use the connected wallet address
+    return connectedWalletAddress?.toLowerCase()
+  }, [walletAddress, connectedWalletAddress])
 
   const queryKey = useCallback(
     (type: 'eth' | 'erc20') => {

--- a/packages/arb-token-bridge-ui/src/hooks/useBalance.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useBalance.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react'
 import { BigNumber, utils } from 'ethers'
-import { useAccount } from 'wagmi'
 import useSWR, {
   useSWRConfig,
   unstable_serialize,
@@ -41,16 +40,13 @@ const merge: Middleware = (useSWRNext: SWRHook) => {
 }
 
 const useBalance = ({ chainId, walletAddress }: UseBalanceProps) => {
-  const { address: connectedWalletAddress } = useAccount()
-
   const walletAddressLowercased = useMemo(() => {
-    // use balances for the passed wallet address only if it's valid
-    if (utils.isAddress(String(walletAddress))) {
-      return walletAddress?.toLowerCase()
+    // use balances for the wallet address only if it's valid
+    if (!walletAddress || !utils.isAddress(walletAddress)) {
+      return undefined
     }
-    // otherwise use the connected wallet address
-    return connectedWalletAddress?.toLowerCase()
-  }, [walletAddress, connectedWalletAddress])
+    return walletAddress.toLowerCase()
+  }, [walletAddress])
 
   const queryKey = useCallback(
     (type: 'eth' | 'erc20') => {


### PR DESCRIPTION
Fixes an issue with `useBalances` where passing any destination address would retrigger fetching, even if the address is not valid. This also caused flakiness in ERC20 deposit and withdrawal e2e.

### Testing
Before:
On prod you should see `useBalance` retrigger in the network tab with each character typed in the custom destination address.

After:
`useBalance` updates only when the custom destination address is complete and valid.