### PR TITLE
ci: update audit ci allowlist

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,16 +1,5 @@
 {
   "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
   "low": true,
-  "allowlist": [
-    // temp measure until npm cli fixes its registration issue
-    // see https://github.com/actions/toolkit/issues/1960#issuecomment-2682212538
-    //
-    // Octokit request package vulnerable to ReDoS
-    // Only used in development scripts for GitHub API interactions
-    "GHSA-rmvr-2pp2-xj38",
-    // https://github.com/advisories/GHSA-h5c3-5r3r-rr8q
-    // Octokit plugin-paginate-rest vulnerable to ReDoS
-    // Only used in development scripts for GitHub API pagination
-    "GHSA-h5c3-5r3r-rr8q"
-  ]
+  "allowlist": []
 }


### PR DESCRIPTION
now that npm cli has fixed its registration issue, we can clear out allowlist.