### PR TITLE
refactor: move dialogs to a single component (part 1)

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -20,8 +20,6 @@ import {
 } from './TokenImportDialog'
 import { useArbQueryParams } from '../../hooks/useArbQueryParams'
 import { useDialog } from '../common/Dialog'
-import { TokenApprovalDialog } from './TokenApprovalDialog'
-import { WithdrawalConfirmationDialog } from './WithdrawalConfirmationDialog'
 import { CustomDestinationAddressConfirmationDialog } from './CustomDestinationAddressConfirmationDialog'
 import { TransferPanelSummary } from './TransferPanelSummary'
 import { useAppContextActions } from '../App/AppContext'
@@ -84,6 +82,7 @@ import { useMainContentTabs } from '../MainContent/MainContent'
 import { useIsOftV2Transfer } from './hooks/useIsOftV2Transfer'
 import { OftV2TransferStarter } from '../../token-bridge-sdk/OftV2TransferStarter'
 import { highlightOftTransactionHistoryDisclaimer } from '../TransactionHistory/OftTransactionHistoryDisclaimer'
+import { useNewDialog, DialogWrapper } from '../common/NewDialog'
 
 const signerUndefinedError = 'Signer is undefined'
 const transferNotAllowedError = 'Transfer not allowed'
@@ -167,12 +166,11 @@ export function TransferPanel() {
 
   const latestDestinationAddress = useLatest(destinationAddress)
 
+  const [dialogProps, openDialog] = useNewDialog()
+
   const [tokenImportDialogProps] = useDialog()
   const [tokenCheckDialogProps, openTokenCheckDialog] = useDialog()
-  const [tokenApprovalDialogProps, openTokenApprovalDialog] = useDialog()
   const [customFeeTokenApprovalDialogProps, openCustomFeeTokenApprovalDialog] =
-    useDialog()
-  const [withdrawalConfirmationDialogProps, openWithdrawalConfirmationDialog] =
     useDialog()
   const [
     usdcWithdrawalConfirmationDialogProps,
@@ -328,7 +326,7 @@ export function TransferPanel() {
 
   const tokenAllowanceApprovalCctp = async () => {
     setIsCctp(true)
-    const waitForInput = openTokenApprovalDialog()
+    const waitForInput = openDialog('approve_token')
     const [confirmed] = await waitForInput()
     return confirmed
   }
@@ -341,7 +339,7 @@ export function TransferPanel() {
 
   const tokenAllowanceApproval = async () => {
     setIsCctp(false)
-    const waitForInput = openTokenApprovalDialog()
+    const waitForInput = openDialog('approve_token')
     const [confirmed] = await waitForInput()
     return confirmed
   }
@@ -383,7 +381,7 @@ export function TransferPanel() {
   }
 
   const confirmWithdrawal = async () => {
-    const waitForInput = openWithdrawalConfirmationDialog()
+    const waitForInput = openDialog('withdrawal_confirmation')
     const [confirmed] = await waitForInput()
     return confirmed
   }
@@ -1148,12 +1146,7 @@ export function TransferPanel() {
 
   return (
     <>
-      <TokenApprovalDialog
-        {...tokenApprovalDialogProps}
-        token={selectedToken}
-        isCctp={isCctp}
-        isOft={isOftTransfer}
-      />
+      <DialogWrapper {...dialogProps} />
 
       {nativeCurrency.isCustom && (
         <CustomFeeTokenApprovalDialog
@@ -1161,16 +1154,6 @@ export function TransferPanel() {
           customFeeToken={nativeCurrency}
         />
       )}
-
-      <WithdrawalConfirmationDialog
-        {...withdrawalConfirmationDialogProps}
-        amount={amount}
-      />
-
-      <USDCWithdrawalConfirmationDialog
-        {...usdcWithdrawalConfirmationDialogProps}
-        amount={amount}
-      />
 
       <USDCDepositConfirmationDialog
         {...usdcDepositConfirmationDialogProps}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -381,7 +381,7 @@ export function TransferPanel() {
   }
 
   const confirmWithdrawal = async () => {
-    const waitForInput = openDialog('withdrawal_confirmation')
+    const waitForInput = openDialog('withdraw')
     const [confirmed] = await waitForInput()
     return confirmed
   }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -82,7 +82,7 @@ import { useMainContentTabs } from '../MainContent/MainContent'
 import { useIsOftV2Transfer } from './hooks/useIsOftV2Transfer'
 import { OftV2TransferStarter } from '../../token-bridge-sdk/OftV2TransferStarter'
 import { highlightOftTransactionHistoryDisclaimer } from '../TransactionHistory/OftTransactionHistoryDisclaimer'
-import { useNewDialog, DialogWrapper } from '../common/NewDialog'
+import { useDialog2, DialogWrapper } from '../common/Dialog2'
 
 const signerUndefinedError = 'Signer is undefined'
 const transferNotAllowedError = 'Transfer not allowed'
@@ -166,7 +166,7 @@ export function TransferPanel() {
 
   const latestDestinationAddress = useLatest(destinationAddress)
 
-  const [dialogProps, openDialog] = useNewDialog()
+  const [dialogProps, openDialog] = useDialog2()
 
   const [tokenImportDialogProps] = useDialog()
   const [tokenCheckDialogProps, openTokenCheckDialog] = useDialog()

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -1155,6 +1155,11 @@ export function TransferPanel() {
         />
       )}
 
+      <USDCWithdrawalConfirmationDialog
+        {...usdcWithdrawalConfirmationDialogProps}
+        amount={amount}
+      />
+
       <USDCDepositConfirmationDialog
         {...usdcDepositConfirmationDialogProps}
         amount={amount}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -195,8 +195,6 @@ export function TransferPanel() {
     updateEthChildBalance
   } = useBalances()
 
-  const [isCctp, setIsCctp] = useState(false)
-
   const { destinationAddressError } = useDestinationAddressError()
 
   const [showProjectsListing, setShowProjectsListing] = useState(false)
@@ -325,8 +323,7 @@ export function TransferPanel() {
   }
 
   const tokenAllowanceApprovalCctp = async () => {
-    setIsCctp(true)
-    const waitForInput = openDialog('approve_token')
+    const waitForInput = openDialog('approve_token', { isCctp: true })
     const [confirmed] = await waitForInput()
     return confirmed
   }
@@ -338,8 +335,7 @@ export function TransferPanel() {
   }
 
   const tokenAllowanceApproval = async () => {
-    setIsCctp(false)
-    const waitForInput = openDialog('approve_token')
+    const waitForInput = openDialog('approve_token', { isCctp: false })
     const [confirmed] = await waitForInput()
     return confirmed
   }
@@ -579,7 +575,6 @@ export function TransferPanel() {
       //
     } finally {
       setTransferring(false)
-      setIsCctp(false)
     }
   }
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -323,7 +323,7 @@ export function TransferPanel() {
   }
 
   const tokenAllowanceApprovalCctp = async () => {
-    const waitForInput = openDialog('approve_token', { isCctp: true })
+    const waitForInput = openDialog('approve_cctp_usdc')
     const [confirmed] = await waitForInput()
     return confirmed
   }
@@ -335,7 +335,7 @@ export function TransferPanel() {
   }
 
   const tokenAllowanceApproval = async () => {
-    const waitForInput = openDialog('approve_token', { isCctp: false })
+    const waitForInput = openDialog('approve_token')
     const [confirmed] = await waitForInput()
     return confirmed
   }

--- a/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
@@ -13,7 +13,7 @@ import { useArbQueryParams } from '../../hooks/useArbQueryParams'
 type WaitForInputFunction = () => Promise<[boolean, unknown]>
 
 /**
- * Opens the dialog and returns a function which can be called to retreive a {@link WaitForInputFunction}.
+ * Opens the dialog and returns a function which can be called to retrieve a {@link WaitForInputFunction}.
  */
 type OpenDialogFunction = (dialogType: DialogType) => WaitForInputFunction
 

--- a/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { TokenApprovalDialog } from '../TransferPanel/TokenApprovalDialog'
 import { useIsOftV2Transfer } from '../TransferPanel/hooks/useIsOftV2Transfer'
 import { useSelectedToken } from '../../hooks/useSelectedToken'
-import { useIsCctpTransfer } from '../TransferPanel/hooks/useIsCctpTransfer'
 import { WithdrawalConfirmationDialog } from '../TransferPanel/WithdrawalConfirmationDialog'
 import { useArbQueryParams } from '../../hooks/useArbQueryParams'
 /**
@@ -13,10 +12,25 @@ import { useArbQueryParams } from '../../hooks/useArbQueryParams'
  */
 type WaitForInputFunction = () => Promise<[boolean, unknown]>
 
+type HasParams<T extends DialogType> = T extends keyof DialogTypeParams
+  ? true
+  : false
+
+type ParamsType<T extends DialogType> = HasParams<T> extends true
+  ? T extends keyof DialogTypeParams
+    ? DialogTypeParams[T]
+    : never
+  : Record<string, unknown> | undefined
+
 /**
  * Opens the dialog and returns a function which can be called to retreive a {@link WaitForInputFunction}.
  */
-type OpenDialogFunction = (dialogType: DialogType) => WaitForInputFunction
+type OpenDialogFunction = <T extends DialogType>(
+  dialogType: T,
+  ...args: T extends keyof DialogTypeParams
+    ? [params: DialogTypeParams[T]]
+    : [params?: undefined]
+) => WaitForInputFunction
 
 /**
  * Returns an array containing {@link DialogProps} and {@link OpenDialogFunction}.
@@ -25,11 +39,18 @@ type UseDialogResult = [DialogProps, OpenDialogFunction]
 
 type DialogType = 'approve_token' | 'withdraw'
 
+// Add additional properties here
+type DialogTypeParams = {
+  approve_token: { isCctp: boolean }
+}
+
 export function useDialog2(): UseDialogResult {
   const resolveRef =
     useRef<
       (value: [boolean, unknown] | PromiseLike<[boolean, unknown]>) => void
     >()
+
+  const [params, setParams] = useState<ParamsType<DialogType>>()
 
   // Whether the dialog is currently open
   const [openedDialogType, setOpenedDialogType] = useState<DialogType | null>(
@@ -37,8 +58,14 @@ export function useDialog2(): UseDialogResult {
   )
 
   const openDialog: OpenDialogFunction = useCallback(
-    (dialogType: DialogType) => {
+    <T extends DialogType>(
+      dialogType: T,
+      ...args: T extends keyof DialogTypeParams
+        ? [params: DialogTypeParams[T]]
+        : [params?: Record<string, unknown>]
+    ) => {
       setOpenedDialogType(dialogType)
+      setParams(args[0])
 
       return () => {
         return new Promise(resolve => {
@@ -60,18 +87,18 @@ export function useDialog2(): UseDialogResult {
     []
   )
 
-  return [{ openedDialogType, onClose: closeDialog }, openDialog]
+  return [{ openedDialogType, onClose: closeDialog, params }, openDialog]
 }
 
-type DialogProps = {
-  openedDialogType: DialogType | null
+type DialogProps<T extends DialogType = DialogType> = {
+  openedDialogType: T | null
   onClose: (confirmed: boolean, onCloseData?: unknown) => void
+  params: ParamsType<T>
 }
 
 export function DialogWrapper(props: DialogProps) {
   const isOftTransfer = useIsOftV2Transfer()
   const [selectedToken] = useSelectedToken()
-  const isCctp = useIsCctpTransfer()
   const [{ amount }] = useArbQueryParams()
 
   const [isOpen, setIsOpen] = useState(false)
@@ -86,11 +113,12 @@ export function DialogWrapper(props: DialogProps) {
 
   switch (openedDialogType) {
     case 'approve_token':
+      const approveTokenParams = props.params as DialogTypeParams['approve_token']
       return (
         <TokenApprovalDialog
           {...commonProps}
           token={selectedToken}
-          isCctp={isCctp}
+          isCctp={approveTokenParams.isCctp}
           isOft={isOftTransfer}
         />
       )

--- a/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
@@ -25,7 +25,7 @@ type UseDialogResult = [DialogProps, OpenDialogFunction]
 
 type DialogType = 'approve_token' | 'withdraw'
 
-export function useNewDialog(): UseDialogResult {
+export function useDialog2(): UseDialogResult {
   const resolveRef =
     useRef<
       (value: [boolean, unknown] | PromiseLike<[boolean, unknown]>) => void

--- a/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
@@ -113,7 +113,8 @@ export function DialogWrapper(props: DialogProps) {
 
   switch (openedDialogType) {
     case 'approve_token':
-      const approveTokenParams = props.params as DialogTypeParams['approve_token']
+      const approveTokenParams =
+        props.params as DialogTypeParams['approve_token']
       return (
         <TokenApprovalDialog
           {...commonProps}

--- a/packages/arb-token-bridge-ui/src/components/common/NewDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NewDialog.tsx
@@ -23,7 +23,7 @@ type OpenDialogFunction = (dialogType: DialogType) => WaitForInputFunction
  */
 type UseDialogResult = [DialogProps, OpenDialogFunction]
 
-type DialogType = 'approve_token' | 'withdrawal_confirmation'
+type DialogType = 'approve_token' | 'withdraw'
 
 export function useNewDialog(): UseDialogResult {
   const resolveRef =
@@ -94,7 +94,7 @@ export function DialogWrapper(props: DialogProps) {
           isOft={isOftTransfer}
         />
       )
-    case 'withdrawal_confirmation':
+    case 'withdraw':
       return <WithdrawalConfirmationDialog {...commonProps} amount={amount} />
     default:
       return null

--- a/packages/arb-token-bridge-ui/src/components/common/NewDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NewDialog.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useRef, useState } from 'react'
+
+import { ButtonProps } from './Button'
+import { TokenApprovalDialog } from '../TransferPanel/TokenApprovalDialog'
+import { useIsOftV2Transfer } from '../TransferPanel/hooks/useIsOftV2Transfer'
+import { useSelectedToken } from '../../hooks/useSelectedToken'
+import { useIsCctpTransfer } from '../TransferPanel/hooks/useIsCctpTransfer'
+import { WithdrawalConfirmationDialog } from '../TransferPanel/WithdrawalConfirmationDialog'
+import { useArbQueryParams } from '../../hooks/useArbQueryParams'
+/**
+ * Returns a promise which resolves to an array [boolean, unknown] value,
+ * `false` if the action was canceled and `true` if it was confirmed.
+ * Second index contain any additional information
+ */
+type WaitForInputFunction = () => Promise<[boolean, unknown]>
+
+/**
+ * Opens the dialog and returns a function which can be called to retreive a {@link WaitForInputFunction}.
+ */
+export type OpenDialogFunction = (
+  dialogType: DialogType
+) => WaitForInputFunction
+
+/**
+ * Contains two props, `isOpen` and `onClose`, which should be passed down to a Dialog component.
+ */
+export type UseDialogProps = Pick<DialogProps, 'openedDialog' | 'onClose'>
+
+/**
+ * Contains additional info about the dialog.
+ */
+export type OtherDialogInfo = { didOpen: boolean }
+
+/**
+ * Returns an array containing {@link UseDialogProps} and {@link OpenDialogFunction}.
+ */
+export type UseDialogResult = [
+  UseDialogProps,
+  OpenDialogFunction,
+  OtherDialogInfo
+]
+
+/**
+ * Initial parameters for the dialog.
+ */
+type UseDialogParams = {
+  /**
+   * Whether the dialog should be open by default.
+   */
+  defaultIsOpen?: boolean
+}
+
+type DialogType = 'approve_token' | 'withdrawal_confirmation'
+
+export function useNewDialog(params?: UseDialogParams): UseDialogResult {
+  const resolveRef =
+    useRef<
+      (value: [boolean, unknown] | PromiseLike<[boolean, unknown]>) => void
+    >()
+
+  // Whether the dialog is currently open
+  const [openedDialog, setOpenedDialog] = useState<DialogType | null>(null)
+  // Whether the dialog was ever open
+  const [didOpen, setDidOpen] = useState(params?.defaultIsOpen ?? false)
+
+  const openDialog: OpenDialogFunction = useCallback(
+    (dialogType: DialogType) => {
+      setOpenedDialog(dialogType)
+      setDidOpen(true)
+
+      return () => {
+        return new Promise(resolve => {
+          resolveRef.current = resolve
+        })
+      }
+    },
+    []
+  )
+
+  const closeDialog = useCallback(
+    (confirmed: boolean, onCloseData?: unknown) => {
+      if (typeof resolveRef.current !== 'undefined') {
+        resolveRef.current([confirmed, onCloseData])
+      }
+
+      setOpenedDialog(null)
+    },
+    []
+  )
+
+  return [{ openedDialog, onClose: closeDialog }, openDialog, { didOpen }]
+}
+
+type DialogProps = {
+  openedDialog: DialogType | null
+  closeable?: boolean
+  title?: string | JSX.Element
+  initialFocus?: React.MutableRefObject<HTMLElement | null>
+  cancelButtonProps?: Partial<ButtonProps>
+  actionButtonProps?: Partial<ButtonProps>
+  actionButtonTitle?: string
+  isFooterHidden?: boolean
+  onClose: (confirmed: boolean, onCloseData?: unknown) => void
+  className?: string
+}
+
+export function DialogWrapper(props: DialogProps) {
+  const isOftTransfer = useIsOftV2Transfer()
+  const [selectedToken] = useSelectedToken()
+  const isCctp = useIsCctpTransfer()
+  const [{ amount }] = useArbQueryParams()
+
+  switch (props.openedDialog) {
+    case 'approve_token':
+      return (
+        <TokenApprovalDialog
+          {...props}
+          isOpen
+          token={selectedToken}
+          isCctp={isCctp}
+          isOft={isOftTransfer}
+        />
+      )
+    case 'withdrawal_confirmation':
+      return <WithdrawalConfirmationDialog {...props} isOpen amount={amount} />
+    default:
+      return null
+  }
+}

--- a/packages/arb-token-bridge-ui/src/components/common/NewDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NewDialog.tsx
@@ -16,19 +16,12 @@ type WaitForInputFunction = () => Promise<[boolean, unknown]>
 /**
  * Opens the dialog and returns a function which can be called to retreive a {@link WaitForInputFunction}.
  */
-export type OpenDialogFunction = (
-  dialogType: DialogType
-) => WaitForInputFunction
+type OpenDialogFunction = (dialogType: DialogType) => WaitForInputFunction
 
 /**
- * Contains two props, `isOpen` and `onClose`, which should be passed down to a Dialog component.
+ * Returns an array containing {@link DialogProps} and {@link OpenDialogFunction}.
  */
-export type UseDialogProps = Pick<DialogProps, 'openedDialog' | 'onClose'>
-
-/**
- * Returns an array containing {@link UseDialogProps} and {@link OpenDialogFunction}.
- */
-export type UseDialogResult = [UseDialogProps, OpenDialogFunction]
+type UseDialogResult = [DialogProps, OpenDialogFunction]
 
 type DialogType = 'approve_token' | 'withdrawal_confirmation'
 
@@ -39,11 +32,13 @@ export function useNewDialog(): UseDialogResult {
     >()
 
   // Whether the dialog is currently open
-  const [openedDialog, setOpenedDialog] = useState<DialogType | null>(null)
+  const [openedDialogType, setOpenedDialogType] = useState<DialogType | null>(
+    null
+  )
 
   const openDialog: OpenDialogFunction = useCallback(
     (dialogType: DialogType) => {
-      setOpenedDialog(dialogType)
+      setOpenedDialogType(dialogType)
 
       return () => {
         return new Promise(resolve => {
@@ -60,16 +55,16 @@ export function useNewDialog(): UseDialogResult {
         resolveRef.current([confirmed, onCloseData])
       }
 
-      setOpenedDialog(null)
+      setOpenedDialogType(null)
     },
     []
   )
 
-  return [{ openedDialog, onClose: closeDialog }, openDialog]
+  return [{ openedDialogType, onClose: closeDialog }, openDialog]
 }
 
 type DialogProps = {
-  openedDialog: DialogType | null
+  openedDialogType: DialogType | null
   onClose: (confirmed: boolean, onCloseData?: unknown) => void
 }
 
@@ -81,15 +76,15 @@ export function DialogWrapper(props: DialogProps) {
 
   const [isOpen, setIsOpen] = useState(false)
 
-  const { openedDialog } = props
+  const { openedDialogType } = props
   const commonProps: DialogProps & { isOpen: boolean } = { ...props, isOpen }
 
   // By doing this we enable fade in transition when dialog opens.
   useEffect(() => {
-    setIsOpen(openedDialog !== null)
-  }, [openedDialog])
+    setIsOpen(openedDialogType !== null)
+  }, [openedDialogType])
 
-  switch (openedDialog) {
+  switch (openedDialogType) {
     case 'approve_token':
       return (
         <TokenApprovalDialog


### PR DESCRIPTION
Note we move 2-3 dialogs at a time, opened more PRs