### PR TITLE
feat: autodetect LayerZero tokens

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
@@ -17,7 +17,6 @@ import { ERC20BridgeToken } from '../../hooks/arbTokenBridge.types'
 import { warningToast } from '../common/atoms/Toast'
 import { useNetworks } from '../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
-import { isWithdrawOnlyToken } from '../../util/WithdrawOnlyUtils'
 import { isTransferDisabledToken } from '../../util/TokenTransferDisabledUtils'
 import { useTransferDisabledDialogStore } from './TransferDisabledDialog'
 import { TokenInfo } from './TokenInfo'
@@ -298,12 +297,6 @@ export function TokenImportDialog({
       storeNewToken(l1Address).catch(() => {
         setStatus(ImportStatus.ERROR)
       })
-    }
-
-    // do not allow import of withdraw-only tokens at deposit mode
-    if (isDepositMode && isWithdrawOnlyToken(l1Address, childChain.id)) {
-      openTransferDisabledDialog()
-      return
     }
 
     if (isTransferDisabledToken(l1Address, childChain.id)) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -38,7 +38,6 @@ import { TokenRow } from './TokenRow'
 import { useNetworks } from '../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
 import { useTransferDisabledDialogStore } from './TransferDisabledDialog'
-import { isWithdrawOnlyToken } from '../../util/WithdrawOnlyUtils'
 import { isTransferDisabledToken } from '../../util/TokenTransferDisabledUtils'
 import { useTokenFromSearchParams } from './TransferPanelUtils'
 import { Switch } from '../common/atoms/Switch'
@@ -371,6 +370,8 @@ function TokensPanel({
     isArbitrumOne,
     isArbitrumSepolia,
     isOrbitChain,
+    isParentChainArbitrumOne,
+    isParentChainArbitrumSepolia,
     getBalance,
     nativeCurrency
   ])
@@ -535,7 +536,6 @@ export function TokenSearch({
     childChainProvider,
     parentChain,
     parentChainProvider,
-    isDepositMode,
     isTeleportMode
   } = useNetworksRelationship(networks)
   const { updateUSDCBalances } = useUpdateUSDCBalances({ walletAddress })
@@ -629,12 +629,6 @@ export function TokenSearch({
           ...erc20DataToErc20BridgeToken(data),
           l2Address: _token.l2Address
         })
-      }
-
-      // do not allow import of withdraw-only tokens at deposit mode
-      if (isDepositMode && isWithdrawOnlyToken(_token.address, childChain.id)) {
-        openTransferDisabledDialog()
-        return
       }
 
       if (isTransferDisabledToken(_token.address, childChain.id)) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainInput.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainInput.tsx
@@ -180,17 +180,16 @@ function ErrorMessage({
     case TransferReadinessRichErrorMessage.TOKEN_WITHDRAW_ONLY:
     case TransferReadinessRichErrorMessage.TOKEN_TRANSFER_DISABLED:
       return (
-        <>
-          <span className="text-sm text-brick">
-            This token can&apos;t be bridged over.
-          </span>{' '}
+        <div className="text-sm text-brick">
+          <span>This token can&apos;t be bridged over.</span>{' '}
           <button
             className="arb-hover underline"
             onClick={openTransferDisabledDialog}
           >
-            Learn more.
+            Learn more
           </button>
-        </>
+          <span>.</span>
+        </div>
       )
   }
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useSelectedTokenIsWithdrawOnly.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useSelectedTokenIsWithdrawOnly.ts
@@ -11,10 +11,14 @@ export function useSelectedTokenIsWithdrawOnly() {
     app: { selectedToken }
   } = useAppState()
   const [networks] = useNetworks()
-  const { parentChain, childChain } = useNetworksRelationship(networks)
+  const { isDepositMode, parentChain, childChain } =
+    useNetworksRelationship(networks)
 
   const queryKey = useMemo(() => {
     if (!selectedToken) {
+      return null
+    }
+    if (!isDepositMode) {
       return null
     }
     return [
@@ -22,7 +26,7 @@ export function useSelectedTokenIsWithdrawOnly() {
       parentChain.id,
       childChain.id
     ] as const
-  }, [selectedToken, parentChain.id, childChain.id])
+  }, [selectedToken, isDepositMode, parentChain.id, childChain.id])
 
   const { data: isSelectedTokenWithdrawOnly, isLoading } = useSWRImmutable(
     queryKey,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useSelectedTokenIsWithdrawOnly.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useSelectedTokenIsWithdrawOnly.ts
@@ -1,0 +1,41 @@
+import useSWRImmutable from 'swr/immutable'
+import { useMemo } from 'react'
+
+import { useAppState } from '../../../state'
+import { useNetworks } from '../../../hooks/useNetworks'
+import { useNetworksRelationship } from '../../../hooks/useNetworksRelationship'
+import { isWithdrawOnlyToken } from '../../../util/WithdrawOnlyUtils'
+
+export function useSelectedTokenIsWithdrawOnly() {
+  const {
+    app: { selectedToken }
+  } = useAppState()
+  const [networks] = useNetworks()
+  const { parentChain, childChain } = useNetworksRelationship(networks)
+
+  const queryKey = useMemo(() => {
+    if (!selectedToken) {
+      return null
+    }
+    return [
+      selectedToken.address.toLowerCase(),
+      parentChain.id,
+      childChain.id
+    ] as const
+  }, [selectedToken, parentChain.id, childChain.id])
+
+  const { data: isSelectedTokenWithdrawOnly, isLoading } = useSWRImmutable(
+    queryKey,
+    ([parentChainErc20Address, parentChainId, childChainId]) =>
+      isWithdrawOnlyToken({
+        parentChainErc20Address,
+        parentChainId,
+        childChainId
+      })
+  )
+
+  return {
+    isSelectedTokenWithdrawOnly,
+    isSelectedTokenWithdrawOnlyLoading: isLoading
+  }
+}

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -249,11 +249,17 @@ export async function isWithdrawOnlyToken({
     return true
   }
 
+  const inWithdrawOnlyList = (withdrawOnlyTokens[childChainId] ?? [])
+    .map(token => token.l1Address.toLowerCase())
+    .includes(parentChainErc20Address.toLowerCase())
+
+  if (inWithdrawOnlyList) {
+    return true
+  }
+
   if (await isLayerZeroToken(parentChainErc20Address, parentChainId)) {
     return true
   }
 
-  return (withdrawOnlyTokens[childChainId] ?? [])
-    .map(token => token.l1Address.toLowerCase())
-    .includes(parentChainErc20Address.toLowerCase())
+  return false
 }

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -134,12 +134,6 @@ export const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
       l2Address: '0xa4431f62db9955bfd056c30e5ae703bf0d0eaec8'
     },
     {
-      symbol: 'GSWIFT',
-      l2CustomAddr: '0x580e933d90091b9ce380740e3a4a39c67eb85b4c',
-      l1Address: '0x580e933d90091b9ce380740e3a4a39c67eb85b4c',
-      l2Address: '0x88e5369f73312eba739dcdf83bdb8bad3d08f4c8'
-    },
-    {
       symbol: 'eETH',
       l2CustomAddr: '',
       l1Address: '0x35fA164735182de50811E8e2E824cFb9B6118ac2',
@@ -198,6 +192,19 @@ export const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
       l2CustomAddr: '0x8B0E6f19Ee57089F7649A455D89D7bC6314D04e8',
       l1Address: '0x0B7f0e51Cd1739D6C96982D55aD8fA634dd43A9C',
       l2Address: '0x6Ab317237cc72B2cdb54EcfcC180b61E00F7df76'
+    },
+    // LayerZero tokens
+    {
+      symbol: 'GSWIFT',
+      l2CustomAddr: '0x580e933d90091b9ce380740e3a4a39c67eb85b4c',
+      l1Address: '0x580e933d90091b9ce380740e3a4a39c67eb85b4c',
+      l2Address: '0x88e5369f73312eba739dcdf83bdb8bad3d08f4c8'
+    },
+    {
+      symbol: 'ZRO',
+      l2CustomAddr: '0x6985884c4392d348587b19cb9eaaf157f13271cd',
+      l1Address: '0x6985884c4392d348587b19cb9eaaf157f13271cd',
+      l2Address: '0xd99f14023f6bde3142d339b6c069b2b711da7e37'
     }
   ],
   [ChainId.ArbitrumNova]: []


### PR DESCRIPTION
Closes FS-850

This PR utilises the OFT method that LayerZero tokens inherit to identify if they are a LayerZero token.

By default all tokens utilising the LayerZero implementation are withdraw-only on our bridge.

Example: 
ZRO https://etherscan.io/token/0x6985884c4392d348587b19cb9eaaf157f13271cd

The `oftVersion()` is only availalbe on LayerZero v2 contract so legacy tokens will not be detected, as they implemented https://github.com/LayerZero-Labs/endpoint-v1-solidity-examples/blob/main/contracts/token/oft/v1/OFT.sol
e.g. GSWIFT https://etherscan.io/address/0x580e933d90091b9ce380740e3a4a39c67eb85b4c