### PR TITLE
test: add `clickClaimButton` method to e2e

### DIFF
--- a/packages/arb-token-bridge-ui/tests/e2e/cypress.d.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/cypress.d.ts
@@ -20,6 +20,7 @@ import {
   findTransactionDetailsCustomDestinationAddress,
   findTransactionInTransactionHistory,
   findClaimButton,
+  clickClaimButton,
   selectTransactionsPanelTab,
   confirmSpending,
   claimCctp,
@@ -70,6 +71,7 @@ declare global {
       findTransactionDetailsCustomDestinationAddress: typeof findTransactionDetailsCustomDestinationAddress
       findTransactionInTransactionHistory: typeof findTransactionInTransactionHistory
       findClaimButton: typeof findClaimButton
+      clickClaimButton: typeof clickClaimButton
       confirmSpending: typeof confirmSpending
       claimCctp: typeof claimCctp
       selectRoute: typeof selectRoute

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawCctp.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawCctp.cy.ts
@@ -72,12 +72,11 @@ describe('Withdraw USDC through CCTP', () => {
       amount: USDCAmountToSend,
       symbol: 'USDC'
     })
-    cy.findClaimButton(
+    cy.clickClaimButton(
       formatAmount(USDCAmountToSend, {
         symbol: 'USDC'
-      }),
-      { timeout: 120_000 }
-    ).click()
+      })
+    )
     cy.allowMetamaskToSwitchNetwork()
     cy.rejectMetamaskTransaction()
     cy.changeMetamaskNetwork('arbitrum-sepolia')
@@ -117,12 +116,11 @@ describe('Withdraw USDC through CCTP', () => {
       Cypress.env('CUSTOM_DESTINATION_ADDRESS')
     )
     cy.closeTransactionDetails()
-    cy.findClaimButton(
+    cy.clickClaimButton(
       formatAmount(USDCAmountToSend, {
         symbol: 'USDC'
-      }),
-      { timeout: 120_000 }
-    ).click()
+      })
+    )
     cy.allowMetamaskToSwitchNetwork()
     cy.rejectMetamaskTransaction()
   })

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
@@ -145,11 +145,11 @@ describe('Withdraw ERC20 Token', () => {
 
         cy.switchToTransactionHistoryTab('pending')
 
-        cy.findClaimButton(
+        cy.clickClaimButton(
           formatAmount(ERC20AmountToSend, {
             symbol: testCase.symbol
           })
-        ).click()
+        )
 
         cy.confirmMetamaskTransaction()
 

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawNativeToken.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawNativeToken.cy.ts
@@ -98,11 +98,11 @@ describe('Withdraw native token', () => {
 
           cy.switchToTransactionHistoryTab('pending')
 
-          cy.findClaimButton(
+          cy.clickClaimButton(
             formatAmount(ETHToWithdraw, {
               symbol: nativeTokenSymbol
             })
-          ).click()
+          )
 
           cy.confirmMetamaskTransaction()
 

--- a/packages/arb-token-bridge-ui/tests/support/commands.ts
+++ b/packages/arb-token-bridge-ui/tests/support/commands.ts
@@ -359,6 +359,12 @@ export function claimCctp(amount: number, options: { accept: boolean }) {
   }
 }
 
+export function clickClaimButton(amountToClaim: string) {
+  cy.findClaimButton(amountToClaim).should('be.visible')
+  cy.wait(10_000)
+  cy.findClaimButton(amountToClaim).click()
+}
+
 export function selectRoute(type: 'arbitrum' | 'oftV2' | 'cctp') {
   cy.findByLabelText(`Route ${type}`).should('be.visible').click()
 }
@@ -385,6 +391,7 @@ Cypress.Commands.addAll({
   closeTransactionDetails,
   findTransactionInTransactionHistory,
   findClaimButton,
+  clickClaimButton,
   findTransactionDetailsCustomDestinationAddress,
   confirmSpending,
   claimCctp,


### PR DESCRIPTION
Signer can be undefined for the first few renders as the claim button shows. In e2e we click it instantly which causes a failure on occasion 