### PR TITLE
fix: withdrawal status updates in tx history

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/helpers.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/helpers.ts
@@ -33,6 +33,7 @@ import { getAttestationHashAndMessageFromReceipt } from '../../util/cctp/getAtte
 import { isTeleport } from '@/token-bridge-sdk/teleport'
 import { getOutgoingMessageState } from '../../util/withdrawals/helpers'
 import { getUniqueIdOrHashFromEvent } from '../../hooks/useArbTokenBridge'
+import { getProviderForChainId } from '../../token-bridge-sdk/utils'
 
 const PARENT_CHAIN_TX_DETAILS_OF_CLAIM_TX =
   'arbitrum:bridge:claim:parent:tx:details'
@@ -404,9 +405,9 @@ export async function getUpdatedWithdrawal(
     return tx
   }
 
-  const parentChainProvider = getProvider(tx.parentChainId)
-  const childChainProvider = getProvider(tx.childChainId)
-  const txReceipt = await childChainProvider.getTransactionReceipt(tx.txId)
+  const parentChainProvider = getProviderForChainId(tx.parentChainId)
+  const childChainProvider = getProviderForChainId(tx.childChainId)
+  const txReceipt = await getTxReceipt(tx)
   const childTxReceipt = new ChildTransactionReceipt(txReceipt)
   const [withdrawalEvent] = await childTxReceipt.getChildToParentEvents()
 

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/helpers.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/helpers.ts
@@ -1,13 +1,12 @@
 import dayjs from 'dayjs'
-import {
-  StaticJsonRpcProvider,
-  TransactionReceipt
-} from '@ethersproject/providers'
+import { Provider, StaticJsonRpcProvider } from '@ethersproject/providers'
 import {
   EthDepositMessage,
   EthDepositMessageStatus,
   ParentToChildMessageStatus,
-  ParentToChildMessageReader
+  ParentToChildMessageReader,
+  ChildTransactionReceipt,
+  ChildToParentTransactionEvent
 } from '@arbitrum/sdk'
 
 import {
@@ -32,6 +31,8 @@ import { getDepositStatus } from '../../state/app/utils'
 import { getBlockBeforeConfirmation } from '../../state/cctpState'
 import { getAttestationHashAndMessageFromReceipt } from '../../util/cctp/getAttestationHashAndMessageFromReceipt'
 import { isTeleport } from '@/token-bridge-sdk/teleport'
+import { getOutgoingMessageState } from '../../util/withdrawals/helpers'
+import { getUniqueIdOrHashFromEvent } from '../../hooks/useArbTokenBridge'
 
 const PARENT_CHAIN_TX_DETAILS_OF_CLAIM_TX =
   'arbitrum:bridge:claim:parent:tx:details'
@@ -144,14 +145,31 @@ export function getTxReceipt(tx: MergedTransaction) {
   return provider.getTransactionReceipt(tx.txId)
 }
 
-function getWithdrawalStatusFromReceipt(
-  receipt: TransactionReceipt
-): WithdrawalStatus | undefined {
-  switch (receipt.status) {
+async function getWithdrawalStatusFromEvents({
+  withdrawalEvent,
+  childChainId,
+  parentChainProvider,
+  childChainProvider
+}: {
+  withdrawalEvent: ChildToParentTransactionEvent
+  parentChainProvider: Provider
+  childChainProvider: Provider
+  childChainId: ChainId
+}): Promise<WithdrawalStatus | undefined> {
+  const outgoingMessageState = await getOutgoingMessageState(
+    withdrawalEvent,
+    parentChainProvider,
+    childChainProvider,
+    childChainId
+  )
+
+  switch (outgoingMessageState) {
     case 0:
-      return WithdrawalStatus.FAILURE
-    case 1:
       return WithdrawalStatus.UNCONFIRMED
+    case 1:
+      return WithdrawalStatus.CONFIRMED
+    case 2:
+      return WithdrawalStatus.EXECUTED
     default:
       return undefined
   }
@@ -386,14 +404,31 @@ export async function getUpdatedWithdrawal(
     return tx
   }
 
-  const receipt = await getTxReceipt(tx)
+  const parentChainProvider = getProvider(tx.parentChainId)
+  const childChainProvider = getProvider(tx.childChainId)
+  const txReceipt = await childChainProvider.getTransactionReceipt(tx.txId)
+  const childTxReceipt = new ChildTransactionReceipt(txReceipt)
+  const [withdrawalEvent] = await childTxReceipt.getChildToParentEvents()
 
-  if (receipt) {
-    const newStatus = getWithdrawalStatusFromReceipt(receipt)
+  if (childTxReceipt) {
+    const newStatus = withdrawalEvent
+      ? await getWithdrawalStatusFromEvents({
+          withdrawalEvent,
+          childChainId: tx.childChainId,
+          parentChainProvider,
+          childChainProvider
+        })
+      : undefined
+
+    // unique id for withdrawal event is required for claiming, if the new status changes to confirmed
+    const uniqueId = withdrawalEvent
+      ? getUniqueIdOrHashFromEvent(withdrawalEvent)
+      : null
 
     if (typeof newStatus !== 'undefined') {
       return {
         ...tx,
+        uniqueId,
         status: newStatus
       }
     }


### PR DESCRIPTION
Fixed the logic for fetching and updating withdrawal status in tx history - otherwise, it was not activating the `Claim` button even if the withdrawal status would change into `Confirmed`.

This also explains why the Claim button wouldn't get activated while tx history was kept open - but would activate when the page was refreshed.