### PR TITLE
refactor: import shallow correctly into CctpRoute

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/Routes/CctpRoute.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/Routes/CctpRoute.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import {shallow} from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 import { useNetworks } from '../../../hooks/useNetworks'
 import { Route, Token } from './Route'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/Routes/CctpRoute.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/Routes/CctpRoute.tsx
@@ -1,14 +1,15 @@
+import { useMemo } from 'react'
+import {shallow} from 'zustand/shallow'
+
 import { useNetworks } from '../../../hooks/useNetworks'
 import { Route, Token } from './Route'
 import { isNetwork } from '../../../util/networks'
 
-import { CommonAddress } from '../../../util/CommonAddressUtils'
 import { getCctpTransferDuration } from '../../../hooks/useTransferDuration'
 import { useRouteStore } from '../hooks/useRouteStore'
 import { useArbQueryParams } from '../../../hooks/useArbQueryParams'
-import { useMemo } from 'react'
 import { getUsdcTokenAddressFromSourceChainId } from '../../../state/cctpState'
-import shallow from 'zustand/shallow'
+
 export function CctpRoute() {
   const [{ amount }] = useArbQueryParams()
   const [{ sourceChain }] = useNetworks()


### PR DESCRIPTION
Right now if you run the app locally and select the CCTP route for USDC, the app would crash.

<img width="610" alt="image" src="https://github.com/user-attachments/assets/e6d98bb7-1b22-4c86-a6a1-ba4f9bf320b4" />
<img width="462" alt="image" src="https://github.com/user-attachments/assets/882f5e77-2d52-4611-8250-933aa697a40e" />
