### PR TITLE
fix: show balance when amount2 input is visible

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/DestinationNetworkBox.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/DestinationNetworkBox.tsx
@@ -25,10 +25,10 @@ import {
 } from '../../common/NetworkSelectionContainer'
 import { useNativeCurrencyBalances } from './useNativeCurrencyBalances'
 import { useIsBatchTransferSupported } from '../../../hooks/TransferPanel/useIsBatchTransferSupported'
-import { useArbQueryParams } from '../../../hooks/useArbQueryParams'
 import { ether } from '../../../constants'
 import { formatAmount } from '../../../util/NumberUtils'
 import { Loader } from '../../common/atoms/Loader'
+import { useIsAmount2InputVisible } from './SourceNetworkBox'
 
 function NativeCurrencyDestinationBalance({ prefix }: { prefix?: string }) {
   const nativeCurrencyBalances = useNativeCurrencyBalances()
@@ -156,12 +156,12 @@ export function DestinationNetworkBox({
 }) {
   const [networks] = useNetworks()
   const { destinationAddress } = useDestinationAddressStore()
-  const [{ amount2 }] = useArbQueryParams()
   const isBatchTransferSupported = useIsBatchTransferSupported()
   const [
     destinationNetworkSelectionDialogProps,
     openDestinationNetworkSelectionDialog
   ] = useDialog()
+  const { isAmount2InputVisible } = useIsAmount2InputVisible()
 
   return (
     <>
@@ -178,7 +178,7 @@ export function DestinationNetworkBox({
             <DestinationNetworkBalance
               showUsdcSpecificInfo={showUsdcSpecificInfo}
             />
-            {isBatchTransferSupported && Number(amount2) > 0 && (
+            {isBatchTransferSupported && isAmount2InputVisible && (
               <NativeCurrencyDestinationBalance />
             )}
           </BalancesContainer>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/DestinationNetworkBox.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/DestinationNetworkBox.tsx
@@ -28,7 +28,7 @@ import { useIsBatchTransferSupported } from '../../../hooks/TransferPanel/useIsB
 import { ether } from '../../../constants'
 import { formatAmount } from '../../../util/NumberUtils'
 import { Loader } from '../../common/atoms/Loader'
-import { useIsAmount2InputVisible } from './SourceNetworkBox'
+import { useAmount2InputVisibility } from './SourceNetworkBox'
 
 function NativeCurrencyDestinationBalance({ prefix }: { prefix?: string }) {
   const nativeCurrencyBalances = useNativeCurrencyBalances()
@@ -161,7 +161,7 @@ export function DestinationNetworkBox({
     destinationNetworkSelectionDialogProps,
     openDestinationNetworkSelectionDialog
   ] = useDialog()
-  const { isAmount2InputVisible } = useIsAmount2InputVisible()
+  const { isAmount2InputVisible } = useAmount2InputVisibility()
 
   return (
     <>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/SourceNetworkBox.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/SourceNetworkBox.tsx
@@ -1,12 +1,7 @@
-import {
-  ChangeEventHandler,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react'
+import { ChangeEventHandler, useCallback, useEffect, useMemo } from 'react'
 import { utils } from 'ethers'
 import { PlusCircleIcon } from '@heroicons/react/24/outline'
+import { create } from 'zustand'
 
 import { getNetworkName } from '../../../util/networks'
 import {
@@ -57,12 +52,24 @@ function Amount2ToggleButton({
   )
 }
 
+export const useIsAmount2InputVisible = create<{
+  isAmount2InputVisible: boolean
+  showAmount2Input: () => void
+}>(set => ({
+  isAmount2InputVisible: false,
+  showAmount2Input: () => {
+    set(() => ({
+      isAmount2InputVisible: true
+    }))
+  }
+}))
+
 export function SourceNetworkBox({
   showUsdcSpecificInfo
 }: {
   showUsdcSpecificInfo: boolean
 }) {
-  const [isAmount2InputVisible, setIsAmount2InputVisible] = useState(false)
+  const { isAmount2InputVisible, showAmount2Input } = useIsAmount2InputVisible()
 
   const [networks] = useNetworks()
   const { childChain, childChainProvider, isDepositMode } =
@@ -99,7 +106,7 @@ export function SourceNetworkBox({
 
   useEffect(() => {
     if (isBatchTransferSupported && Number(amount2) > 0) {
-      setIsAmount2InputVisible(true)
+      showAmount2Input()
     }
   }, [isBatchTransferSupported, amount2])
 
@@ -158,9 +165,7 @@ export function SourceNetworkBox({
 
           {isBatchTransferSupported && !isAmount2InputVisible && (
             <div className="flex justify-end">
-              <Amount2ToggleButton
-                onClick={() => setIsAmount2InputVisible(true)}
-              />
+              <Amount2ToggleButton onClick={showAmount2Input} />
             </div>
           )}
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/SourceNetworkBox.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/SourceNetworkBox.tsx
@@ -52,7 +52,7 @@ function Amount2ToggleButton({
   )
 }
 
-export const useIsAmount2InputVisible = create<{
+export const useAmount2InputVisibility = create<{
   isAmount2InputVisible: boolean
   showAmount2Input: () => void
 }>(set => ({
@@ -69,7 +69,8 @@ export function SourceNetworkBox({
 }: {
   showUsdcSpecificInfo: boolean
 }) {
-  const { isAmount2InputVisible, showAmount2Input } = useIsAmount2InputVisible()
+  const { isAmount2InputVisible, showAmount2Input } =
+    useAmount2InputVisibility()
 
   const [networks] = useNetworks()
   const { childChain, childChainProvider, isDepositMode } =


### PR DESCRIPTION
Before we'd show native currency balance on the destination chain only if `amount2` is greater than 0. It's because we didn't have access to the state so we use zustand now.

Before - ETH balance not showing because `amount2` is not set:
<img width="712" alt="Screenshot 2024-09-12 at 15 38 16" src="https://github.com/user-attachments/assets/65366a8d-2c7e-49be-824a-9d9d11cdc6bf">

After - ETH balance showing because the `amount2` input is shown, regardless of its value:
<img width="712" alt="Screenshot 2024-09-12 at 15 39 28" src="https://github.com/user-attachments/assets/8d090f32-3e8b-4b2b-a5d3-00ba79cf736c">