### PR TITLE
fix: return usdc token before token lists token

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
@@ -9,8 +9,6 @@ import { useTokenLists } from '../../hooks/useTokenLists'
 import { TokenListWithId } from '../../util/TokenListUtils'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
 import { useNetworks } from '../../hooks/useNetworks'
-import { isTokenMainnetUSDC, isTokenSepoliaUSDC } from '../../util/TokenUtils'
-import { isNetwork } from '../../util/networks'
 
 export function useTokensFromLists(): ContractStorage<ERC20BridgeToken> {
   const [networks] = useNetworks()
@@ -107,19 +105,11 @@ function tokenListsToSearchableTokenStorage(
               return
             }
 
-            const isMainnetUsdc =
-              isNetwork(Number(l1ChainId)).isEthereumMainnet &&
-              isTokenMainnetUSDC(addressOnL1)
-            const isSepoliaUsdc =
-              isNetwork(Number(l1ChainId)).isSepolia &&
-              isTokenSepoliaUSDC(addressOnL1)
-            const isMainnetOrSepoliaUsdc = isMainnetUsdc || isSepoliaUsdc
-
             if (typeof acc[addressOnL1] === 'undefined') {
               // Token is not on the list yet
               acc[addressOnL1] = {
-                name: isMainnetOrSepoliaUsdc ? 'USD Coin' : token.name,
-                symbol: isMainnetOrSepoliaUsdc ? 'USDC' : token.symbol,
+                name: token.name,
+                symbol: token.symbol,
                 type: TokenType.ERC20,
                 logoURI: token.logoURI,
                 address: addressOnL1,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
@@ -9,6 +9,8 @@ import { useTokenLists } from '../../hooks/useTokenLists'
 import { TokenListWithId } from '../../util/TokenListUtils'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
 import { useNetworks } from '../../hooks/useNetworks'
+import { isTokenMainnetUSDC, isTokenSepoliaUSDC } from '../../util/TokenUtils'
+import { isNetwork } from '../../util/networks'
 
 export function useTokensFromLists(): ContractStorage<ERC20BridgeToken> {
   const [networks] = useNetworks()
@@ -105,11 +107,19 @@ function tokenListsToSearchableTokenStorage(
               return
             }
 
+            const isMainnetUsdc =
+              isNetwork(Number(l1ChainId)).isEthereumMainnet &&
+              isTokenMainnetUSDC(addressOnL1)
+            const isSepoliaUsdc =
+              isNetwork(Number(l1ChainId)).isSepolia &&
+              isTokenSepoliaUSDC(addressOnL1)
+            const isMainnetOrSepoliaUsdc = isMainnetUsdc || isSepoliaUsdc
+
             if (typeof acc[addressOnL1] === 'undefined') {
               // Token is not on the list yet
               acc[addressOnL1] = {
-                name: token.name,
-                symbol: token.symbol,
+                name: isMainnetOrSepoliaUsdc ? 'USD Coin' : token.name,
+                symbol: isMainnetOrSepoliaUsdc ? 'USDC' : token.symbol,
                 type: TokenType.ERC20,
                 logoURI: token.logoURI,
                 address: addressOnL1,

--- a/packages/arb-token-bridge-ui/src/hooks/useSelectedToken.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useSelectedToken.ts
@@ -79,9 +79,9 @@ export const useSelectedToken = () => {
   }
 
   return [
+    usdcToken ||
     tokensFromUser[tokenFromSearchParams] ||
       tokensFromLists[tokenFromSearchParams] ||
-      usdcToken ||
       null,
     setSelectedToken
   ] as const
@@ -116,8 +116,10 @@ export async function getUsdcToken({
     isArbitrumSepolia: isParentChainArbitrumSepolia
   } = isNetwork(parentChainId)
 
+  console.log({ tokenAddress })
   // Ethereum Mainnet USDC
   if (isTokenMainnetUSDC(tokenAddress) && isParentChainEthereumMainnet) {
+    console.log('token 1')
     return {
       ...commonUSDC,
       address: CommonAddress.Ethereum.USDC,

--- a/packages/arb-token-bridge-ui/src/hooks/useSelectedToken.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useSelectedToken.ts
@@ -80,7 +80,7 @@ export const useSelectedToken = () => {
 
   return [
     usdcToken ||
-    tokensFromUser[tokenFromSearchParams] ||
+      tokensFromUser[tokenFromSearchParams] ||
       tokensFromLists[tokenFromSearchParams] ||
       null,
     setSelectedToken

--- a/packages/arb-token-bridge-ui/src/hooks/useSelectedToken.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useSelectedToken.ts
@@ -116,10 +116,8 @@ export async function getUsdcToken({
     isArbitrumSepolia: isParentChainArbitrumSepolia
   } = isNetwork(parentChainId)
 
-  console.log({ tokenAddress })
   // Ethereum Mainnet USDC
   if (isTokenMainnetUSDC(tokenAddress) && isParentChainEthereumMainnet) {
-    console.log('token 1')
     return {
       ...commonUSDC,
       address: CommonAddress.Ethereum.USDC,


### PR DESCRIPTION
When L2 address is found in the token lists, we use its data to also set L1 address for the token: https://github.com/OffchainLabs/arbitrum-token-bridge/blob/master/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts#L87-L119

Because L2's USDC name is "Bridged USDC", it sets it as L1 token name in our list.

So we need to apply USDC first.