### PR TITLE
fix: fetch correct teleport status on initial load

### DIFF
--- a/packages/arb-token-bridge-ui/src/state/app/utils.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/utils.ts
@@ -62,24 +62,18 @@ export const getDepositStatus = (
     return DepositStatus.L1_PENDING
   }
 
-  // for teleport txn
-  if (
-    isTeleport({
-      sourceChainId: tx.parentChainId, // we make sourceChain=parentChain assumption coz it's a deposit txn
-      destinationChainId: tx.childChainId
-    })
-  ) {
-    const { l2ToL3MsgData, l1ToL2MsgData } = tx as TeleporterMergedTransaction
+  if (isTeleporterTransaction(tx)) {
+    const { l2ToL3MsgData, parentToChildMsgData } = tx
 
     // if any of the retryable info is missing, first fetch might be pending
-    if (!l1ToL2MsgData || !l2ToL3MsgData) return DepositStatus.L2_PENDING
+    if (!parentToChildMsgData || !l2ToL3MsgData) return DepositStatus.L2_PENDING
 
     // if we find `l2ForwarderRetryableTxID` then this tx will need to be redeemed
     if (l2ToL3MsgData.l2ForwarderRetryableTxID) return DepositStatus.L2_FAILURE
 
     // if we find first retryable leg failing, then no need to check for the second leg
     const firstLegDepositStatus = getDepositStatusFromL1ToL2MessageStatus(
-      l1ToL2MsgData.status
+      parentToChildMsgData.status
     )
     if (firstLegDepositStatus !== DepositStatus.L2_SUCCESS) {
       return firstLegDepositStatus
@@ -91,11 +85,13 @@ export const getDepositStatus = (
     if (typeof secondLegDepositStatus !== 'undefined') {
       return secondLegDepositStatus
     }
-    switch (l1ToL2MsgData.status) {
+    switch (parentToChildMsgData.status) {
       case ParentToChildMessageStatus.REDEEMED:
         return DepositStatus.L2_PENDING // tx is still pending if `l1ToL2MsgData` is redeemed (but l2ToL3MsgData is not)
       default:
-        return getDepositStatusFromL1ToL2MessageStatus(l1ToL2MsgData.status)
+        return getDepositStatusFromL1ToL2MessageStatus(
+          parentToChildMsgData.status
+        )
     }
   }
 


### PR DESCRIPTION
On load teleport txs would show in pending tab even if completed. After a few moments updater would update them correctly.

This fixes the initial status