### PR TITLE
fix: deposit fee for custom gas token chains

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
@@ -598,9 +598,7 @@ export function useTransferReadiness(): UseTransferReadinessResult {
                   asset: ether.symbol,
                   chain: networks.sourceChain.name,
                   balance: formatAmount(ethBalanceFloat),
-                  requiredBalance: formatAmount(
-                    estimatedL1GasFees + estimatedL2GasFees
-                  )
+                  requiredBalance: formatAmount(estimatedL1GasFees)
                 })
               }
             })


### PR DESCRIPTION
### Problem
When users attempt to bridge (native) tokens to a chain with a custom fee token eg. Plume, `useTransferReadiness()` hook was incorrectly validating gas fees. The validation was treating both L1 (parent chain) and L2 (child chain) gas fees as a single combined check against the ETH balance.  ie. it was adding L1 fee and L2 fee, even though both are denoted by different tokens.

### Solution
Now the gas fee validation is separated into two distinct checks for custom fee token chains:

1. **L1 Gas Fee Check**: Validates if the user has enough ETH (/ parent chain's native token) to cover the retryable creation fee on the parent chain
2. **L2 Gas Fee Check**: Validates if the user has enough of the custom fee token (on the parent chain itself) to cover the child chain execution cost

Closes INT-430