### PR TITLE
chore: extend bold warning banner date

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/BoLDUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/BoLDUtils.ts
@@ -8,11 +8,11 @@ const boldUpgrades: {
 } = {
   [ChainId.ArbitrumOne]: {
     dateStart: new Date('2025-02-05T14:00:00Z'),
-    dateEnd: new Date('2025-02-12T14:00:00Z')
+    dateEnd: new Date('2025-02-19T14:00:00Z')
   },
   [ChainId.ArbitrumNova]: {
     dateStart: new Date('2025-02-05T14:00:00Z'),
-    dateEnd: new Date('2025-02-12T14:00:00Z')
+    dateEnd: new Date('2025-02-19T14:00:00Z')
   }
 }
 


### PR DESCRIPTION
We want to show the banner for the entire duration of withdrawal-wait time window, not just until BoLD launch.