### PR TITLE
feat: enable Layer Leap for Proof of Play Boss

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/TokenTeleportEnabledUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenTeleportEnabledUtils.ts
@@ -13,7 +13,12 @@ const teleportEnabledTokens: {
     {
       symbol: 'WETH',
       l1Address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-      allowedL3ChainIds: [1380012617, 70700]
+      allowedL3ChainIds: [1380012617, 70700, 70701]
+    },
+    {
+      symbol: 'USDC',
+      l1Address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      allowedL3ChainIds: [70701]
     },
     {
       symbol: 'RARI',

--- a/packages/arb-token-bridge-ui/src/util/TokenTeleportEnabledUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenTeleportEnabledUtils.ts
@@ -16,11 +16,6 @@ const teleportEnabledTokens: {
       allowedL3ChainIds: [1380012617, 70700, 70701]
     },
     {
-      symbol: 'USDC',
-      l1Address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-      allowedL3ChainIds: [70701]
-    },
-    {
       symbol: 'RARI',
       l1Address: '0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF',
       allowedL3ChainIds: [1380012617] // only allowed for RARI

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -475,7 +475,7 @@ function isArbitrumChain(
 }
 
 export const TELEPORT_ALLOWLIST: { [id: number]: number[] } = {
-  [ChainId.Ethereum]: [1380012617, 70700], // Rari and PopApex
+  [ChainId.Ethereum]: [1380012617, 70700, 70701], // Rari, PopApex and PopBoss
   [ChainId.Sepolia]: [1918988905] // RARI Testnet
 }
 


### PR DESCRIPTION
Note: only ETH and WETH have been allowlisted, since USDC is not supported for LayerLeap transfers yet.

[Tested here](https://etherscan.io/tx/0xa5f3e2cbf6c3c55fff85ff740ecf7d373474c7fce66e4438808ca0c13054d70f)

Closes #1826