### PR TITLE
fix: allow USDC selection if token bridge not loaded

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -555,10 +555,6 @@ export function TokenSearch({
       return
     }
 
-    if (typeof bridgeTokens === 'undefined') {
-      return
-    }
-
     try {
       // Native USDC on L2 won't have a corresponding L1 address
       const isNativeUSDC =
@@ -597,6 +593,10 @@ export function TokenSearch({
           decimals: 6,
           listIds: new Set()
         })
+        return
+      }
+
+      if (typeof bridgeTokens === 'undefined') {
         return
       }
 


### PR DESCRIPTION
Caused USDC not being selectable on Orbit chains if token bridge was undefined