### PR TITLE
feat: limit concurrent batched withdrawals

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -34,6 +34,7 @@
     "next-query-params": "^5.1.0",
     "overmind": "^28.0.1",
     "overmind-react": "^29.0.1",
+    "p-limit": "^6.2.0",
     "posthog-js": "^1.236.5",
     "query-string": "^9.1.1",
     "react": "^18.3.1",

--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -309,13 +309,17 @@ export async function fetchWithdrawalsInBatches(
     )
 
     return limit(async () => {
-      performance.mark(`withdrawal batch start chainId:${childChainId} ${i}/${batchCount}`)
+      performance.mark(
+        `withdrawal batch start chainId:${childChainId} ${i}/${batchCount}`
+      )
       const result = await fetchWithdrawals({
         ...params,
         fromBlock: fromBlockForBatch,
         toBlock: toBlockForBatch
       })
-      performance.mark(`withdrawal batch end chainId:${childChainId} ${i}/${batchCount}`)
+      performance.mark(
+        `withdrawal batch end chainId:${childChainId} ${i}/${batchCount}`
+      )
       return result
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11340,6 +11340,13 @@ p-limit@^4.0.0:
   dependencies:
     yocto-queue "^1.0.0"
 
+p-limit@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-6.2.0.tgz#c254d22ba6aeef441a3564c5e6c2f2da59268a0f"
+  integrity sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==
+  dependencies:
+    yocto-queue "^1.1.1"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz"
@@ -15162,6 +15169,11 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+yocto-queue@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
+  integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
 
 yoga-wasm-web@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
closes FS-1282

Limits withdrawal batches we fetch in parallel to 10 for specified chains.

### Testing
1. Go to Performance tab in devtools.
2. Click Record and refresh the page right away.
3. Record the first ~10s as transaction history is loading (no need to wait for the entire history to finish fetching).
4. CTRL/CMD + F and search for: "withdrawal batch start chainId:4078".
5. Iterate through batches and check timestamps. Concurrent fetches of 10 should have around the same timestamp. There may be deviations based on network delays etc but the most important is they don't fetch at the same time.