### PR TITLE
fix: skip retries for LayerZero API 404 response

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
@@ -302,7 +302,10 @@ export function useOftTransactionHistory({
           isTestnet ? LAYERZERO_API_URL_TESTNET : LAYERZERO_API_URL_MAINNET
         }/messages/wallet/${walletAddress}`
       : null,
-    fetcher
+    fetcher,
+    {
+      shouldRetryOnError: false
+    }
   )
 
   return {

--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
@@ -310,13 +310,7 @@ export function useOftTransactionHistory({
       : null,
     fetcher,
     {
-      onErrorRetry: (error, key, config, revalidate, { retryCount }) => {
-        // don't retry on 404 (LayerZero API returns 404 if no transactions are found)
-        if (error.status === 404 || retryCount >= 2) return
-
-        // else, retry on error as usual
-        setTimeout(() => revalidate({ retryCount }), 5_000)
-      }
+      errorRetryCount: 2
     }
   )
 

--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
@@ -304,7 +304,11 @@ export function useOftTransactionHistory({
       : null,
     fetcher,
     {
-      shouldRetryOnError: false
+      onErrorRetry: (error, key, config, revalidate, { retryCount }) => {
+        if (error.status === 404) return // don't retry on 404 (LayerZero API returns 404 if no transactions are found)
+
+        setTimeout(() => revalidate({ retryCount }), 10000)
+      }
     }
   )
 

--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
@@ -315,7 +315,7 @@ export function useOftTransactionHistory({
         if (error.status === 404 || retryCount >= 2) return
 
         // else, retry on error as usual
-        setTimeout(() => revalidate({ retryCount }), 10000)
+        setTimeout(() => revalidate({ retryCount }), 5_000)
       }
     }
   )


### PR DESCRIPTION
LayerZero API returns 404 if no transactions are found, but SWR considers it as an API error, and retries by default. This results in `Loading Transactions` popping up in periodically.