### PR TITLE
ci: don't run tests on master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,6 @@ on:
       - opened
       - edited
       - synchronize
-  push:
-    branches: ["master"]
   workflow_dispatch:
   merge_group:
 


### PR DESCRIPTION
@spsjvc mentioned that everything is checked when it's still a PR, so we shouldn't need to run tests again when it's merged into master

For the change, see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-workflow-only-when-a-push-to-specific-branches-occurs