### PR TITLE
ci: comment out monitor cron schedules

### DIFF
--- a/.github/workflows/assertion-monitor.yml
+++ b/.github/workflows/assertion-monitor.yml
@@ -2,8 +2,8 @@ name: Assertion Monitor
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 */6 * * *"  # Run every 6 hours
+  # schedule:
+  #   - cron: "0 */6 * * *"  # Run every 6 hours
 
 jobs:
   run-monitoring:

--- a/.github/workflows/batch-poster-monitor.yml
+++ b/.github/workflows/batch-poster-monitor.yml
@@ -2,8 +2,8 @@ name: Batch Poster Monitor
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 */6 * * *"  # Run every 6 hours
+  # schedule:
+  #   - cron: "0 */6 * * *"  # Run every 6 hours
 
 jobs:
   run-monitoring:

--- a/.github/workflows/retryable-monitor.yml
+++ b/.github/workflows/retryable-monitor.yml
@@ -2,8 +2,8 @@ name: Retryable Monitor
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "3 8 * * *" # Run once a day at 08:03am GMT
+  # schedule:
+  #   - cron: "3 8 * * *" # Run once a day at 08:03am GMT
 
 jobs:
   run-retryable-monitoring:


### PR DESCRIPTION
## Summary

- Comment out the three monitor workflow cron schedules while keeping the schedule definitions visible for later re-enable.
- Leave the SBOM export cron active.
- Fix GitHub Actions lint findings by tightening workflow shell quoting/input expressions and adding an actionlint config for custom runner labels if needed.

## Validation

- `actionlint` passes.
- `yarn prettier --check .github/actionlint.yaml .github/workflows/add-orbit-chain.yml .github/workflows/e2e-tests.yml .github/workflows/monitoring.yml .github/workflows/assertion-monitor.yml .github/workflows/batch-poster-monitor.yml .github/workflows/retryable-monitor.yml` passes.

## Notes

The branch was recreated from `OffchainLabs/arbitrum-token-bridge:master` so the PR only contains the workflow changes for this repository.
