### PR TITLE
chore: disable monitoring

### DIFF
--- a/.github/workflows/assertion-monitor.yml
+++ b/.github/workflows/assertion-monitor.yml
@@ -2,8 +2,8 @@ name: Assertion Monitor
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 */6 * * *"  # Run every 6 hours
+  # schedule:
+  #  - cron: "0 */6 * * *"  # Run every 6 hours
 
 jobs:
   run-monitoring:

--- a/.github/workflows/batch-poster-monitor.yml
+++ b/.github/workflows/batch-poster-monitor.yml
@@ -2,8 +2,8 @@ name: Batch Poster Monitor
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 */6 * * *"  # Run every 6 hours
+  # schedule:
+  #  - cron: "0 */6 * * *"  # Run every 6 hours
 
 jobs:
   run-monitoring:

--- a/.github/workflows/retryable-monitor.yml
+++ b/.github/workflows/retryable-monitor.yml
@@ -2,8 +2,8 @@ name: Retryable Monitor
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "3 8 * * *" # Run once a day at 08:03am GMT
+  # schedule:
+  #  - cron: "3 8 * * *" # Run once a day at 08:03am GMT
 
 jobs:
   run-retryable-monitoring:


### PR DESCRIPTION
Disabling monitoring in `arbitrum-token-bridge`, in order to move the run to `arbitrum-portal`. See https://github.com/OffchainLabs/arbitrum-portal/pull/98