### PR TITLE
fix: show transfer button loader for USDC.e deposits

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -283,10 +283,10 @@ export function TransferPanel() {
       const [confirmed] = await waitForInput()
 
       if (confirmed) {
-        transfer()
+        return transfer()
       }
     } else {
-      transfer()
+      return transfer()
     }
   }
 


### PR DESCRIPTION
closes FS-998

### Issue
Try to deposit USDC (through Arbitrum bridge, not CCTP). The transfer button loading state will reset as soon as you confirm the USDC dialog.

This happened because [here](https://github.com/OffchainLabs/arbitrum-token-bridge/blob/master/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx#L422) we await `depositToken` but the transfer method wasn't returned, so it jumped to finally block and set transferring to false.