### PR TITLE
ci: update PR ci run condition

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,13 +2,11 @@ name: Build, Test
 
 on:
   pull_request:
-    branches: ["master"]
     types:
       - opened
-      - edited
       - synchronize
+      - reopened
   push:
-    branches: ["master"]
   workflow_dispatch:
   merge_group:
 


### PR DESCRIPTION
This allows PRs with base branch that is not `master` to run CI tests