### PR TITLE
fix: update unite chain color

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
+++ b/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
@@ -900,7 +900,7 @@
         "childWethGateway": "0x0000000000000000000000000000000000000000"
       },
       "bridgeUiConfig": {
-        "color": "#b1fb00",
+        "color": "#7aad00",
         "network": {
           "name": "Unite Mainnet",
           "logo": "/images/unite-mainnet_Logo.png"

--- a/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
+++ b/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
@@ -1463,7 +1463,7 @@
         "childWethGateway": "0x0000000000000000000000000000000000000000"
       },
       "bridgeUiConfig": {
-        "color": "#b1fb00",
+        "color": "#7aad00",
         "network": {
           "name": "Unite Testnet",
           "logo": "/images/unite-testnet_Logo.png"


### PR DESCRIPTION
Updating for a11y.

Prev:
![image](https://github.com/user-attachments/assets/145be74c-e664-43ab-a74c-6ac8d3fbdb6f)

Now:
![image](https://github.com/user-attachments/assets/96e24cbc-8f50-46ec-a8eb-29ed81a2a2f6)
