### PR TITLE
feat: control network selection from query params

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -22,7 +22,10 @@ import { useIsTestnetMode } from '../../hooks/useIsTestnetMode'
 import { SearchPanel } from './SearchPanel/SearchPanel'
 import { SearchPanelTable } from './SearchPanel/SearchPanelTable'
 import { TestnetToggle } from './TestnetToggle'
-import { useArbQueryParams } from '../../hooks/useArbQueryParams'
+import {
+  useArbQueryParams,
+  DisabledFeatures
+} from '../../hooks/useArbQueryParams'
 import { getBridgeUiConfigForChain } from '../../util/bridgeUiConfig'
 import { getWagmiChain } from '../../util/wagmi/getWagmiChain'
 import { NetworkImage } from './NetworkImage'
@@ -33,6 +36,7 @@ import { shouldOpenOneNovaDialog } from '../TransferPanel/TransferPanelMain/util
 import { useChainIdsForNetworkSelection } from '../../hooks/TransferPanel/useChainIdsForNetworkSelection'
 import { useAccountType } from '../../hooks/useAccountType'
 import { useSelectedToken } from '../../hooks/useSelectedToken'
+import { useDisabledFeatures } from '../../hooks/useDisabledFeatures'
 
 type NetworkType = 'core' | 'more' | 'orbit'
 
@@ -116,6 +120,10 @@ export function NetworkButton({
   const { isSmartContractWallet, isLoading } = useAccountType()
   const isSource = type === 'source'
   const chains = useChainIdsForNetworkSelection({ isSource })
+  const { isFeatureDisabled } = useDisabledFeatures()
+  const allowNetworkSelection = !isFeatureDisabled(
+    DisabledFeatures.NETWORK_SELECTION
+  )
 
   const selectedChainId = isSource
     ? networks.sourceChain.id
@@ -126,7 +134,8 @@ export function NetworkButton({
   const disabled =
     hasOneOrLessChain ||
     (isSmartContractWallet && type === 'source') ||
-    isLoading
+    isLoading ||
+    !allowNetworkSelection
 
   const backgroundColor = getBridgeUiConfigForChain(selectedChainId).color
 

--- a/packages/arb-token-bridge-ui/src/hooks/useArbQueryParams.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/useArbQueryParams.tsx
@@ -40,7 +40,8 @@ export enum TabParamEnum {
 
 export enum DisabledFeatures {
   BATCH_TRANSFERS = 'batch-transfers',
-  TX_HISTORY = 'tx-history'
+  TX_HISTORY = 'tx-history',
+  NETWORK_SELECTION = 'network-selection'
 }
 
 export enum AmountQueryParamEnum {


### PR DESCRIPTION
This PR implements support for `disabledFeatures = network-selection`, which allows control over whether users can modify network pairs in the Bridge UI.