### PR TITLE
feat: show relevant address tx history banner

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/useTransactionReminderInfo.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/useTransactionReminderInfo.ts
@@ -1,13 +1,13 @@
 import { useMemo } from 'react'
-import { useAccount } from 'wagmi'
 
 import { useTransactionHistory } from '../../hooks/useTransactionHistory'
 import { isTxClaimable, isTxPending } from './helpers'
 import { isDepositReadyToRedeem } from '../../state/app/utils'
+import { useTransactionHistoryAddressStore } from './TransactionHistorySearchBar'
 
 export function useTransactionReminderInfo() {
-  const { address } = useAccount()
-  const { transactions } = useTransactionHistory(address)
+  const { sanitizedAddress } = useTransactionHistoryAddressStore()
+  const { transactions } = useTransactionHistory(sanitizedAddress)
 
   const {
     numClaimableTransactions,


### PR DESCRIPTION
Currently we show the tx history banner for the connected address even when the user is searching another address on tx history
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/c6218720-be3a-4162-b815-3835425ff98d" />


This PR shows the relevant tx history banner for the searched address instead
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/8b2f5ad4-d615-4714-946b-c2f1b61e6e1e" />

Closes FS-1095