### PR TITLE
fix: fix balance loader alignment

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/DestinationNetworkBox.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/DestinationNetworkBox.tsx
@@ -93,7 +93,7 @@ function BalanceRow({
         />
         <span>{symbol}</span>
       </div>
-      <div>
+      <div className="flex space-x-1">
         <span>Balance: </span>
         <span
           aria-label={`${symbol} balance amount on ${


### PR DESCRIPTION
Below the old version, loader misaligned 

<img width="577" alt="image" src="https://github.com/user-attachments/assets/eb599dbd-2035-4689-ac44-5f6754731d82" />
