### PR TITLE
test: Simplify amount in e2e tests

### DIFF
--- a/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
@@ -59,7 +59,7 @@ describe('Deposit Token', () => {
       })
 
       it(`should deposit ${tokenType} successfully to the same address`, () => {
-        const ERC20AmountToSend = Number((Math.random() * 0.001).toFixed(5)) // randomize the amount to be sure that previous transactions are not checked in e2e
+        const ERC20AmountToSend = Number((Math.random() * 10).toFixed(5)) // randomize the amount to be sure that previous transactions are not checked in e2e
 
         cy.login({ networkType: 'parentChain' })
         context('should add a new token', () => {

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/depositETH.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/depositETH.cy.ts
@@ -9,7 +9,7 @@ import {
 } from '../../support/common'
 
 describe('Deposit ETH', () => {
-  const ETHAmountToDeposit = 0.0001
+  const ETHAmountToDeposit = 1 + Number(Math.random().toFixed(5))
 
   const isOrbitTest = Cypress.env('ORBIT_TEST') == '1'
   const depositTime = isOrbitTest ? 'Less than a minute' : '9 minutes'

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
@@ -74,7 +74,7 @@ describe('Withdraw ERC20 Token', () => {
       })
 
       it(`should withdraw ${tokenType} to the same address successfully`, () => {
-        ERC20AmountToSend = Number((Math.random() * 0.001).toFixed(5)) // randomize the amount to be sure that previous transactions are not checked in e2e
+        ERC20AmountToSend = Number((Math.random() * 10).toFixed(5)) // randomize the amount to be sure that previous transactions are not checked in e2e
 
         cy.login({ networkType: 'childChain' })
         context(`should add ${tokenType} correctly`, () => {

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawETH.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawETH.cy.ts
@@ -11,7 +11,7 @@ import {
 import { formatAmount } from '../../../src/util/NumberUtils'
 
 describe('Withdraw ETH', () => {
-  let ETHToWithdraw = Number((Math.random() * 0.001).toFixed(5)) // randomize the amount to be sure that previous transactions are not checked in e2e
+  let ETHToWithdraw = 1 + Number(Math.random().toFixed(5)) // randomize the amount to be sure that previous transactions are not checked in e2e
   let l1EthBal: string
 
   beforeEach(() => {

--- a/packages/arb-token-bridge-ui/tests/support/commands.ts
+++ b/packages/arb-token-bridge-ui/tests/support/commands.ts
@@ -274,9 +274,7 @@ export const fillCustomDestinationAddress = () => {
 export function typeAmount(
   amount: string | number
 ): Cypress.Chainable<JQuery<HTMLElement>> {
-  return cy
-    .findByPlaceholderText(/enter amount/i)
-    .typeRecursively(String(amount))
+  return cy.findByPlaceholderText(/enter amount/i).type(String(amount))
 }
 
 export function findSourceChainButton(


### PR DESCRIPTION
Removes `.` in ERC20 E2E to reduce flakyness of `typeAmount`
Changes `0.0001` ETH amount to `1.XXX`

<!--
  Thanks for submitting a pull request!
  Please provide some context to facilitate reviews.

  The PR title should be in lowercase and must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).

  For a work-in-progress PR,
  - add (wip) to indicate the wip status, i.e. fix(wip): a bug fix
  - please mark the PR as "Draft" if it is not ready for review
-->

### Summary

<!--
  Explain the **motivation** behind this change.
  What existing problem does the pull request solve?
  Any implementation details to explain?
  What code paths or UI flow do the code changes hit?
-->

### Steps to test

<!--
  How did you verify that your PR solves the issue?
  If applicable, share the steps that a reviewer should follow.
  Example: The exact commands you ran and their output, screenshots / gifs / videos if the pull request changes the UI.
-->
