### PR TITLE
fix: re-enable move funds button after transfer

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainInput.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainInput.tsx
@@ -224,6 +224,15 @@ export const TransferPanelMainInput = React.memo(
     const [localValue, setLocalValue] = useState(value)
 
     useEffect(() => {
+      /**
+       * If value is empty, set localValue to empty string
+       * this is useful when transfer was successful and the `amount` query param
+       * was reset to an empty string
+       */
+      if (value === '') {
+        setLocalValue('')
+      }
+
       if (!isMaxAmount || !maxAmount) {
         return
       }
@@ -233,7 +242,7 @@ export const TransferPanelMainInput = React.memo(
        * If user types anything before we receive the amount, isMaxAmount is set to false in the parent
        */
       setLocalValue(maxAmount)
-    }, [isMaxAmount, maxAmount])
+    }, [isMaxAmount, maxAmount, value])
 
     const handleMaxButtonClick: React.MouseEventHandler<HTMLButtonElement> =
       useCallback(


### PR DESCRIPTION
Currently on production, the "Move Funds" button is disabled after a successful transfer because the `amount` query param is cleared after transfer, but the input value is not cleared.

This PR synchronises the input value with the query param.