### PR TITLE
feat: control transfers to non-arbitrum chains

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/useSyncConnectedChainToQueryParams.ts
+++ b/packages/arb-token-bridge-ui/src/components/App/useSyncConnectedChainToQueryParams.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useAccount, useDisconnect } from 'wagmi'
 
 import { useArbQueryParams } from '../../hooks/useArbQueryParams'
+import { useAllowTransfersToNonArbitrumChains } from '../../hooks/useAllowTransfersToNonArbitrumChains'
 import { sanitizeQueryParams } from '../../hooks/useNetworks'
 import { onDisconnectHandler } from '../../util/walletConnectUtils'
 import { addressIsSmartContract } from '../../util/AddressUtils'
@@ -20,6 +21,9 @@ export function useSyncConnectedChainToQueryParams() {
   const [{ sourceChain, destinationChain }, setQueryParams] =
     useArbQueryParams()
 
+  const allowTransfersToNonArbitrumChains =
+    useAllowTransfersToNonArbitrumChains()
+
   const setSourceChainToConnectedChain = useCallback(() => {
     if (typeof chain === 'undefined') {
       return
@@ -28,11 +32,12 @@ export function useSyncConnectedChainToQueryParams() {
     const { sourceChainId: sourceChain, destinationChainId: destinationChain } =
       sanitizeQueryParams({
         sourceChainId: chain.id,
-        destinationChainId: undefined
+        destinationChainId: undefined,
+        allowTransfersToNonArbitrumChains
       })
 
     setQueryParams({ sourceChain, destinationChain })
-  }, [chain, setQueryParams])
+  }, [chain, setQueryParams, allowTransfersToNonArbitrumChains])
 
   useEffect(() => {
     async function checkCorrectChainForSmartContractWallet() {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -10,6 +10,7 @@ import { getExplorerUrl, isNetwork } from '../../util/networks'
 import { ExternalLink } from '../common/ExternalLink'
 
 import { useAccountType } from '../../hooks/useAccountType'
+import { useAllowTransfersToNonArbitrumChains } from '../../hooks/useAllowTransfersToNonArbitrumChains'
 import {
   isTokenArbitrumSepoliaNativeUSDC,
   isTokenArbitrumOneNativeUSDC,
@@ -39,9 +40,18 @@ export function SwitchNetworksButton(
   const { isSmartContractWallet, isLoading: isLoadingAccountType } =
     useAccountType()
 
-  const disabled = isSmartContractWallet || isLoadingAccountType
-
+  const allowTransfersToNonArbitrumChains =
+    useAllowTransfersToNonArbitrumChains()
   const [networks, setNetworks] = useNetworks()
+
+  const destinationChainNonArbitrumNotAllowed =
+    !allowTransfersToNonArbitrumChains &&
+    isNetwork(networks.sourceChain.id).isNonArbitrumNetwork
+
+  const disabled =
+    isSmartContractWallet ||
+    isLoadingAccountType ||
+    destinationChainNonArbitrumNotAllowed
 
   return (
     <div className="z-[1] flex h-4 w-full items-center justify-center lg:h-1">

--- a/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useChainIdsForNetworkSelection.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/TransferPanel/useChainIdsForNetworkSelection.ts
@@ -1,10 +1,12 @@
 import {
   getDestinationChainIds,
-  getSupportedChainIds
+  getSupportedChainIds,
+  isNetwork
 } from '../../util/networks'
 import { ChainId } from '../../types/ChainId'
 import { useIsTestnetMode } from '../useIsTestnetMode'
 import { useNetworks } from '../useNetworks'
+import { useAllowTransfersToNonArbitrumChains } from '../useAllowTransfersToNonArbitrumChains'
 import { useMemo } from 'react'
 
 export function useChainIdsForNetworkSelection({
@@ -14,6 +16,8 @@ export function useChainIdsForNetworkSelection({
 }) {
   const [networks] = useNetworks()
   const [isTestnetMode] = useIsTestnetMode()
+  const allowTransfersToNonArbitrumChains =
+    useAllowTransfersToNonArbitrumChains()
 
   return useMemo(() => {
     if (isSource) {
@@ -23,7 +27,10 @@ export function useChainIdsForNetworkSelection({
       })
     }
 
-    const destinationChainIds = getDestinationChainIds(networks.sourceChain.id)
+    const destinationChainIds = getDestinationChainIds(
+      networks.sourceChain.id,
+      allowTransfersToNonArbitrumChains
+    )
 
     // if source chain is Arbitrum One, add Arbitrum Nova to destination
     if (networks.sourceChain.id === ChainId.ArbitrumOne) {
@@ -34,6 +41,17 @@ export function useChainIdsForNetworkSelection({
       destinationChainIds.push(ChainId.ArbitrumOne)
     }
 
+    if (!allowTransfersToNonArbitrumChains) {
+      return destinationChainIds.filter(
+        chainId => !isNetwork(chainId).isNonArbitrumNetwork
+      )
+    }
+
     return destinationChainIds
-  }, [isSource, isTestnetMode, networks.sourceChain.id])
+  }, [
+    isSource,
+    isTestnetMode,
+    networks.sourceChain.id,
+    allowTransfersToNonArbitrumChains
+  ])
 }

--- a/packages/arb-token-bridge-ui/src/hooks/useAllowTransfersToNonArbitrumChains.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useAllowTransfersToNonArbitrumChains.ts
@@ -1,0 +1,12 @@
+import { useMode } from './useMode'
+
+/**
+ * Hook to control whether transfers to non-Arbitrum chains are allowed.
+ * This allows the bridge UI to be used as an "Arbitrum onboarding tool only"
+ * by restricting transfers to only Arbitrum networks.
+ */
+export function useAllowTransfersToNonArbitrumChains(): boolean {
+  const { embedMode } = useMode()
+
+  return !embedMode
+}

--- a/packages/arb-token-bridge-ui/src/pages/index.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/index.tsx
@@ -207,7 +207,8 @@ export async function getServerSideProps({
   // sanitize the query params
   const sanitizedChainIds = sanitizeQueryParams({
     sourceChainId,
-    destinationChainId
+    destinationChainId,
+    allowTransfersToNonArbitrumChains: true
   })
   const sanitized = {
     ...sanitizedChainIds,

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -423,6 +423,7 @@ export function isNetwork(chainId: ChainId) {
 
   const isCoreChain = isEthereumMainnetOrTestnet || isArbitrum
   const isOrbitChain = getIsArbitrumChain(chainId) && !isCoreChain
+  const isNonArbitrumNetwork = isBase || isEthereumMainnetOrTestnet
 
   return {
     // L1
@@ -444,7 +445,8 @@ export function isNetwork(chainId: ChainId) {
     // General
     isTestnet: isTestnetChain(chainId),
     // Core Chain is a chain category for the UI
-    isCoreChain
+    isCoreChain,
+    isNonArbitrumNetwork
   }
 }
 
@@ -550,7 +552,10 @@ export function sortChainIds(chainIds: number[]) {
   })
 }
 
-export function getDestinationChainIds(chainId: ChainId): ChainId[] {
+export function getDestinationChainIds(
+  chainId: ChainId,
+  allowTransfersToNonArbitrumChains = true
+): ChainId[] {
   const chain = getChainByChainId(chainId)
 
   if (!chain) {
@@ -561,7 +566,7 @@ export function getDestinationChainIds(chainId: ChainId): ChainId[] {
 
   const validDestinationChainIds = getChildChainIds(chain)
 
-  if (parentChainId) {
+  if (parentChainId && allowTransfersToNonArbitrumChains) {
     return sortChainIds([parentChainId, ...validDestinationChainIds])
   }
 


### PR DESCRIPTION
This PR implements the functionality to control whether transfers to non-Arbitrum chains are allowed, enabling the bridge UI to be used as an "Arbitrum onboarding tool only" by restricting transfers to only Arbitrum networks.

Created a new hook called useAllowTransfersToNonArbitrumChains() which is linked to embed-mode in the code. Didn't want to directly use embed-mode for this logic because we wanted code to be more readable, and we wanted a way to distinguish between embed-mode vs this feature so that it would be easier to de-link these 2 when the possibility arises in the future.

### Changes
- Added `useAllowTransfersToNonArbitrumChains` hook that returns false in embed mode
- Updated network utilities to support filtering non-Arbitrum chains
- Modified transfer panel to disable network switching when non-Arbitrum transfers are blocked
- Updated chain selection logic to filter out non-Arbitrum destinations when appropriate