### PR TITLE
refactor: clean up `useTransactionHistory` before pagination

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryTable.tsx
@@ -96,12 +96,12 @@ export const HistoryLoader = () => {
   return <span className="animate-pulse">Loading transactions...</span>
 }
 
-const FailedChainPairsTooltip = ({
-  failedChainPairs
+const ErroredChainsTooltip = ({
+  erroredChains
 }: {
-  failedChainPairs: ChainPair[]
+  erroredChains: ChainPair[]
 }) => {
-  if (failedChainPairs.length === 0) {
+  if (erroredChains.length === 0) {
     return null
   }
 
@@ -113,7 +113,7 @@ const FailedChainPairsTooltip = ({
             We were unable to fetch data for the following chain pairs:
           </span>
           <ul className="flex list-disc flex-col pl-4">
-            {failedChainPairs.map(pair => (
+            {erroredChains.map(pair => (
               <li key={`${pair.parentChainId}-${pair.childChainId}`}>
                 <b>{getNetworkName(pair.parentChainId)}</b>
                 {' <> '}
@@ -142,7 +142,7 @@ export const TransactionHistoryTable = (
     loading,
     completed,
     error,
-    failedChainPairs,
+    erroredChains,
     resume,
     selectedTabIndex,
     oldestTxTimeAgoString
@@ -216,13 +216,13 @@ export const TransactionHistoryTable = (
       >
         {loading ? (
           <div className="flex h-[28px] items-center space-x-2">
-            <FailedChainPairsTooltip failedChainPairs={failedChainPairs} />
+            <ErroredChainsTooltip erroredChains={erroredChains} />
             <HistoryLoader />
           </div>
         ) : (
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center justify-start space-x-1">
-              <FailedChainPairsTooltip failedChainPairs={failedChainPairs} />
+              <ErroredChainsTooltip erroredChains={erroredChains} />
               <span className="text-xs">
                 Showing {transactions.length}{' '}
                 {isPendingTab ? 'pending' : 'settled'} transactions made in{' '}


### PR DESCRIPTION
A few clean ups and renaming that is nice to have before pagination, and can be merged individually.

Reasoning for changes:
1. `FailedChainPairsTooltip` to `ErroredChainsTooltip` - just nit but feels easier on the eye and faster to understand
2. `useTransactionHistoryWithoutStatuses` to `useRawTransactionHistory` - less of a mouthful, but also with future changes we will have one more type of transactions structure that are without statuses. We will have `raw`, `unloaded` and `loaded` transactions:
- `useRawTransactionHistory` returns `Transfer[]` - minimal data sorted chronologically. All it gives us are transactions ordered by date: these transactions can't be used as table rows because they lack crucial details (e.g. token data and more).
- `useUnloadedTransactionHistory` returns `MergedTransaction[]` - can be used as table rows, but they lack status data. We will display those in transaction history and load status in the background.
- `useTransactionHistory` returns `MergedTransaction[]` - this is the full `loaded` data, with status.
3. `txPages` to `loadedPages` - based on above point 2.