### PR TITLE
fix: tx history fixes for no wallet connection

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/EmptyTransactionHistory.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/EmptyTransactionHistory.tsx
@@ -25,9 +25,14 @@ export const EmptyTransactionHistory = ({
   )
 
   if (typeof txHistoryAddress === 'undefined') {
-    return <ContentWrapper>
-      <p>Please connect your wallet or search for a wallet address to see transactions.</p>
-    </ContentWrapper>
+    return (
+      <ContentWrapper>
+        <p>
+          Please connect your wallet or search for a wallet address to see
+          transactions.
+        </p>
+      </ContentWrapper>
+    )
   }
 
   if (loading) {

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/EmptyTransactionHistory.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/EmptyTransactionHistory.tsx
@@ -1,5 +1,6 @@
 import { GET_HELP_LINK } from '../../constants'
 import { ExternalLink } from '../common/ExternalLink'
+import { useTransactionHistoryAddressStore } from './TransactionHistorySearchBar'
 import {
   ContentWrapper,
   HistoryLoader,
@@ -19,6 +20,16 @@ export const EmptyTransactionHistory = ({
   resume: () => void
   tabType: 'pending' | 'settled'
 }) => {
+  const txHistoryAddress = useTransactionHistoryAddressStore(
+    state => state.sanitizedAddress
+  )
+
+  if (typeof txHistoryAddress === 'undefined') {
+    return <ContentWrapper>
+      <p>Please connect your wallet or search for a wallet address to see transactions.</p>
+    </ContentWrapper>
+  }
+
   if (loading) {
     return (
       <ContentWrapper>

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchResults.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchResults.tsx
@@ -67,6 +67,9 @@ export function TransactionHistorySearchResults() {
   const searchError = useTransactionHistoryAddressStore(
     state => state.searchError
   )
+  const txHistoryAddress = useTransactionHistoryAddressStore(
+    state => state.sanitizedAddress
+  )
 
   const oldestTxTimeAgoString = useMemo(() => {
     return dayjs(transactions[transactions.length - 1]?.createdAt).toNow(true)
@@ -140,7 +143,7 @@ export function TransactionHistorySearchResults() {
           </TabButton>
         </Tab.List>
 
-        {!forceFetchReceived && (
+        {!forceFetchReceived && typeof txHistoryAddress !== 'undefined' && (
           <div className="mb-2 text-xs text-white">
             Missing a transaction after sending to or receiving from a different
             address? Click{' '}

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRowAction.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionsTableRowAction.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useAccount, useNetwork } from 'wagmi'
+import { ConnectButton } from '@rainbow-me/rainbowkit'
 
 import { GET_HELP_LINK } from '../../constants'
 import { useClaimWithdrawal } from '../../hooks/useClaimWithdrawal'
@@ -27,6 +28,22 @@ import { useTransactionHistoryAddressStore } from './TransactionHistorySearchBar
 import { Tooltip } from '../common/Tooltip'
 import { addressesEqual } from '../../util/AddressUtils'
 
+function ActionRowConnectButton() {
+  return (
+    <ConnectButton.Custom>
+      {({ openConnectModal }) => (
+        <Button
+          variant="primary"
+          className="w-14 rounded bg-lime-dark p-2 text-xs text-white"
+          onClick={openConnectModal}
+        >
+          Connect
+        </Button>
+      )}
+    </ConnectButton.Custom>
+  )
+}
+
 export function TransactionsTableRowAction({
   tx,
   isError,
@@ -36,7 +53,7 @@ export function TransactionsTableRowAction({
   isError: boolean
   type: 'deposits' | 'withdrawals'
 }) {
-  const { address: connectedAddress } = useAccount()
+  const { address: connectedAddress, isConnected } = useAccount()
   const { chain } = useNetwork()
   const { switchNetworkAsync } = useSwitchNetworkWithConfig()
   const networkName = getNetworkName(chain?.id ?? 0)
@@ -136,6 +153,10 @@ export function TransactionsTableRowAction({
   }
 
   if (isDepositReadyToRedeem(tx)) {
+    if (!isConnected) {
+      return <ActionRowConnectButton />
+    }
+
     // Failed retryable
     return isRedeeming ? (
       <span className="animate-pulse">Retrying...</span>
@@ -168,6 +189,10 @@ export function TransactionsTableRowAction({
   if (tx.status === 'Confirmed') {
     if (tx.isCctp && tx.resolvedAt) {
       return null
+    }
+
+    if (!isConnected) {
+      return <ActionRowConnectButton />
     }
 
     return isClaiming || isClaimingCctp ? (

--- a/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAccountType.ts
@@ -10,17 +10,17 @@ type Result = {
   isLoading: boolean
 }
 
-export function useAccountType(): Result {
-  const { address, isConnected } = useAccount()
+export function useAccountType(addressOverride?: string): Result {
+  const { address: walletAddress } = useAccount()
   // TODO: change to use connected chain when Safe wallet returns it correctly
   // atm Safe UI would try to switch connected chain even when user is at the correct chain
   // so the connected chain WAGMI returns is the wrong chain where the SCW is not deployed on
   const [{ sourceChain }] = useNetworks()
 
+  const address = addressOverride ?? walletAddress
+
   const { data: isSmartContractWallet = false, isLoading } = useSWRImmutable(
-    address && isConnected && sourceChain
-      ? [address, sourceChain.id, 'useAccountType']
-      : null,
+    address && sourceChain ? [address, sourceChain.id, 'useAccountType'] : null,
     ([_address, chainId]) => addressIsSmartContract(_address, chainId),
     {
       shouldRetryOnError: true,

--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -264,7 +264,7 @@ const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
   const { chain } = useNetwork()
   const [isTestnetMode] = useIsTestnetMode()
   const { isSmartContractWallet, isLoading: isLoadingAccountType } =
-    useAccountType()
+    useAccountType(address)
   const [{ txHistory: isTxHistoryEnabled }] = useArbQueryParams()
   const forceFetchReceived = useForceFetchReceived(
     state => state.forceFetchReceived
@@ -428,8 +428,7 @@ const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
     ]
   )
 
-  const shouldFetch =
-    address && chain && !isLoadingAccountType && isTxHistoryEnabled
+  const shouldFetch = address && !isLoadingAccountType && isTxHistoryEnabled
 
   const {
     data: depositsData,
@@ -490,7 +489,7 @@ export const useTransactionHistory = (
   const [isTestnetMode] = useIsTestnetMode()
   const { chain } = useNetwork()
   const { isSmartContractWallet, isLoading: isLoadingAccountType } =
-    useAccountType()
+    useAccountType(address)
   const [{ txHistory: isTxHistoryEnabled }] = useArbQueryParams()
   const { connector } = useAccount()
   // max number of transactions mapped in parallel


### PR DESCRIPTION
### Fixes:
1. Removed "Load more" button for no connected wallet.
2. Removed not needed content from `EmptyTransactionHistory` for no connected wallet.
3. Fixed fetching for searched address for no connected wallet.
4. Added "Connect" button for claiming and retrying for no connected wallet.

Closes FS-1211