### PR TITLE
feat: make Stargate tokens withdraw-only on Plume

### DIFF
--- a/packages/arb-token-bridge-ui/src/types/ChainId.ts
+++ b/packages/arb-token-bridge-ui/src/types/ChainId.ts
@@ -9,6 +9,7 @@ export enum ChainId {
   ArbitrumOne = 42161,
   ArbitrumNova = 42170,
   Base = 8453,
+  Plume = 98866,
   // L2 Testnets
   ArbitrumSepolia = 421614,
   ArbitrumLocal = 412346,

--- a/packages/arb-token-bridge-ui/src/util/CommonAddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/CommonAddressUtils.ts
@@ -2,6 +2,7 @@ export const CommonAddress = {
   Ethereum: {
     USDC: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     USDT: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    WETH: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
     tokenMessengerContractAddress: '0xbd3fa81b58ba92a82136038b25adec7066af3155'
   },
   ArbitrumOne: {

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -252,19 +252,24 @@ export const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
     }
   ],
   [ChainId.ArbitrumNova]: [],
-  // Plume
-  98865: [
+  [ChainId.Plume]: [
     {
       symbol: 'USDC',
       l2CustomAddr: '',
       l1Address: CommonAddress.Ethereum.USDC,
-      l2Address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831'
+      l2Address: '0x54FD4da2Fa19Cf0f63d8f93A6EA5BEd3F9C042C6'
     },
     {
       symbol: 'USDT',
       l2CustomAddr: '',
       l1Address: CommonAddress.Ethereum.USDT,
-      l2Address: '0x4ef0c9098563e2478bdf0cc32a10d24abaa46b1c'
+      l2Address: '0x7c5568fd326086D35B002Cc705C852dbaB7438a8'
+    },
+    {
+      symbol: 'WETH',
+      l2CustomAddr: '',
+      l1Address: CommonAddress.Ethereum.WETH,
+      l2Address: '0xEE9e50425E1599e4eC09f0a5F76Ce35A4924e4AC'
     }
   ]
 }


### PR DESCRIPTION
### Summary

Follow-up to #2221 which makes USDC, USDT, and WETH withdraw-only on the Arbitrum native bridge. These are the three assets that should be [bridged via Stargate](https://stargate.finance/bridge?srcChain=ethereum&srcToken=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&dstChain=plumephoenix&dstToken=0x78adD880A697070c1e765Ac44D65323a0DcCE913) instead, as LayerZero-supported OFTs, rather than the default ArbERC20 tokens.

For the legacy Plume mainnet and testnet, we're just about finished with our offboarding so we'll be able to remove them from the Arbitrum bridge UI shortly.