### PR TITLE
fix: use correct teleport function for checks

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/deposits/helpers.ts
+++ b/packages/arb-token-bridge-ui/src/util/deposits/helpers.ts
@@ -17,13 +17,13 @@ import {
   L2ToL3MessageData,
   Transaction,
   TxnStatus,
-  TeleporterTransaction,
-  isTeleportTx
+  TeleporterTransaction
 } from '../../hooks/useTransactions'
 import { fetchErc20Data } from '../TokenUtils'
 import {
   getL2ConfigForTeleport,
-  fetchTeleportStatusFromTxId
+  fetchTeleportStatusFromTxId,
+  isValidTeleportChainPair
 } from '../../token-bridge-sdk/teleport'
 import { getProviderForChainId } from '../../token-bridge-sdk/utils'
 import { normalizeTimestamp } from '../../state/app/utils'
@@ -71,7 +71,14 @@ export const updateAdditionalDepositData = async ({
       isClassic
     })
 
-  if (isTeleportTx(depositTx)) {
+  if (
+    // txns fetched through subgraph will not have `l2ToL3MsgData`. So `isTeleportTx` will not pass here.
+    // since this is a deposit tx flow, the `parent` and `child` chain will always be `source` and `destination`
+    isValidTeleportChainPair({
+      sourceChainId: depositTx.parentChainId,
+      destinationChainId: depositTx.childChainId
+    })
+  ) {
     const { status, timestampResolved, l1ToL2MsgData, l2ToL3MsgData } =
       await fetchTeleporterDepositStatusData({
         ...depositTx,


### PR DESCRIPTION
Found a regression of https://github.com/OffchainLabs/arbitrum-token-bridge/pull/1823/files#diff-fa7ef4809d0062d5ffe00e6ce9143cd959c42261b05e12fcccb5932650a03cc9L72 where we were letting the teleport txns fetched through subgraph which don't have `l2ToL3MsgData`, fail the teleporter check. 

In this case, the correct util function to be used was `isValidTeleportChainPair` instead of `isTeleportTx`