### PR TITLE
feat: set HPP fast withdrawal time to 24 hours

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
+++ b/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
@@ -1376,7 +1376,8 @@
           "name": "HPP Mainnet",
           "logo": "/images/HPPMainnet_Logo.svg",
           "description": "House Party Protocol (HPP) is a modular AI-powered blockchain and data infrastructure designed for the next generation of decentralized applications, built on the pillars of trustworthy data, verifiable AI, and real-world scalability."
-        }
+        },
+        "fastWithdrawalTime": 86400000
       }
     },
     {
@@ -2300,8 +2301,10 @@
           "name": "HPP Sepolia",
           "logo": "/images/HPPSepolia_Logo.svg",
           "description": "House Party Protocol (HPP) is a modular AI-powered blockchain and data infrastructure designed for the next generation of decentralized applications, built on the pillars of trustworthy data, verifiable AI, and real-world scalability."
-        }
+        },
+        "fastWithdrawalTime": 86400000
       }
+
     },
     {
       "chainId": 393,


### PR DESCRIPTION
Configure fastWithdrawalTime (86400000 ms) for HPP Mainnet and HPP Sepolia to match the announced fast withdrawal window.

### Summary

HPP announced that Arbitrum fast withdrawal is enabled with a **7 day → 24 hour** user-facing confirmation window. The bridge UI uses `bridgeUiConfig.fastWithdrawalTime` (milliseconds) in `getBridgeUiConfigForChain` / `getConfirmationTime` to treat fast withdrawal as active and to drive **withdrawal ETA strings**, **approximate duration**, and **estimated completion** (`useTransferDuration`, `getWithdrawalConfirmationDate`). Without this field, those flows fall back to the standard challenge-period estimate.

This change sets `fastWithdrawalTime` to **86400000** (24 hours in ms) for **HPP Mainnet** and **HPP Sepolia** in `packages/arb-token-bridge-ui/src/util/orbitChainsData.json`, aligned with the public announcement.

### Steps to test

1. Run the UI locally (e.g. from `packages/arb-token-bridge-ui` per repo README).
2. Select **HPP Mainnet** (or **HPP Sepolia**) as the child/source chain for a withdrawal toward Ethereum (or Sepolia).
3. Confirm the transfer panel / withdrawal flow shows a **~24 hour** (or “1 day”) style confirmation estimate instead of the long default challenge period.
4. Optionally start a test withdrawal and confirm the **estimated time remaining** / completion logic uses the fast-withdrawal path (no need to wait for on-chain finality; UI copy and timers are enough to verify).