### PR TITLE
refactor: organize `AppProviders` and `Layout`

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -1,50 +1,32 @@
-import { useEffect, useMemo, useState } from 'react'
-import { useAccount, WagmiProvider } from 'wagmi'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { darkTheme, RainbowKitProvider, Theme } from '@rainbow-me/rainbowkit'
+import React, { useEffect, useState } from 'react'
+import { useAccount } from 'wagmi'
 
-import merge from 'lodash-es/merge'
 import axios from 'axios'
-import { createOvermind } from 'overmind'
-import { Provider } from 'overmind-react'
 import { useLocalStorage } from '@uidotdev/usehooks'
-
 import { TokenBridgeParams } from '../../hooks/useArbTokenBridge'
 import { WelcomeDialog } from './WelcomeDialog'
 import { BlockedDialog } from './BlockedDialog'
-import { AppContextProvider } from './AppContext'
-import { config, useActions } from '../../state'
+
+import { useActions } from '../../state'
 import { MainContent } from '../MainContent/MainContent'
 import { ArbTokenBridgeStoreSync } from '../syncers/ArbTokenBridgeStoreSync'
 import { TokenListSyncer } from '../syncers/TokenListSyncer'
-import { ArbQueryParamProvider } from '../../hooks/useArbQueryParams'
 import { Header, HeaderAccountOrConnectWalletButton } from '../common/Header'
 import { TOS_LOCALSTORAGE_KEY } from '../../constants'
-import { getProps } from '../../util/wagmi/setup'
 import { useAccountIsBlocked } from '../../hooks/useAccountIsBlocked'
 import { useCCTPIsBlocked } from '../../hooks/CCTP/useCCTPIsBlocked'
 import { useNetworks } from '../../hooks/useNetworks'
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship'
 import { useSyncConnectedChainToAnalytics } from './useSyncConnectedChainToAnalytics'
 import { useSyncConnectedChainToQueryParams } from './useSyncConnectedChainToQueryParams'
-import React from 'react'
+import { Layout } from '../common/Layout'
+import { AppProviders } from './AppProviders'
 
 declare global {
   interface Window {
     Cypress?: any
   }
 }
-
-const rainbowkitTheme = merge(darkTheme(), {
-  colors: {
-    accentColor: 'var(--blue-link)'
-  },
-  fonts: {
-    body: 'Roboto, sans-serif'
-  }
-} as Theme)
-
-const queryClient = new QueryClient()
 
 const ArbTokenBridgeStoreSyncWrapper = (): JSX.Element | null => {
   const actions = useActions()
@@ -155,44 +137,12 @@ const AppContent = React.memo(() => {
 
 AppContent.displayName = 'AppContent'
 
-// We're doing this as a workaround so users can select their preferred chain on WalletConnect.
-//
-// https://github.com/orgs/WalletConnect/discussions/2733
-// https://github.com/wagmi-dev/references/blob/main/packages/connectors/src/walletConnect.ts#L114
-const searchParams = new URLSearchParams(window.location.search)
-const targetChainKey = searchParams.get('sourceChain')
-
-const wagmiConfig = getProps(targetChainKey)
-
-// Clear cache for everything related to WalletConnect v2.
-//
-// TODO: Remove this once the fix for the infinite loop / memory leak is identified.
-Object.keys(localStorage).forEach(key => {
-  if (
-    key === 'wagmi.requestedChains' ||
-    key === 'wagmi.store' ||
-    key.startsWith('wc@2')
-  ) {
-    localStorage.removeItem(key)
-  }
-})
-
 export default function App() {
-  const overmind = useMemo(() => createOvermind(config), [])
-
   return (
-    <Provider value={overmind}>
-      <ArbQueryParamProvider>
-        <WagmiProvider config={wagmiConfig}>
-          <QueryClientProvider client={queryClient}>
-            <RainbowKitProvider theme={rainbowkitTheme}>
-              <AppContextProvider>
-                <AppContent />
-              </AppContextProvider>
-            </RainbowKitProvider>
-          </QueryClientProvider>
-        </WagmiProvider>
-      </ArbQueryParamProvider>
-    </Provider>
+    <AppProviders>
+      <Layout>
+        <AppContent />
+      </Layout>
+    </AppProviders>
   )
 }

--- a/packages/arb-token-bridge-ui/src/components/App/AppProviders.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/AppProviders.tsx
@@ -1,0 +1,67 @@
+import { ReactNode, useMemo } from 'react'
+import { Provider as OvermindProvider } from 'overmind-react'
+import { WagmiProvider } from 'wagmi'
+import { darkTheme, RainbowKitProvider, Theme } from '@rainbow-me/rainbowkit'
+import merge from 'lodash-es/merge'
+import { createOvermind } from 'overmind'
+
+import { config } from '../../state'
+import { ArbQueryParamProvider } from '../../hooks/useArbQueryParams'
+import { AppContextProvider } from './AppContext'
+import { getProps } from '../../util/wagmi/setup'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const rainbowkitTheme = merge(darkTheme(), {
+  colors: {
+    accentColor: 'var(--blue-link)'
+  },
+  fonts: {
+    body: 'Roboto, sans-serif'
+  }
+} as Theme)
+
+// We're doing this as a workaround so users can select their preferred chain on WalletConnect.
+//
+// https://github.com/orgs/WalletConnect/discussions/2733
+// https://github.com/wagmi-dev/references/blob/main/packages/connectors/src/walletConnect.ts#L114
+const searchParams = new URLSearchParams(window.location.search)
+const targetChainKey = searchParams.get('sourceChain')
+
+const wagmiConfig = getProps(targetChainKey)
+
+// Clear cache for everything related to WalletConnect v2.
+//
+// TODO: Remove this once the fix for the infinite loop / memory leak is identified.
+Object.keys(localStorage).forEach(key => {
+  if (
+    key === 'wagmi.requestedChains' ||
+    key === 'wagmi.store' ||
+    key.startsWith('wc@2')
+  ) {
+    localStorage.removeItem(key)
+  }
+})
+
+interface AppProvidersProps {
+  children: ReactNode
+}
+
+const queryClient = new QueryClient()
+
+export function AppProviders({ children }: AppProvidersProps) {
+  const overmind = useMemo(() => createOvermind(config), [])
+
+  return (
+    <OvermindProvider value={overmind}>
+      <ArbQueryParamProvider>
+        <WagmiProvider config={wagmiConfig}>
+          <QueryClientProvider client={queryClient}>
+            <RainbowKitProvider theme={rainbowkitTheme}>
+              <AppContextProvider>{children}</AppContextProvider>
+            </RainbowKitProvider>
+          </QueryClientProvider>
+        </WagmiProvider>
+      </ArbQueryParamProvider>
+    </OvermindProvider>
+  )
+}

--- a/packages/arb-token-bridge-ui/src/pages/_app.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/_app.tsx
@@ -13,8 +13,6 @@ import 'tippy.js/themes/light.css'
 
 import '@rainbow-me/rainbowkit/styles.css'
 
-import { Layout } from '../components/common/Layout'
-
 import '../styles/tailwind.css'
 import {
   ChainKeyQueryParam,
@@ -154,9 +152,7 @@ export default function App({ Component, pageProps, router }: AppProps) {
         {/* title must be here because it doesn't render if it's in DynamicMetaData */}
         <title>{siteTitle}</title>
       </Head>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      <Component {...pageProps} />
     </>
   )
 }


### PR DESCRIPTION
The PR extracts provider-related code currently scattered in `App.tsx` into a new wrapper component called `AppProviders.tsx`

Also, it moves the `Layout` component out from NextJs managed `_app`, to `App.tsx` managed by us. This is because in order to ship responsive embed-mode later, we will need the common `Layout` to be conditionally rendered based on the query params being passed to it.